### PR TITLE
chore(release): publish

### DIFF
--- a/packages/compat-layers/lambda-at-edge-compat/CHANGELOG.md
+++ b/packages/compat-layers/lambda-at-edge-compat/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.5.0-alpha.3](https://github.com/danielcondemarin/serverless-next.js/compare/@sls-next/next-aws-cloudfront@1.5.0-alpha.2...@sls-next/next-aws-cloudfront@1.5.0-alpha.3) (2020-09-09)
+
+### Features
+
+- **lambda-at-edge, next-aws-cloudfront:** support Preview Mode ([#562](https://github.com/danielcondemarin/serverless-next.js/issues/562)) ([5e1ea38](https://github.com/danielcondemarin/serverless-next.js/commit/5e1ea3891e48d75de5973902a014b67f14c8380a))
+
 # [1.5.0-alpha.2](https://github.com/danielcondemarin/serverless-next.js/compare/@sls-next/next-aws-cloudfront@1.5.0-alpha.1...@sls-next/next-aws-cloudfront@1.5.0-alpha.2) (2020-08-14)
 
 **Note:** Version bump only for package @sls-next/next-aws-cloudfront

--- a/packages/compat-layers/lambda-at-edge-compat/package.json
+++ b/packages/compat-layers/lambda-at-edge-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/next-aws-cloudfront",
-  "version": "1.5.0-alpha.2",
+  "version": "1.5.0-alpha.3",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.6.0-alpha.8](https://github.com/danielcondemarin/serverless-next.js/compare/@sls-next/lambda-at-edge@1.6.0-alpha.7...@sls-next/lambda-at-edge@1.6.0-alpha.8) (2020-09-09)
+
+### Features
+
+- **lambda-at-edge:** use new aws s3 client for faster require time ([#583](https://github.com/danielcondemarin/serverless-next.js/issues/583)) ([f9eef45](https://github.com/danielcondemarin/serverless-next.js/commit/f9eef458552e5ff5ee60e9b43df7ccf221a2ec0c))
+- **lambda-at-edge, next-aws-cloudfront:** support Preview Mode ([#562](https://github.com/danielcondemarin/serverless-next.js/issues/562)) ([5e1ea38](https://github.com/danielcondemarin/serverless-next.js/commit/5e1ea3891e48d75de5973902a014b67f14c8380a))
+
 # [1.6.0-alpha.7](https://github.com/danielcondemarin/serverless-next.js/compare/@sls-next/lambda-at-edge@1.6.0-alpha.6...@sls-next/lambda-at-edge@1.6.0-alpha.7) (2020-08-31)
 
 ### Bug Fixes

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.6.0-alpha.7",
+  "version": "1.6.0-alpha.8",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.3.0-alpha.4](https://github.com/danielcondemarin/serverless-next.js/compare/@sls-next/s3-static-assets@1.3.0-alpha.3...@sls-next/s3-static-assets@1.3.0-alpha.4) (2020-09-09)
+
+### Features
+
+- **aws-cloudfront, s3-static-assets:** support setting individual min, max, default CloudFront TTLs, update Cache-Control headers and TTLs for \_next/data files ([#593](https://github.com/danielcondemarin/serverless-next.js/issues/593)) ([fb8e61d](https://github.com/danielcondemarin/serverless-next.js/commit/fb8e61dc50b11c0e5966548a8c84b58e495ea748))
+
 # [1.3.0-alpha.3](https://github.com/danielcondemarin/serverless-next.js/compare/@sls-next/s3-static-assets@1.3.0-alpha.2...@sls-next/s3-static-assets@1.3.0-alpha.3) (2020-08-19)
 
 ### Bug Fixes

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/s3-static-assets",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.0](https://github.com/serverless-nextjs/serverless-next.js/compare/@sls-next/aws-cloudfront@1.1.1-alpha.2...@sls-next/aws-cloudfront@1.2.0-alpha.0) (2020-09-09)
+
+### Features
+
+- **aws-cloudfront, s3-static-assets:** support setting individual min, max, default CloudFront TTLs, update Cache-Control headers and TTLs for \_next/data files ([#593](https://github.com/serverless-nextjs/serverless-next.js/issues/593)) ([fb8e61d](https://github.com/serverless-nextjs/serverless-next.js/commit/fb8e61dc50b11c0e5966548a8c84b58e495ea748))
+- **aws-cloudfront, serverless-component:** add cloudfront custom error responses ([#590](https://github.com/serverless-nextjs/serverless-next.js/issues/590)) ([f3d2a17](https://github.com/serverless-nextjs/serverless-next.js/commit/f3d2a17b2fac5e9bb67b1f6ed5201c8128600314))
+
 ## [1.1.1-alpha.2](https://github.com/serverless-nextjs/serverless-next.js/compare/@sls-next/aws-cloudfront@1.1.1-alpha.1...@sls-next/aws-cloudfront@1.1.1-alpha.2) (2020-08-14)
 
 **Note:** Version bump only for package @sls-next/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-cloudfront",
-  "version": "1.1.1-alpha.2",
+  "version": "1.2.0-alpha.0",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.17.0-alpha.10](https://github.com/danielcondemarin/serverless-next.js/compare/@sls-next/serverless-component@1.17.0-alpha.9...@sls-next/serverless-component@1.17.0-alpha.10) (2020-09-09)
+
+### Bug Fixes
+
+- **serverless-component:** wait sequentially for resources to be removed, so as to avoid race conditions ([#588](https://github.com/danielcondemarin/serverless-next.js/issues/588)) ([7bcb032](https://github.com/danielcondemarin/serverless-next.js/commit/7bcb032f3199f245643fab91e8b671083a857cc3))
+
+### Features
+
+- **aws-cloudfront, s3-static-assets:** support setting individual min, max, default CloudFront TTLs, update Cache-Control headers and TTLs for \_next/data files ([#593](https://github.com/danielcondemarin/serverless-next.js/issues/593)) ([fb8e61d](https://github.com/danielcondemarin/serverless-next.js/commit/fb8e61dc50b11c0e5966548a8c84b58e495ea748))
+- **aws-cloudfront, serverless-component:** add cloudfront custom error responses ([#590](https://github.com/danielcondemarin/serverless-next.js/issues/590)) ([f3d2a17](https://github.com/danielcondemarin/serverless-next.js/commit/f3d2a17b2fac5e9bb67b1f6ed5201c8128600314))
+- **serverless-component:** allow passing an inline policy ([#575](https://github.com/danielcondemarin/serverless-next.js/issues/575)) ([05ddcc9](https://github.com/danielcondemarin/serverless-next.js/commit/05ddcc98c03e642b8ab9fda3e20334215a8cb017))
+
 # [1.17.0-alpha.9](https://github.com/danielcondemarin/serverless-next.js/compare/@sls-next/serverless-component@1.17.0-alpha.8...@sls-next/serverless-component@1.17.0-alpha.9) (2020-08-31)
 
 **Note:** Version bump only for package @sls-next/serverless-component

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.17.0-alpha.9",
+  "version": "1.17.0-alpha.10",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",


### PR DESCRIPTION
 - @sls-next/next-aws-cloudfront@1.5.0-alpha.3
 - @sls-next/lambda-at-edge@1.6.0-alpha.8
 - @sls-next/s3-static-assets@1.3.0-alpha.4
 - @sls-next/aws-cloudfront@1.2.0-alpha.0
 - @sls-next/serverless-component@1.17.0-alpha.10