### PR TITLE
fix(lambda-at-edge): render Next 500 page when SSR render fails, and ensure 404 pages return 404 status codes

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -20,6 +20,7 @@ import {
 } from "../types";
 import S3 from "aws-sdk/clients/s3";
 import { performance } from "perf_hooks";
+import { ServerResponse } from "http";
 
 const perfLogger = (logLambdaExecutionTimes: boolean): PerfLogger => {
   if (logLambdaExecutionTimes) {
@@ -221,22 +222,41 @@ const handleOriginRequest = async ({
     s3Origin.path = `${basePath}/static-pages`;
     request.uri = pagePath.replace("pages", "");
     addS3HostHeader(request, normalisedS3DomainName);
+
     return request;
   }
 
   const tBeforePageRequire = now();
-  const page = require(`./${pagePath}`); // eslint-disable-line
+  let page = require(`./${pagePath}`); // eslint-disable-line
   const tAfterPageRequire = now();
 
   log("require JS execution time", tBeforePageRequire, tAfterPageRequire);
 
   const tBeforeSSR = now();
   const { req, res, responsePromise } = lambdaAtEdgeCompat(event.Records[0].cf);
-  page.render(req, res);
+  try {
+    // If page is _error.js, set status to 404 so _error.js will render a 404 page
+    if (pagePath === "pages/_error.js") {
+      res.statusCode = 404;
+    }
+
+    // Render page
+    await page.render(req, res);
+  } catch (error) {
+    // Set status to 500 so _error.js will render a 500 page
+    console.error(
+      `Error rendering page: ${pagePath}. Error:\n${error}\nRendering Next.js error page.`
+    );
+    res.statusCode = 500;
+    page = require("./pages/_error.js"); // eslint-disable-line
+    await page.render(req, res);
+  }
   const response = await responsePromise;
   const tAfterSSR = now();
 
   log("SSR execution time", tBeforeSSR, tAfterSSR);
+
+  setCloudFrontResponseStatus(response, res);
 
   return response;
 };
@@ -254,7 +274,14 @@ const handleOriginResponse = async ({
   const request = event.Records[0].cf.request;
   const uri = normaliseUri(request.uri);
   const { status } = response;
-  if (status !== "403") return response;
+  if (status !== "403") {
+    const pagePath = router(manifest)(uri);
+    if (pagePath === "pages/404.html") {
+      response.status = "404";
+      response.statusDescription = "Not Found";
+    }
+    return response;
+  }
   const { domainName, region } = request.origin!.s3!;
   const bucketName = domainName.replace(`.s3.${region}.amazonaws.com`, "");
   // It's usually better to do this outside the handler, but we need to know the bucket region
@@ -358,4 +385,18 @@ const createRedirectResponse = (uri: string, querystring: string) => {
       ]
     }
   };
+};
+
+// This sets CloudFront response for 404 or 500 statuses
+const setCloudFrontResponseStatus = (
+  response: CloudFrontResultResponse,
+  res: ServerResponse
+): void => {
+  if (res.statusCode == 404) {
+    response.status = "404";
+    response.statusDescription = "Not Found";
+  } else if (res.statusCode == 500) {
+    response.status = "500";
+    response.statusDescription = "Internal Server Error";
+  }
 };

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-trailing-slash.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-trailing-slash.json
@@ -34,6 +34,7 @@
         "/customers/new": "pages/customers/new.js",
         "/api/getCustomers": "pages/api/getCustomers.js",
         "/_error": "pages/_error.js",
+        "/erroredPage": "pages/erroredPage.js",
         "/404": "pages/404.html"
       }
     },

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest.json
@@ -34,6 +34,7 @@
         "/customers/new": "pages/customers/new.js",
         "/api/getCustomers": "pages/api/getCustomers.js",
         "/_error": "pages/_error.js",
+        "/erroredPage": "pages/erroredPage.js",
         "/404": "pages/404.html"
       }
     },

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-404.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-404.test.ts
@@ -1,6 +1,6 @@
 import { handler } from "../../src/default-handler";
 import { createCloudFrontEvent } from "../test-utils";
