### PR TITLE
fix(lambda-at-edge): fix for 404s on public files

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -306,8 +306,8 @@ const handleOriginResponse = async ({
   const uri = normaliseUri(request.uri);
   const { status } = response;
   if (status !== "403") {
-    const pagePath = router(manifest)(uri);
-    if (pagePath === "pages/404.html") {
+    const { publicFiles } = manifest;
+    if (!publicFiles[uri] && router(manifest)(uri) === "pages/404.html") {
       response.status = "404";
       response.statusDescription = "Not Found";
     }

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -303,16 +303,16 @@ const handleOriginResponse = async ({
 }) => {
   const response = event.Records[0].cf.response;
   const request = event.Records[0].cf.request;
-  const uri = normaliseUri(request.uri);
   const { status } = response;
   if (status !== "403") {
-    const { publicFiles } = manifest;
-    if (!publicFiles[uri] && router(manifest)(uri) === "pages/404.html") {
+    // Set 404 status code for 404.html page. We do not need normalised URI as it will always be "/404.html"
+    if (request.uri === "/404.html") {
       response.status = "404";
       response.statusDescription = "Not Found";
     }
     return response;
   }
+  const uri = normaliseUri(request.uri);
   const { domainName, region } = request.origin!.s3!;
   const bucketName = domainName.replace(`.s3.${region}.amazonaws.com`, "");
   // It's usually better to do this outside the handler, but we need to know the bucket region

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-404.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-404.test.ts
@@ -68,7 +68,7 @@ describe("Lambda@Edge", () => {
 
   it("static 404 page should return CloudFront 404 status code after successful S3 origin response", async () => {
     const event = createCloudFrontEvent({
-      uri: "/page/does/not/exist",
+      uri: "/404.html",
       host: "mydistribution.cloudfront.net",
       config: { eventType: "origin-response" } as any,
       response: {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
@@ -171,26 +171,20 @@ describe("Lambda@Edge", () => {
         }
       );
 
-      it.each`
-        path
-        ${"/terms.html"}
-      `(
-        `path $path returns 200 status after a successful S3 Origin response`,
-        async ({ path }) => {
-          const event = createCloudFrontEvent({
-            uri: path,
-            host: "mydistribution.cloudfront.net",
-            config: { eventType: "origin-response" } as any,
-            response: {
-              status: "200"
-            } as any
-          });
+      it("terms.html should return 200 status after successful S3 Origin response", async () => {
+        const event = createCloudFrontEvent({
+          uri: "/terms.html",
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-response" } as any,
+          response: {
+            status: "200"
+          } as any
+        });
 
-          const response = (await handler(event)) as CloudFrontResultResponse;
+        const response = (await handler(event)) as CloudFrontResultResponse;
 
-          expect(response.status).toEqual("200");
-        }
-      );
+        expect(response.status).toEqual("200");
+      });
     });
 
     describe("Public files routing", () => {
@@ -548,26 +542,20 @@ describe("Lambda@Edge", () => {
         }
       );
 
-      it.each`
-        path
-        ${"/404.html"}
-      `(
-        `path $path returns 404 status after a successful S3 Origin response`,
-        async ({ path }) => {
-          const event = createCloudFrontEvent({
-            uri: path,
-            host: "mydistribution.cloudfront.net",
-            config: { eventType: "origin-response" } as any,
-            response: {
-              status: "200"
-            } as any
-          });
+      it("404.html should return 404 status after successful S3 Origin response", async () => {
+        const event = createCloudFrontEvent({
+          uri: "/404.html",
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-response" } as any,
+          response: {
+            status: "200"
+          } as any
+        });
 
-          const response = (await handler(event)) as CloudFrontResultResponse;
+        const response = (await handler(event)) as CloudFrontResultResponse;
 
-          expect(response.status).toEqual("404");
-        }
-      );
+        expect(response.status).toEqual("404");
+      });
     });
 
     describe("500 page", () => {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
@@ -194,6 +194,21 @@ describe("Lambda@Edge", () => {
         expect(request.uri).toEqual("/manifest.json");
       });
 
+      it("public file should return 200 status after successful S3 Origin response", async () => {
+        const event = createCloudFrontEvent({
+          uri: "/basepath/manifest.json",
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-response" } as any,
+          response: {
+            status: "200"
+          } as any
+        });
+
+        const response = (await handler(event)) as CloudFrontResultResponse;
+
+        expect(response.status).toEqual("200");
+      });
+
       it.each`
         path                          | expectedRedirect
         ${"/basepath/favicon.ico/"}   | ${"/basepath/favicon.ico"}

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
@@ -170,6 +170,27 @@ describe("Lambda@Edge", () => {
           await runRedirectTest(path, expectedRedirect);
         }
       );
+
+      it.each`
+        path
+        ${"/terms.html"}
+      `(
+        `path $path returns 200 status after a successful S3 Origin response`,
+        async ({ path }) => {
+          const event = createCloudFrontEvent({
+            uri: path,
+            host: "mydistribution.cloudfront.net",
+            config: { eventType: "origin-response" } as any,
+            response: {
+              status: "200"
+            } as any
+          });
+
+          const response = (await handler(event)) as CloudFrontResultResponse;
+
+          expect(response.status).toEqual("200");
+        }
+      );
     });
 
     describe("Public files routing", () => {
@@ -196,7 +217,7 @@ describe("Lambda@Edge", () => {
 
       it("public file should return 200 status after successful S3 Origin response", async () => {
         const event = createCloudFrontEvent({
-          uri: "/basepath/manifest.json",
+          uri: "/manifest.json",
           host: "mydistribution.cloudfront.net",
           config: { eventType: "origin-response" } as any,
           response: {
@@ -523,6 +544,27 @@ describe("Lambda@Edge", () => {
           const decodedBody = new Buffer(body, "base64").toString("utf8");
 
           expect(decodedBody).toEqual("pages/_error.js - 404");
+          expect(response.status).toEqual("404");
+        }
+      );
+
+      it.each`
+        path
+        ${"/404.html"}
+      `(
+        `path $path returns 404 status after a successful S3 Origin response`,
+        async ({ path }) => {
+          const event = createCloudFrontEvent({
+            uri: path,
+            host: "mydistribution.cloudfront.net",
+            config: { eventType: "origin-response" } as any,
+            response: {
+              status: "200"
+            } as any
+          });
+
+          const response = (await handler(event)) as CloudFrontResultResponse;
+
           expect(response.status).toEqual("404");
         }
       );

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -4,7 +4,6 @@ import {
   CloudFrontResultResponse,
   CloudFrontOrigin
 } from "aws-lambda";
-import { handler } from "src/default-handler";
 
 jest.mock(
   "../../src/prerender-manifest.json",

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -171,6 +171,27 @@ describe("Lambda@Edge", () => {
           await runRedirectTest(path, expectedRedirect);
         }
       );
+
+      it.each`
+        path
+        ${"/terms.html"}
+      `(
+        `path $path returns 200 status after a successful S3 Origin response`,
+        async ({ path }) => {
+          const event = createCloudFrontEvent({
+            uri: path,
+            host: "mydistribution.cloudfront.net",
+            config: { eventType: "origin-response" } as any,
+            response: {
+              status: "200"
+            } as any
+          });
+
+          const response = (await handler(event)) as CloudFrontResultResponse;
+
+          expect(response.status).toEqual("200");
+        }
+      );
     });
 
     describe("Public files routing", () => {
@@ -487,6 +508,27 @@ describe("Lambda@Edge", () => {
           const decodedBody = new Buffer(body, "base64").toString("utf8");
 
           expect(decodedBody).toEqual("pages/_error.js - 404");
+          expect(response.status).toEqual("404");
+        }
+      );
+
+      it.each`
+        path
+        ${"/404.html"}
+      `(
+        `path $path returns 404 status after a successful S3 Origin response`,
+        async ({ path }) => {
+          const event = createCloudFrontEvent({
+            uri: path,
+            host: "mydistribution.cloudfront.net",
+            config: { eventType: "origin-response" } as any,
+            response: {
+              status: "200"
+            } as any
+          });
+
+          const response = (await handler(event)) as CloudFrontResultResponse;
+
           expect(response.status).toEqual("404");
         }
       );

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -172,26 +172,20 @@ describe("Lambda@Edge", () => {
         }
       );
 
-      it.each`
-        path
-        ${"/terms.html"}
-      `(
-        `path $path returns 200 status after a successful S3 Origin response`,
-        async ({ path }) => {
-          const event = createCloudFrontEvent({
-            uri: path,
-            host: "mydistribution.cloudfront.net",
-            config: { eventType: "origin-response" } as any,
-            response: {
-              status: "200"
-            } as any
-          });
+      it("terms.html should return 200 status after successful S3 Origin response", async () => {
+        const event = createCloudFrontEvent({
+          uri: "/terms.html",
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-response" } as any,
+          response: {
+            status: "200"
+          } as any
+        });
 
-          const response = (await handler(event)) as CloudFrontResultResponse;
+        const response = (await handler(event)) as CloudFrontResultResponse;
 
-          expect(response.status).toEqual("200");
-        }
-      );
+        expect(response.status).toEqual("200");
+      });
     });
 
     describe("Public files routing", () => {
@@ -512,26 +506,20 @@ describe("Lambda@Edge", () => {
         }
       );
 
-      it.each`
-        path
-        ${"/404.html"}
-      `(
-        `path $path returns 404 status after a successful S3 Origin response`,
-        async ({ path }) => {
-          const event = createCloudFrontEvent({
-            uri: path,
-            host: "mydistribution.cloudfront.net",
-            config: { eventType: "origin-response" } as any,
-            response: {
-              status: "200"
-            } as any
-          });
+      it("404.html should return 404 status after successful S3 Origin response", async () => {
+        const event = createCloudFrontEvent({
+          uri: "/404.html",
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-response" } as any,
+          response: {
+            status: "200"
+          } as any
+        });
 
-          const response = (await handler(event)) as CloudFrontResultResponse;
+        const response = (await handler(event)) as CloudFrontResultResponse;
 
-          expect(response.status).toEqual("404");
-        }
-      );
+        expect(response.status).toEqual("404");
+      });
     });
 
     describe("500 page", () => {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -4,6 +4,7 @@ import {
   CloudFrontResultResponse,
   CloudFrontOrigin
 } from "aws-lambda";
+import { handler } from "src/default-handler";
 
 jest.mock(
   "../../src/prerender-manifest.json",
@@ -193,6 +194,21 @@ describe("Lambda@Edge", () => {
           }
         });
         expect(request.uri).toEqual("/manifest.json");
+      });
+
+      it("public file should return 200 status after successful S3 Origin response", async () => {
+        const event = createCloudFrontEvent({
+          uri: "/manifest.json",
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-response" } as any,
+          response: {
+            status: "200"
+          } as any
+        });
+
+        const response = (await handler(event)) as CloudFrontResultResponse;
+
+        expect(response.status).toEqual("200");
       });
 
       it.each`


### PR DESCRIPTION
## Description

This fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/576

* Fixes issue in latest alphas (1.17 alpha.8) where public files are served correctly but with 404 status code. This is because in origin response we should only set 404 code on unnormalised uri `/404.html` (these are file URIs returned by the S3 origin).

## Tests

Added some test cases as well to verify this.

Verified with my app: https://d17ujsvie9w0tw.cloudfront.net/app-store-badge.png (returns 200)
https://d17ujsvie9w0tw.cloudfront.net/notfound/ (returns 404)
https://d17ujsvie9w0tw.cloudfront.net/anotherSSG/ (returns 200)
https://d17ujsvie9w0tw.cloudfront.net/anotherSSR/ (returns 200)
https://d17ujsvie9w0tw.cloudfront.net/ (returns 200)
https://d17ujsvie9w0tw.cloudfront.net/_next/data/jRDzHTftCxGo7bHQ1tybv/index.json (returns 200)
https://d17ujsvie9w0tw.cloudfront.net/_next/data/notfound (returns 404)

## Additional context

Seems something like this is not easily caught in unit tests (or hard to write, due to different inputs to request vs. response handlers). Apologies since I was confusing the input to origin response handler (should be "/404.html" for 404 page). Probably if we have e2e tests it would be easier to catch (which I'm working on).

Also, as mentioned in the issue, there seems to be some versioning issue in the latest alpha..seems the 1.17 alpha.5 - alpha.8 all point to latest commit of lambda-at-edge package? So this issue was impacting all those versions. Not sure why this is so?