### PR TITLE
Update README.md to document stable npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Add your next application to the serverless.yml:
 # serverless.yml
 
 myNextApplication:
-  component: "@sls-next/serverless-component@{version_here}" # it is recommended you pin the latest stable version of serverless-next.js
+  component: "serverless-next.js@1.14.0" # it is recommended you pin the latest stable version of serverless-next.js
 ```
 
 Set your AWS credentials as environment variables:


### PR DESCRIPTION
Anyone landing on the github repo package will be directed to use the unusable npm package @sls-next/serverless-component which has no stable release yet.

Should update the README to point to that package only when a stable release is made.