### PR TITLE
IncludeBody option only with viewer-request or origin-request

### DIFF
--- a/packages/aws-cloudfront/__tests__/__snapshots__/lambda-at-edge.test.js.snap
+++ b/packages/aws-cloudfront/__tests__/__snapshots__/lambda-at-edge.test.js.snap
@@ -55,12 +55,12 @@ Object {
               },
               Object {
                 "EventType": "origin-response",
-                "IncludeBody": true,
+                "IncludeBody": undefined,
                 "LambdaFunctionARN": "arn:aws:lambda:us-east-1:123:function:originResponseFunction",
               },
               Object {
                 "EventType": "viewer-response",
-                "IncludeBody": true,
+                "IncludeBody": undefined,
                 "LambdaFunctionARN": "arn:aws:lambda:us-east-1:123:function:viewerResponseFunction",
               },
             ],

--- a/packages/aws-cloudfront/__tests__/lambda-at-edge.test.js
+++ b/packages/aws-cloudfront/__tests__/lambda-at-edge.test.js
@@ -64,14 +64,12 @@ describe("Input origin as a custom url", () => {
           {
             EventType: "origin-response",
             LambdaFunctionARN:
-              "arn:aws:lambda:us-east-1:123:function:originResponseFunction",
-            IncludeBody: true
+              "arn:aws:lambda:us-east-1:123:function:originResponseFunction"
           },
           {
             EventType: "viewer-response",
             LambdaFunctionARN:
-              "arn:aws:lambda:us-east-1:123:function:viewerResponseFunction",
-            IncludeBody: true
+              "arn:aws:lambda:us-east-1:123:function:viewerResponseFunction"
           }
         ]
       }

--- a/packages/aws-cloudfront/lib/addLambdaAtEdgeToCacheBehavior.js
+++ b/packages/aws-cloudfront/lib/addLambdaAtEdgeToCacheBehavior.js
@@ -19,7 +19,7 @@ module.exports = (cacheBehavior, lambdaAtEdgeConfig = {}) => {
     cacheBehavior.LambdaFunctionAssociations.Items.push({
       EventType: eventType,
       LambdaFunctionARN: lambdaAtEdgeConfig[eventType],
-      IncludeBody: true
+      IncludeBody: eventType.includes("request") ? true : undefined
     });
   });
 };


### PR DESCRIPTION
I need to set headers for a specific public file so I wanted to setup origin-response or viewer-response for that.

Adding a viewer-response or origin-response causes the following error message:
  `InvalidLambdaFunctionAssociation: The IncludeBody option can only be used with viewer-request or origin-request events.`


**To Reproduce**
Steps to reproduce the behavior:
Add to serverless.yml
```
    cloudfront:
      defaults:
        lambda@edge:
          viewer-response: <arn>
```


**Desktop (please complete the following information):**

- OS: Windows 10
- Version @sls-next/serverless-component@1.16.0

**Additional context**

Doing something like this...
```
    cacheBehavior.LambdaFunctionAssociations.Items.push({
      EventType: eventType,
      LambdaFunctionARN: lambdaAtEdgeConfig[eventType],
      IncludeBody: eventType.contains("request") ? true : undefined
    });
```
in /packages/aws-cloudfront/lib/addLambdaAtEdgeToCacheBehavior.js works for viewer-response.

Note: If I try to do it for origin-response, the deployment is successful but origin-response still doesn't get set.  I see these lines of comments in component.ts.html so perhaps serverless-next.js is intentionally filtering.
    // make sure that origin-response is not set.
    // this is reserved for serverless-next.js usage