### PR TITLE
Ignore calls to res.end() after the first one

### DIFF
--- a/packages/lambda-at-edge-compat/__tests__/next-aws-cloudfront.response.test.js
+++ b/packages/lambda-at-edge-compat/__tests__/next-aws-cloudfront.response.test.js
@@ -318,6 +318,24 @@ describe("Response Tests", () => {
     });
   });
 
+  it("res.end() ignores any calls after the first one", () => {
+    expect.assertions(1);
+
+    const { res, responsePromise } = create({
+      request: {
+        path: "/",
+        headers: {}
+      }
+    });
+
+    res.end("ok");
+    res.end();
+
+    return responsePromise.then((response) => {
+      expect(response.body).toEqual("b2s=");
+    });
+  });
+
   it(`gzips`, () => {
     expect.assertions(2);
 

--- a/packages/lambda-at-edge-compat/next-aws-cloudfront.js
+++ b/packages/lambda-at-edge-compat/next-aws-cloudfront.js
@@ -221,13 +221,17 @@ const handler = (event) => {
 
   const responsePromise = new Promise((resolve) => {
     res.end = (text) => {
+      if (res.finished === true) {
+        return;
+      }
+
+      res.finished = true;
+
       if (text) res.write(text);
 
       if (!res.statusCode) {
         res.statusCode = 200;
       }
-
-      res.finished = true;
 
       if (response.body) {
         response.bodyEncoding = "base64";


### PR DESCRIPTION
This PR ensures the next-aws-cloudfront compat layer behaves in the same way that nodejs server does when `res.end()` is called more than once. That is, ignore subsequent calls after the first one. 

Fixes  https://github.com/serverless-nextjs/serverless-next.js/issues/316