### PR TITLE
docs: update path for local deployment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ First, create your own test serverless component app and in the `serverless.yml`
 ```yml
 # serverless.yml
 nextApp:
-  component: "/path/to/your/fork/serverless-next.js/packages/serverless-component"
+  component: "/path/to/your/fork/serverless-next.js/packages/serverless-components/nextjs-component"
   inputs: ...
 ```
 


### PR DESCRIPTION
For some reason I was getting `Error: Component "/Users/danielphang/IdeaProjects/serverless-next.js/packages/serverless-component" was not found on NPM nor could it be resolved locally.` if just using the `serverless-component` path to deploy.

I had to use `serverless-components/nextjs-component` for it to work. I think the doc might need to be updated? 