### PR TITLE
fix(lambda-at-edge): proper routing for pages with basePath

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -47,14 +47,18 @@ const addS3HostHeader = (
 const isDataRequest = (uri: string): boolean => uri.startsWith("/_next/data");
 
 const normaliseUri = (uri: string): string => {
-  if (basePath) uri = uri.slice(basePath.length);
+  // Remove basePath prefix
+  if (basePath && uri.startsWith(basePath)) {
+    uri = uri.slice(basePath.length);
+  }
 
-  // Remove trailing slash for all paths except "/"
-  if (uri.length > 1 && uri.endsWith("/")) {
+  // Remove trailing slash for all paths
+  if (uri.endsWith("/")) {
     uri = uri.slice(0, -1);
   }
 
-  return uri === "" ? "/index" : uri;
+  // Empty path should be normalised to "/" as there is no Next.js route for ""
+  return uri === "" ? "/" : uri;
 };
 
 const normaliseS3OriginDomain = (s3Origin: CloudFrontS3Origin): string => {
@@ -169,8 +173,10 @@ const handleOriginRequest = async ({
     if (newUri.endsWith("/")) {
       newUri = newUri.slice(0, -1);
     }
-  } else if (uri !== "/index" && uri !== "/") {
-    // HTML/SSR pages get redirected based on trailingSlash in next.config.js, except for index page
+  } else if (request.uri !== "/" && request.uri !== "") {
+    // HTML/SSR pages get redirected based on trailingSlash in next.config.js
+    // We should never redirect unnormalised URI "/" or "" as this could cause a redirect loop due to browsers appending trailing slash
+    // to root page requests
     const trailingSlash = manifest.trailingSlash;
 
     if (!trailingSlash && newUri.endsWith("/")) {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-404.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-404.json
@@ -40,7 +40,6 @@
     "html": {
       "nonDynamic": {
         "/": "pages/index.html",
-        "/index": "pages/index.html",
         "/terms": "pages/terms.html",
         "/404": "pages/404.html"
       },

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-trailing-slash.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-trailing-slash.json
@@ -40,7 +40,6 @@
     "html": {
       "nonDynamic": {
         "/": "pages/index.html",
-        "/index": "pages/index.html",
         "/terms": "pages/terms.html"
       },
       "dynamic": {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest.json
@@ -40,7 +40,6 @@
     "html": {
       "nonDynamic": {
         "/": "pages/index.html",
-        "/index": "pages/index.html",
         "/terms": "pages/terms.html"
       },
       "dynamic": {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
@@ -109,8 +109,6 @@ describe("Lambda@Edge", () => {
       it.each`
         path                                                        | expectedPage
         ${"/basepath"}                                              | ${"/index.html"}
-        ${"/basepath/"}                                             | ${"/index.html"}
-        ${"/basepath/index"}                                        | ${"/index.html"}
         ${"/basepath/terms"}                                        | ${"/terms.html"}
         ${"/basepath/users/batman"}                                 | ${"/users/[user].html"}
         ${"/basepath/users/test/catch/all"}                         | ${"/users/[...user].html"}
@@ -150,6 +148,7 @@ describe("Lambda@Edge", () => {
 
       it.each`
         path
+        ${"/basepath"}
         ${"/basepath/terms"}
         ${"/basepath/users/batman"}
         ${"/basepath/users/test/catch/all"}

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
@@ -433,7 +433,7 @@ describe("Lambda@Edge", () => {
       });
 
       it("redirects unmatched request path", async () => {
-        let path = "/page/does/not/exist";
+        let path = "/basepath/page/does/not/exist";
         let expectedRedirect;
         if (trailingSlash) {
           expectedRedirect = path + "/";
@@ -443,6 +443,43 @@ describe("Lambda@Edge", () => {
         }
         await runRedirectTest(path, expectedRedirect);
       });
+
+      // Next.js serves 404 on pages that do not have basepath prefix. It doesn't redirect whether there is trailing slash or not.
+      it.each`
+        path
+        ${"/terms"}
+        ${"/not/found"}
+        ${"/manifest.json"}
+        ${"/terms/"}
+        ${"/not/found/"}
+        ${"/manifest.json/"}
+      `(
+        "serves 404 page from S3 for path without basepath prefix: $path",
+        async ({ path, expectedPage }) => {
+          const event = createCloudFrontEvent({
+            uri: path,
+            host: "mydistribution.cloudfront.net"
+          });
+
+          const result = await handler(event);
+
+          const request = result as CloudFrontRequest;
+
+          expect(request.origin).toEqual({
+            s3: {
+              authMethod: "origin-access-identity",
+              domainName: "my-bucket.s3.amazonaws.com",
+              path: "/basepath/static-pages",
+              region: "us-east-1"
+            }
+          });
+          expect(request.uri).toEqual("/404.html");
+          expect(request.headers.host[0].key).toEqual("host");
+          expect(request.headers.host[0].value).toEqual(
+            "my-bucket.s3.amazonaws.com"
+          );
+        }
+      );
     });
   });
 });

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -109,7 +109,6 @@ describe("Lambda@Edge", () => {
       it.each`
         path                                                  | expectedPage
         ${"/"}                                                | ${"/index.html"}
-        ${"/index"}                                           | ${"/index.html"}
         ${"/terms"}                                           | ${"/terms.html"}
         ${"/users/batman"}                                    | ${"/users/[user].html"}
         ${"/users/test/catch/all"}                            | ${"/users/[...user].html"}


### PR DESCRIPTION
## Description

This fixes routing for basePath URLs and fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/571.

1. Routing/redirects for basePath with index page (and others) did not work correctly (e.g with default settings `/basePath` returned  `/index` which is not a valid path so it returned 404 page and `/basePath/` returned index page).
2. If basePath is expected but unnormalized URL doesn't have it as prefix, serve static 404 page. No redirects are done for these if they have trailing slash or not (same as Next.js)

## Cause

It looks to be due to the normalization logic where `basePath` becomes empty after removing `basePath`, then returns `/index` after normalization. Then it tries to find a page `/index`, but it doesn't exist, so the SSR 404 page is rendered. With `basePath/`, it becomes `/` which routes to index page correctly.

This wasn't caught in tests before since `/index` was added as a route, but in actual Next.js apps only `/` exists (I saw the `/index` route was added in tests in Sept 2019, probably Next no longer supports this and only provided the `/` route).

As an aside, `basePath` stripping logic was also slightly wrong as it was just removing the length of `basePath`. If you have basePath of `/basepath`, then `/abc` becomes empty, and normalized URI is `/index` (which doesn't exist, so it goes to 404 page, which happens to be correct).  Updated this to check for whether the URI actually starts with `basePath`, if not, return static 404 page.

## Tests

Updated `default-handler` tests. Removed `/index` route as above, in a real Next.js app, `index` page is never mapped to `/index`, only `/`.

Test app with basepath of /test/dwa: https://d113kzwzk7s27f.cloudfront.net/test/dwa (with trailing slash it redirects to this). I will test with various pages and with/without basepath.