### PR TITLE
feat(nextjs-component): allow setting custom API cache behavior

### DIFF
--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -74,9 +74,7 @@ class NextjsComponent extends Component {
     // check for other api like paths
     for (const path of stillToMatch) {
       if (/^(\/?api\/.*|\/?api)$/.test(path)) {
-        throw Error(
-          `Setting custom cache behaviour for api/ route "${path}" is not supported`
-        );
+        stillToMatch.delete(path);
       }
     }
 


### PR DESCRIPTION
## Description

This allows setting custom cache behavior for API routes, e.g for api/*. Example config which I tested with `next-app` in the end-to-end tests.

This closes: https://github.com/serverless-nextjs/serverless-next.js/issues/608 and https://github.com/serverless-nextjs/serverless-next.js/issues/532

## Testing

Tested on the app:

```yml
next-app:
  component: "../../serverless-components/nextjs-component"
  inputs:
    cloudfront:
      api/*:
        minTTL: 10
        maxTTL: 100
        defaultTTL: 50
        forward:
          headers:
            [
                Host
            ]
```

This will be reflected in the CloudFront behavior for api/* as follows:

<img width="943" alt="Screen Shot 2020-09-25 at 12 22 32 AM" src="https://user-images.githubusercontent.com/3221524/94238723-9d57a280-fec5-11ea-8e09-79a0b64b7696.png">
