### PR TITLE
fix(nextjs-component, e2e-tests): allow all CloudFront HTTP methods for default caching behavior

### DIFF
--- a/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
@@ -13,6 +13,16 @@ describe("Pages Tests", () => {
 
         cy.visit(path);
       });
+
+      ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"].forEach(
+        (method) => {
+          it(`allows HTTP method: ${method}`, () => {
+            cy.request({ url: path, method: method }).then((response) => {
+              expect(response.status).to.equal(200);
+            });
+          });
+        }
+      );
     });
   });
 
@@ -31,6 +41,16 @@ describe("Pages Tests", () => {
 
         cy.visit(path);
       });
+
+      ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"].forEach(
+        (method) => {
+          it(`allows HTTP method: ${method}`, () => {
+            cy.request({ url: path, method: method }).then((response) => {
+              expect(response.status).to.equal(200);
+            });
+          });
+        }
+      );
     });
   });
 
@@ -42,6 +62,27 @@ describe("Pages Tests", () => {
 
         cy.ensureRouteCached(path);
         cy.visit(path);
+      });
+
+      ["HEAD", "GET"].forEach((method) => {
+        it(`allows HTTP method: ${method}`, () => {
+          cy.request({ url: path, method: method }).then((response) => {
+            expect(response.status).to.equal(200);
+          });
+        });
+      });
+
+      ["DELETE", "POST", "OPTIONS", "PUT", "PATCH"].forEach((method) => {
+        it(`disallows HTTP method with 4xx error: ${method}`, () => {
+          cy.request({
+            url: path,
+            method: method,
+            failOnStatusCode: false
+          }).then((response) => {
+            expect(response.status).to.be.at.least(400);
+            expect(response.status).to.be.lessThan(500);
+          });
+        });
       });
     });
   });

--- a/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
@@ -684,7 +684,15 @@ describe("Custom inputs", () => {
         minTTL: 0,
         defaultTTL: 0,
         maxTTL: 31536000,
-        allowedHttpMethods: ["HEAD", "GET"],
+        allowedHttpMethods: [
+          "HEAD",
+          "DELETE",
+          "POST",
+          "GET",
+          "OPTIONS",
+          "PUT",
+          "PATCH"
+        ],
         forward: {
           cookies: "all",
           queryString: true

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -520,7 +520,15 @@ class NextjsComponent extends Component {
           ...cloudFrontDefaults.forward
         },
         // everything after here cant be overridden
-        allowedHttpMethods: ["HEAD", "GET"],
+        allowedHttpMethods: [
+          "HEAD",
+          "DELETE",
+          "POST",
+          "GET",
+          "OPTIONS",
+          "PUT",
+          "PATCH"
+        ],
         "lambda@edge": {
           ...defaultLambdaAtEdgeConfig,
           "origin-request": `${defaultEdgeLambdaOutputs.arn}:${defaultEdgeLambdaPublishOutputs.version}`,


### PR DESCRIPTION
This fixes https://github.com/serverless-nextjs/serverless-next.js/issues/454 and similar issues.

Not sure why we don't allow all CloudFront methods on default caching behavior, which will allow more HTTP methods e.g form posts on SSR pages, similar to Vercel.

This component already adds a policy to the S3 bucket to only allow GetObject from the origin access identity (CloudFront), so requesters cannot modify S3 objects with these additional methods (e.g using DELETE to delete a public file). See: https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_AllowedMethods.html

## Tests

Updated unit and e2e tests, and ran them (e2e tests not yet automated).

SSR page: https://dcrrk28otqvm3.cloudfront.net/ssr-page (allows GET, HEAD, PUT, PATCH, DELETE, POST, OPTIONS). E.g POST/DELETE will return page itself since there is no different behavior here for POST/DELETE

For resources in S3:
SSG page: https://dcrrk28otqvm3.cloudfront.net/ssg-page (allows GET, HEAD. OPTIONS requires origin request header)
Public files: https://dcrrk28otqvm3.cloudfront.net/app-store-badge.png (allows, GET, HEAD. OPTIONS requires origin request header.

The above two, for POST gets 405 Method Not Allowed, and for PUT, PATCH, DELETE gets 403 Forbidden, which should be due to the S3 bucket policy only allow GetObject from the CloudFront distribution.

Static JS (same as before, it cannot be DELETED, as _next/static cache behavior only allows GET, HEAD): https://dcrrk28otqvm3.cloudfront.net/_next/static/chunks/framework.085e84bea8b122ad7b41.js

For comparison:

Vercel SSR page: https://nextjs-repros.vercel.app/anotherSSR (allows GET, HEAD, PUT, PATCH, DELETE, POST, OPTIONS and even more uncommon methods, since they do not use CloudFront but their own custom CDN).
Vercel SSG page: https://nextjs-repros.vercel.app/anotherSSG (allows GET, OPTIONS, HEAD)