-import { CloudFrontResultResponse } from "aws-lambda";
+import { CloudFrontRequest, CloudFrontResultResponse } from "aws-lambda";
 
 jest.mock(
   "../../src/manifest.json",
@@ -39,8 +39,23 @@ describe("Lambda@Edge", () => {
       config: { eventType: "origin-request" } as any
     });
 
+    const request = (await handler(event)) as CloudFrontRequest;
+
+    expect(request.uri).toEqual("/404.html");
+  });
+
+  it("static 404 page should return CloudFront 404 status code after successful S3 origin response", async () => {
+    const event = createCloudFrontEvent({
+      uri: "/page/does/not/exist",
+      host: "mydistribution.cloudfront.net",
+      config: { eventType: "origin-response" } as any,
+      response: {
+        status: "200"
+      } as any
+    });
+
     const response = (await handler(event)) as CloudFrontResultResponse;
 
-    expect(response.uri).toEqual("/404.html");
+    expect(response.status).toEqual("404");
   });
 });

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
@@ -429,8 +429,8 @@ describe("Lambda@Edge", () => {
         const body = response.body as string;
         const decodedBody = new Buffer(body, "base64").toString("utf8");
 
-        expect(decodedBody).toEqual("pages/_error.js");
-        expect(response.status).toEqual(200);
+        expect(decodedBody).toEqual("pages/_error.js - 404");
+        expect(response.status).toEqual("404");
       });
 
       it("redirects unmatched request path", async () => {
@@ -443,6 +443,27 @@ describe("Lambda@Edge", () => {
           path += "/";
         }
         await runRedirectTest(path, expectedRedirect);
+      });
+    });
+
+    describe("500 page", () => {
+      xit("renders 500 page if page render has an error", async () => {
+        const event = createCloudFrontEvent({
+          uri: trailingSlash
+            ? "/basepath/erroredPage/"
+            : "/basepath/erroredPage",
+          host: "mydistribution.cloudfront.net"
+        });
+
+        mockPageRequire("pages/_error.js");
+        mockPageRequire("pages/erroredPage.js");
+
+        const response = (await handler(event)) as CloudFrontResultResponse;
+        const body = response.body as string;
+        const decodedBody = new Buffer(body, "base64").toString("utf8");
+
+        expect(decodedBody).toEqual("pages/_error.js - 500");
+        expect(response.status).toEqual("500");
       });
     });
   });

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
@@ -447,7 +447,7 @@ describe("Lambda@Edge", () => {
     });
 
     describe("500 page", () => {
-      xit("renders 500 page if page render has an error", async () => {
+      it("renders 500 page if page render has an error", async () => {
         const event = createCloudFrontEvent({
           uri: trailingSlash
             ? "/basepath/erroredPage/"

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -429,8 +429,8 @@ describe("Lambda@Edge", () => {
         const body = response.body as string;
         const decodedBody = new Buffer(body, "base64").toString("utf8");
 
-        expect(decodedBody).toEqual("pages/_error.js");
-        expect(response.status).toEqual(200);
+        expect(decodedBody).toEqual("pages/_error.js - 404");
+        expect(response.status).toEqual("404");
       });
 
       it("redirects unmatched request path", async () => {
@@ -443,6 +443,25 @@ describe("Lambda@Edge", () => {
           path += "/";
         }
         await runRedirectTest(path, expectedRedirect);
+      });
+    });
+
+    describe("500 page", () => {
+      it("renders 500 page if page render has an error", async () => {
+        const event = createCloudFrontEvent({
+          uri: trailingSlash ? "/erroredPage/" : "/erroredPage",
+          host: "mydistribution.cloudfront.net"
+        });
+
+        mockPageRequire("pages/erroredPage.js");
+        mockPageRequire("pages/_error.js");
+
+        const response = (await handler(event)) as CloudFrontResultResponse;
+        const body = response.body as string;
+        const decodedBody = new Buffer(body, "base64").toString("utf8");
+
+        expect(decodedBody).toEqual("pages/_error.js - 500");
+        expect(response.status).toEqual("500");
       });
     });
   });

--- a/packages/libs/lambda-at-edge/tests/shared-fixtures/built-artifact/pages/_error.js
+++ b/packages/libs/lambda-at-edge/tests/shared-fixtures/built-artifact/pages/_error.js
@@ -1,5 +1,8 @@
 module.exports = {
   render: (req, res) => {
-    res.end("pages/_error.js");
+    // We add status code in the body of _error.js for test purposes since
+    // the Next.js default _error.js page shows different text based on the status
+    // that is used when rendering the page.
+    res.end(`pages/_error.js - ${res.statusCode}`);
   }
 };

--- a/packages/libs/lambda-at-edge/tests/shared-fixtures/built-artifact/pages/erroredPage.js
+++ b/packages/libs/lambda-at-edge/tests/shared-fixtures/built-artifact/pages/erroredPage.js
@@ -1,0 +1,5 @@
+module.exports = {
+  render: (req, res) => {
+    throw Error("This page had an error while rendering!");
+  }
+};


### PR DESCRIPTION
## Description

This fixes https://github.com/serverless-nextjs/serverless-next.js/issues/566 and few other improvements:

* 500 page that is part of Next.js (`_error.js`) is rendered instead of CloudFront's 503 when SSR page has an error. It also sets 500 status code so that the message in the page actually says there is a 500 error.
* 404 pages were returning 200 status codes incorrectly, and now return 404 status codes. Similarly, ensured that we passed in 404 status into page render (previously we weren't, though Next.js by default renders 404 page anyway)

FYI: CloudFront will cache 4xx/5xx responses for 1 minute: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages-expiration.html. We could make it less if needed, but I think this is sensible.

## Tests

Added and updated unit tests for `default-handler` for all the above cases.

You can also see a sample app:

500 page (page throws error in `getInitialProps()`: https://dpjozqtv88tg7.cloudfront.net/anotherSSR/ -> 500 status code
404 page (statically rendered): https://dpjozqtv88tg7.cloudfront.net/notfound/ -> 404 status code. Try it with any unmatched path and it should work.

404 page (SSR): will add another app for this.

## Other Notes

I believe this should have minimal perf impact:

* In case of a 500, the Lambda is already initialized from trying to render the initial page. So doing another `require` on the `_error.js` page (which would normally have few dependencies, maybe just the app layout) should be pretty fast.
* In case of a 404 that's based on `_error.js`, i.e it is SSR (user did not add a static 404 page), the rendering is the same, I am just setting the status code to be 404 (instead of 200) to render the page as a 404 and have the correct response code.
* In case of a 404 that's statically rendered (user added a static 404 page), in origin response handler, after S3 returns success, we check the `router` for whether it's the `404.html` page, and set the 404 status code in the response as well. Future calls will be cached in CloudFront. This router check would need to be added for all such origin responses. I believe the router call should be pretty fast.
