### PR TITLE
test(e2e-tests): add e2e tests step in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,3 +34,17 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn test
       - run: yarn integration
+      - name: Wait for existing workflow to complete before e2e tests
+        if: ${{ matrix.node-version == '12.x' }}
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run e2e tests
+        if: ${{ matrix.node-version == '12.x' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AT }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ST }}
+        run: |
+          cd packages/e2e-tests/next-app
+          yarn --frozen-lockfile
+          yarn e2e:ci

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AT }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ST }}
+          WAIT_TIMEOUT: 3600 # For initial deployment, CF distribution takes some time. Can remove for subsequent deployments.
         run: |
           cd packages/e2e-tests/next-app
           yarn --frozen-lockfile

--- a/packages/e2e-tests/next-app/package.json
+++ b/packages/e2e-tests/next-app/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start -p $PORT",
     "serverless": "serverless",
-    "e2e": "cypress run"
+    "e2e": "cypress run",
+    "e2e:ci": "ts-node --project tsconfig.scripts.json scripts/run-e2e-ci.ts"
   },
   "repository": {
     "type": "git",
@@ -31,13 +32,17 @@
     "@types/node": "14.6.2",
     "@types/node-fetch": "2.5.7",
     "@types/react": "16.9.48",
+    "@types/uuid": "8.3.0",
+    "aws-sdk": "2.758.0",
     "babel-plugin-istanbul": "6.0.0",
     "babel-plugin-transform-class-properties": "6.24.1",
     "cypress": "5.1.0",
     "istanbul-lib-coverage": "3.0.0",
     "nyc": "15.1.0",
     "ts-node": "9.0.0",
-    "typescript": "4.0.2"
+    "typescript": "4.0.2",
+    "uuid": "8.3.0",
+    "yargs": "16.0.3"
   },
   "nyc": {
     "report-dir": "cypress-coverage"

--- a/packages/e2e-tests/next-app/scripts/run-e2e-ci.ts
+++ b/packages/e2e-tests/next-app/scripts/run-e2e-ci.ts
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+
+import fetch from "node-fetch";
+import { v4 as uuidv4 } from "uuid";
+import { execSync } from "child_process";
+import AWS from "aws-sdk";
+import fs from "fs";
+
+// Next.js build ID follows a certain pattern
+const regex = /"buildId":"([a-zA-Z0-9_-]+)"/;
+
+// AWS clients
+const cloudfront = new AWS.CloudFront();
+
+// Timeout from environment variable. By default it's 10 minutes.
+const waitTimeout = parseInt(process.env["WAIT_TIMEOUT"] ?? "600");
+
+// Constants
+const deploymentBucketName = "serverless-next-js-e2e-test"; // For saving .serverless state
+const appName = "next-app";
+
+// To ensure cleanup doesn't happen more than once
+let alreadyCleaned = false;
+
+/**
+ * Check that the given URL matched the expected build ID.
+ * @param url
+ * @param buildId
+ * @param waitDuration
+ * @param pollInterval
+ */
+async function checkWebAppBuildId(
+  url: string,
+  buildId: string,
+  waitDuration: number,
+  pollInterval: number
+): Promise<boolean> {
+  const startDate = new Date();
+  const startTime = startDate.getTime();
+  const waitDurationMillis = waitDuration * 1000;
+
+  while (new Date().getTime() - startTime < waitDurationMillis) {
+    // Guarantee that CloudFront cache is missed by appending uuid query parameter.
+    const uuid: string = uuidv4().replace("-", "");
+    const suffixedUrl: string = url + `/?uuid=${uuid}`;
+
+    try {
+      const response = await fetch(suffixedUrl);
+
+      if (response.status >= 200 && response.status < 400) {
+        const html = await response.text();
+        const matches = regex.exec(html);
+
+        // Found match in actual buildId and expected buildId
+        if (matches && matches.length > 0 && matches[1] === buildId) {
+          console.info(
+            `URL ${url} is ready as build ID matched. Actual build ID: ${matches[1]}, expected build ID: ${buildId}`
+          );
+          return true;
+        }
+      }
+
+      console.info(
+        `URL ${url} is not yet ready. Retrying in ${pollInterval} seconds.`
+      );
+      await new Promise((r) => setTimeout(r, pollInterval * 1000));
+    } catch (error) {
+      // URL may not return anything, so retry after some time
+      if (error.toString().includes("ENOTFOUND")) {
+        console.info(
+          `URL ${url} is not yet provisioned. Retrying in ${pollInterval} seconds.`
+        );
+        await new Promise((r) => setTimeout(r, pollInterval * 1000));
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Get the Next.js build ID from the .next build directory.
+ */
+function getNextBuildId(): string | null {
+  let data;
+  try {
+    data = fs.readFileSync(`.next/BUILD_ID`);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      console.error("Next BUILD_ID file could not be found.");
+      return null;
+    } else {
+      console.error("Error reading Next BUILD_ID file.");
+      return null;
+    }
+  }
+  try {
+    return data.toString();
+  } catch (err) {
+    console.error(`Error: ${err}`);
+    return null;
+  }
+}
+
+/**
+ * Get the app bucket name deployed to by serverless-next.js.
+ * @param appName
+ */
+function getAppBucketName(appName: string): string | null {
+  let data;
+  try {
+    data = fs.readFileSync(`.serverless/Template.${appName}.AwsS3.json`);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      console.error("S3 JSON file could not be found.");
+      return null;
+    } else {
+      console.error("Error reading S3 JSON file.");
+      return null;
+    }
+  }
+  try {
+    const struct = JSON.parse(data.toString());
+    return struct.name;
+  } catch (err) {
+    console.error(`Error: ${err}`);
+    return null;
+  }
+}
+
+/**
+ * Get the CloudFront URL and distribution ID.
+ * @param appName
+ */
+function getCloudFrontDetails(
+  appName: string
+): { cloudFrontUrl: string | null; distributionId: string | null } {
+  let data;
+  try {
+    data = fs.readFileSync(`.serverless/Template.${appName}.CloudFront.json`);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      console.error("CloudFront JSON file could not be found.");
+      return { cloudFrontUrl: null, distributionId: null };
+    } else {
+      console.error("Error reading CloudFront JSON file.");
+      return { cloudFrontUrl: null, distributionId: null };
+    }
+  }
+  try {
+    const struct = JSON.parse(data.toString());
+    return { cloudFrontUrl: struct.url, distributionId: struct.id };
+  } catch (err) {
+    console.error(`Error: ${err}`);
+    return { cloudFrontUrl: null, distributionId: null };
+  }
+}
+
+/**
+ * Check if a distribution is completely deployed and ready.
+ * This means that it has been updated globally, which may take a long time.
+ * @param distributionId
+ * @param waitDuration
+ * @param pollInterval
+ */
+async function checkCloudFrontDistributionReady(
+  distributionId: string,
+  waitDuration: number,
+  pollInterval: number
+): Promise<boolean> {
+  const startDate = new Date();
+  const startTime = startDate.getTime();
+  const waitDurationMillis = waitDuration * 1000;
+
+  while (new Date().getTime() - startTime < waitDurationMillis) {
+    const result = await cloudfront
+      .getDistribution({ Id: distributionId })
+      .promise();
+
+    if (result.Distribution?.Status === "Deployed") {
+      return true;
+    }
+
+    console.info(
+      `Distribution ${distributionId} is not yet ready. Retrying in ${pollInterval} seconds.`
+    );
+    await new Promise((r) => setTimeout(r, pollInterval * 1000));
+  }
+
+  return false;
+}
+
+/**
+ * Check if all invalidations for the distribution have been completed.
+ * @param distributionId
+ * @param waitDuration
+ * @param pollInterval
+ */
+async function checkInvalidationsCompleted(
+  distributionId: string,
+  waitDuration: number,
+  pollInterval: number
+): Promise<boolean> {
+  const startDate = new Date();
+  const startTime = startDate.getTime();
+  const waitDurationMillis = waitDuration * 1000;
+
+  while (new Date().getTime() - startTime < waitDurationMillis) {
+    const result = await cloudfront
+      .listInvalidations({ DistributionId: distributionId, MaxItems: "10" })
+      .promise();
+
+    let invalidationsCompleted = true;
+    for (const invalidationSummary of result.InvalidationList?.Items ?? []) {
+      if (invalidationSummary.Status !== "Completed") {
+        invalidationsCompleted = false;
+        break;
+      }
+    }
+
+    if (invalidationsCompleted) {
+      console.info(`Invalidations for ${distributionId} are completed.`);
+      return true;
+    }
+
+    console.info(
+      `Invalidations for ${distributionId} are not yet completed. Retrying in ${pollInterval} seconds.`
+    );
+    await new Promise((r) => setTimeout(r, pollInterval * 1000));
+  }
+
+  return false;
+}
+
+/**
+ * Cleanup AWS resources such as emptying the app bucket.
+ */
+function cleanup(): void {
+  if (!alreadyCleaned) {
+    // If possible, sync .serverless back to S3
+    console.info("Syncing Serverless data back to S3.");
+    execSync(
+      `aws s3 sync .serverless s3://${deploymentBucketName}/${appName}/.serverless --delete`,
+      { stdio: "inherit" }
+    );
+
+    // Optimistically clean up app's S3 bucket
+    execSync(
+      `aws s3 rm s3://${getAppBucketName(appName)} --recursive || true`,
+      {
+        stdio: "inherit"
+      }
+    );
+
+    alreadyCleaned = true;
+  }
+}
+
+/**
+ * Main function to run the end-to-end test.
+ */
+async function runEndToEndTest(): Promise<boolean> {
+  try {
+    // Create deployment bucket if doesn't already exist
+    console.info(
+      `Creating deployment bucket if it doesn't exist: ${deploymentBucketName}`
+    );
+
+    execSync(`aws s3 mb s3://${deploymentBucketName} || true`, {
+      stdio: "inherit"
+    });
+
+    // Sync .serverless from s3
+    console.info("Syncing Serverless data from S3.");
+    execSync(
+      `aws s3 sync s3://${deploymentBucketName}/${appName}/.serverless .serverless --delete`,
+      { stdio: "inherit" }
+    );
+
+    // Deploy
+    console.info("Deploying serverless-next.js app.");
+    execSync("npx serverless", { stdio: "inherit" });
+
+    // Get Next.js build ID and URL
+    console.info("Getting Next.js build ID");
+    const buildId = getNextBuildId();
+
+    if (!buildId) {
+      throw new Error("Next.js build ID not found.");
+    }
+
+    console.info("Getting CloudFront URL and distribution ID.");
+    const { cloudFrontUrl, distributionId } = getCloudFrontDetails("next-app");
+
+    if (!cloudFrontUrl || !distributionId) {
+      throw new Error("CloudFront url or distribution id not found.");
+    }
+
+    // Check that CloudFront distribution is ready
+    console.info(
+      "Checking if CloudFront invalidations, SSR and SSG pages are ready."
+    );
+    const [cloudFrontReady, ssrReady, ssgReady] = await Promise.all([
+      checkInvalidationsCompleted(distributionId, waitTimeout, 10),
+      checkWebAppBuildId(cloudFrontUrl + "/ssr-page", buildId, waitTimeout, 10),
+      checkWebAppBuildId(cloudFrontUrl + "/ssg-page", buildId, waitTimeout, 10)
+      // The below is not really needed, as it waits for distribution to be deployed globally, which takes a longer time.
+      // checkCloudFrontDistributionReady(distributionId, waitTimeout, 10),
+    ]);
+
+    if (!cloudFrontReady || !ssrReady || !ssgReady) {
+      throw new Error("Timed out waiting for app to be ready!");
+    }
+
+    // Set Cypress variables to use in e2e tests
+    console.info(
+      `Setting CYPRESS_BASE_URL=${cloudFrontUrl} and CYPRESS_NEXT_BUILD_ID=${buildId}`
+    );
+
+    process.env["CYPRESS_BASE_URL"] = cloudFrontUrl;
+    process.env["CYPRESS_NEXT_BUILD_ID"] = buildId;
+
+    // Now run the e2e tests
+    console.info("Running e2e tests.");
+    execSync("yarn e2e", { stdio: "inherit" });
+
+    return true;
+  } catch (error) {
+    console.error(`Error: ${error}`);
+    return false;
+  } finally {
+    cleanup();
+  }
+}
+
+// In case script is exited, ensure cleanup
+process.on("exit", cleanup.bind(null, { cleanup: true }));
+process.on("SIGINT", cleanup.bind(null, { exit: true }));
+
+runEndToEndTest()
+  .then((success) => {
+    if (success) {
+      console.info("End-to-end test successful.");
+      process.exit(0);
+    } else {
+      console.error("End-to-end test failed.");
+      process.exit(1);
+    }
+  })
+  .catch((error) => {
+    console.error(`Unhandled error: ${error}`);
+    process.exit(1);
+  });

--- a/packages/e2e-tests/next-app/tsconfig.scripts.json
+++ b/packages/e2e-tests/next-app/tsconfig.scripts.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": "scripts",
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": false,
+    "preserveConstEnums": true,
+    "removeComments": true,
+    "sourceMap": true,
+    "strictNullChecks": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "target": "es2015",
+    "module": "commonjs",
+    "rootDir": "./"
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/e2e-tests/next-app/yarn.lock
+++ b/packages/e2e-tests/next-app/yarn.lock
@@ -1387,6 +1387,11 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
 
+"@types/uuid@8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -1836,6 +1841,21 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+aws-sdk@2.758.0:
+  version "2.758.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.758.0.tgz#9df99d5e3e22031b4ab7d9332f82782ecc29a7b3"
+  integrity sha512-jxuJuoUb/yVkYaJy6OuPQ5XKRajZXDKPZHvSiF0u5n3DlZfNoj92yHxidm+zpC1DeS/4is6xFCAmEct5lHAy/Q==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -2337,15 +2357,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@5.6.0, buffer@^5.0.2:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
-  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
-buffer@^4.3.0:
+buffer@4.9.2, buffer@^4.3.0:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
   integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
@@ -2353,6 +2365,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@5.6.0, buffer@^5.0.2:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 buffer@~5.2.1:
   version "5.2.1"
@@ -2627,6 +2647,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.1.tgz#a4cb67aad45cd83d8d05128fc9f4d8fbb887e6b3"
+  integrity sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
   version "4.0.1"
@@ -3399,6 +3428,11 @@ eventemitter2@^6.4.2:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.3.tgz#35c563619b13f3681e7eb05cbdaf50f56ba58820"
   integrity sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 events@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
@@ -3783,7 +3817,7 @@ get-assigned-identifiers@^1.2.0:
   resolved "https://registry.yarnpkg.com/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz#6dbf411de648cbaf8d9169ebb0d2d576191e2ff1"
   integrity sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -4058,7 +4092,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-ieee754@^1.1.4:
+ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -4453,6 +4487,11 @@ jest-worker@24.9.0:
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -6159,6 +6198,16 @@ sass-loader@8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
@@ -7010,6 +7059,14 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0, url@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -7055,6 +7112,16 @@ util@~0.10.1:
   integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
   dependencies:
     inherits "2.0.3"
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
+  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
@@ -7211,6 +7278,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -7226,6 +7302,19 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
@@ -7235,6 +7324,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+y18n@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.1.tgz#1ad2a7eddfa8bce7caa2e1f6b5da96c39d99d571"
+  integrity sha512-/jJ831jEs4vGDbYPQp4yGKDYPSCCEQ45uZWJHE1AoYBzqdZi8+LDWas0z4HrmJXmKdpFsTiowSHXdxyFhpmdMg==
 
 yallist@^3.0.2:
   version "3.1.1"
@@ -7253,6 +7347,24 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.0.0:
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.0.0.tgz#c65a1daaa977ad63cebdd52159147b789a4e19a9"
+  integrity sha512-8eblPHTL7ZWRkyjIZJjnGf+TijiKJSwA24svzLRVvtgoi/RZiKa9fFQTrlx0OKLnyHSdt/enrdadji6WFfESVA==
+
+yargs@16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.0.3.tgz#7a919b9e43c90f80d4a142a89795e85399a7e54c"
+  integrity sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==
+  dependencies:
+    cliui "^7.0.0"
+    escalade "^3.0.2"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.1"
+    yargs-parser "^20.0.0"
 
 yargs@^15.0.2:
   version "15.4.1"


### PR DESCRIPTION
This adds e2e tests in the CI workflow. I tested it locally and it works fine, hopefully it works in the CI too (note: it is currently failing due to permissions issue in AWS). This closes https://github.com/serverless-nextjs/serverless-next.js/issues/573.

* It uses a script to:
1. Sync `.serverless` state (to reuse the same distribution) from a deployment S3 bucket.
2. Wait for CloudFront invalidations to complete, Lambda to update, S3 to update, based on the Next.js `BUILD_ID`.
3. Run the Cypress tests (`yarn e2e`) with env variables set for CloudFront URL and `BUILD_ID`.
4. Syncs back `.serverless` state and cleans up app files in `S3`. The Lambda and CloudFront distribution are untouched for future reuse.
* This is run in the 12.x workflow only, and additionally gated using https://github.com/softprops/turnstyle to ensure only one instance is running at a time.
* There is mixed use of aws-cli and aws-sdk, reason being that S3 commands like emptying a bucket or syncing a folder are one-liners in aws-cli, but take much more code using aws-sdk.

Some improvements in the future but it's not needed now as there aren't too many pull requests anyway:
* Manage multiple PR workflows running concurrently - we would need to manage serverless state across multiple CloudFront distributions.
* Update e2e tests to add more coverage of API routes, preview mode, etc.