### PR TITLE
fix(lambda-at-edge): fix data request routing / client-side navigation for SSR index page

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -214,8 +214,8 @@ const handleOriginRequest = async ({
 
   s3Origin.domainName = normalisedS3DomainName;
 
-  // Check if data can be retrieved from S3
-  S3DataCheck: if (isHTMLPage || isPublicFile || hasFallback || isDataReq) {
+  // Check if we can serve request from S3
+  S3Check: if (isHTMLPage || isPublicFile || hasFallback || isDataReq) {
     if (isHTMLPage || hasFallback) {
       s3Origin.path = `${basePath}/static-pages`;
       const pageName = uri === "/" ? "/index" : uri;
@@ -239,7 +239,7 @@ const handleOriginRequest = async ({
         request.uri = pagePath.replace("pages", "");
       } else if (pagePath === "pages/_error.js") {
         // Break to continue to SSR render _error.js
-        break S3DataCheck;
+        break S3Check;
       }
     }
 

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -89,6 +89,9 @@ const router = (
       normalisedUri = uri
         .replace(`/_next/data/${manifest.buildId}`, "")
         .replace(".json", "");
+
+      // Index has a special path of "/" instead of "/index"
+      normalisedUri = normalisedUri === "/index" ? "/" : normalisedUri;
     }
 
     if (ssr.nonDynamic[normalisedUri]) {
@@ -165,8 +168,8 @@ const handleOriginRequest = async ({
   // Handle any redirects
   let newUri = request.uri;
   if (isDataReq || isPublicFile) {
-    // Data requests and public files with trailing slash URL always get redirected to non-trailing slash URL
-    if (newUri.endsWith("/")) {
+    // Data requests and public files with trailing slash URL always get redirected to non-trailing slash URL, except for index requests
+    if (uri !== "/" && newUri.endsWith("/")) {
       newUri = newUri.slice(0, -1);
     }
   } else if (uri !== "/index" && uri !== "/") {
@@ -296,7 +299,7 @@ const handleOriginResponse = async ({
     res.writeHead(200, response.headers as any);
     res.setHeader("Content-Type", "application/json");
     res.end(JSON.stringify(renderOpts.pageData));
-    return responsePromise;
+    return await responsePromise;
   } else {
     const hasFallback = hasFallbackForUri(uri, prerenderManifest);
     if (!hasFallback) return response;

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -179,7 +179,7 @@ const handleOriginRequest = async ({
   // Handle any redirects
   let newUri = request.uri;
   if (isDataReq || isPublicFile) {
-    // Data requests and public files with trailing slash URL always get redirected to non-trailing slash URL, except for index data requests
+    // Data requests and public files with trailing slash URL always get redirected to non-trailing slash URL
     if (newUri.endsWith("/")) {
       newUri = newUri.slice(0, -1);
     }

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-404.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-404.test.ts
@@ -44,6 +44,28 @@ describe("Lambda@Edge", () => {
     expect(request.uri).toEqual("/404.html");
   });
 
+  it.each`
+    path
+    ${"/_next/data/unmatched"}
+  `(
+    "renders a static 404 page if data request can't be matched for path: $path",
+    async ({ path }) => {
+      const event = createCloudFrontEvent({
+        uri: path,
+        origin: {
+          s3: {
+            domainName: "my-bucket.s3.amazonaws.com"
+          }
+        },
+        config: { eventType: "origin-request" } as any
+      });
+
+      const request = (await handler(event)) as CloudFrontRequest;
+
+      expect(request.uri).toEqual("/404.html");
+    }
+  );
+
   it("static 404 page should return CloudFront 404 status code after successful S3 origin response", async () => {
     const event = createCloudFrontEvent({
       uri: "/page/does/not/exist",

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -297,6 +297,7 @@ describe("Lambda@Edge", () => {
     describe("Data Requests", () => {
       it.each`
         path                                                      | expectedPage
+        ${"/_next/data/build-id"}                                 | ${"pages/index.js"}
         ${"/_next/data/build-id/index.json"}                      | ${"pages/index.js"}
         ${"/_next/data/build-id/customers.json"}                  | ${"pages/customers/index.js"}
         ${"/_next/data/build-id/customers/superman.json"}         | ${"pages/customers/[customer].js"}
@@ -327,6 +328,7 @@ describe("Lambda@Edge", () => {
 
       it.each`
         path                                                       | expectedRedirect
+        ${"/_next/data/build-id/"}                                 | ${"/_next/data/build-id"}
         ${"/_next/data/build-id/index.json/"}                      | ${"/_next/data/build-id/index.json"}
         ${"/_next/data/build-id/customers.json/"}                  | ${"/_next/data/build-id/customers.json"}
         ${"/_next/data/build-id/customers/superman.json/"}         | ${"/_next/data/build-id/customers/superman.json"}
@@ -446,6 +448,33 @@ describe("Lambda@Edge", () => {
         }
         await runRedirectTest(path, expectedRedirect);
       });
+
+      it.each`
+        path
+        ${"/_next/data/unmatched"}
+      `(
+        "renders 404 page if data request can't be matched for path: $path",
+        async ({ path }) => {
+          const event = createCloudFrontEvent({
+            uri: path,
+            origin: {
+              s3: {
+                domainName: "my-bucket.s3.amazonaws.com"
+              }
+            },
+            config: { eventType: "origin-request" } as any
+          });
+
+          mockPageRequire("./pages/_error.js");
+
+          const response = (await handler(event)) as CloudFrontResultResponse;
+          const body = response.body as string;
+          const decodedBody = new Buffer(body, "base64").toString("utf8");
+
+          expect(decodedBody).toEqual("pages/_error.js - 404");
+          expect(response.status).toEqual("404");
+        }
+      );
     });
 
     describe("500 page", () => {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -298,13 +298,15 @@ describe("Lambda@Edge", () => {
     describe("Data Requests", () => {
       it.each`
         path                                                      | expectedPage
+        ${"/_next/data/build-id/index.json"}                      | ${"pages/index.js"}
         ${"/_next/data/build-id/customers.json"}                  | ${"pages/customers/index.js"}
         ${"/_next/data/build-id/customers/superman.json"}         | ${"pages/customers/[customer].js"}
         ${"/_next/data/build-id/customers/superman/profile.json"} | ${"pages/customers/[customer]/profile.js"}
       `("serves json data for path $path", async ({ path, expectedPage }) => {
         const event = createCloudFrontEvent({
           uri: path,
-          host: "mydistribution.cloudfront.net"
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-request" } as any
         });
 
         mockPageRequire(expectedPage);
@@ -326,6 +328,7 @@ describe("Lambda@Edge", () => {
 
       it.each`
         path                                                       | expectedRedirect
+        ${"/_next/data/build-id/index.json/"}                      | ${"/_next/data/build-id/index.json"}
         ${"/_next/data/build-id/customers.json/"}                  | ${"/_next/data/build-id/customers.json"}
         ${"/_next/data/build-id/customers/superman.json/"}         | ${"/_next/data/build-id/customers/superman.json"}
         ${"/_next/data/build-id/customers/superman/profile.json/"} | ${"/_next/data/build-id/customers/superman/profile.json"}


### PR DESCRIPTION
## Description

This fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/553

* Using Next/Link component to navigate to index page with the new `getServerSideProps` did not do client-side navigation, because the `index.json` retrieval returned 503 error, and Next.js has a fallback to do a server-side navigation. Fixed by updating the routing of `index` data requests.
* Also fixed 503 errors which were due to trying to `require` `404.html` page in the origin response handler when a data request is unmatched. These now go to proper 404 pages.

## Tests

Updated tests.

On CloudFront:

https://d17ujsvie9w0tw.cloudfront.net/another2/ -> Click on `Home` link, it does client-side navigation.

https://d17ujsvie9w0tw.cloudfront.net/_next/data/kbqVEikVMWVZISeABSsbn/index.json -> returns index json file with 200 status

https://d17ujsvie9w0tw.cloudfront.net/_next/data/kbqVEikVMWVZISeABSsbn/ -> will redirect to non-trailing slash path with 308 status

https://d17ujsvie9w0tw.cloudfront.net/_next/data/kbqVEikVMWVZISeABSsbn -> returns index.json with 200 status

https://d17ujsvie9w0tw.cloudfront.net/_next/data/unmatched -> returns 404 page

https://d17ujsvie9w0tw.cloudfront.net/_next/data/kbqVEikVMWVZISeABSsbn/unmatched.json -> returns 404 page

Tested in my own app with no regressions as well (has SSR/SSG combination).