### PR TITLE
feat(lambda-at-edge): support custom redirects from API routes

### DIFF
--- a/packages/e2e-tests/next-app/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/redirects.test.ts
@@ -136,6 +136,12 @@ describe("Redirects Tests", () => {
         expectedRedirect: "/ssr-page",
         expectedStatus: 200,
         expectedRedirectStatus: 302
+      },
+      {
+        path: "/api/deprecated-basic-api",
+        expectedRedirect: "/api/basic-api",
+        expectedStatus: 200,
+        expectedRedirectStatus: 308
       }
     ].forEach(
       ({ path, expectedRedirect, expectedStatus, expectedRedirectStatus }) => {

--- a/packages/e2e-tests/next-app/next.config.js
+++ b/packages/e2e-tests/next-app/next.config.js
@@ -35,6 +35,11 @@ module.exports = {
         source: "/regex-redirect-2/:slug(\\d{1,})",
         destination: "/regex-redirect-2-dest/:slug",
         permanent: true
+      },
+      {
+        source: "/api/deprecated-basic-api",
+        destination: "/api/basic-api",
+        permanent: true
       }
     ];
   }

--- a/packages/libs/lambda-at-edge/src/api-handler.ts
+++ b/packages/libs/lambda-at-edge/src/api-handler.ts
@@ -1,10 +1,13 @@
 // @ts-ignore
 import manifest from "./manifest.json";
 // @ts-ignore
-import { basePath } from "./routes-manifest.json";
+import RoutesManifestJson from "./routes-manifest.json";
 import cloudFrontCompat from "@sls-next/next-aws-cloudfront";
 import { OriginRequestApiHandlerManifest, OriginRequestEvent } from "../types";
 import { CloudFrontResultResponse, CloudFrontRequest } from "aws-lambda";
+import { createRedirectResponse, getRedirectPath } from "./routing/redirector";
+
+const basePath = RoutesManifestJson.basePath;
 
 const normaliseUri = (uri: string): string => (uri === "/" ? "/index" : uri);
 
@@ -42,6 +45,18 @@ export const handler = async (
   event: OriginRequestEvent
 ): Promise<CloudFrontResultResponse | CloudFrontRequest> => {
   const request = event.Records[0].cf.request;
+  const routesManifest = RoutesManifestJson as RoutesManifestJson;
+
+  // Handle custom redirects
+  const customRedirect = getRedirectPath(request.uri, routesManifest);
+  if (customRedirect) {
+    return createRedirectResponse(
+      customRedirect.redirectPath,
+      request.querystring,
+      customRedirect.statusCode
+    );
+  }
+
   const uri = normaliseUri(request.uri);
 
   const pagePath = router(manifest)(uri);

--- a/packages/libs/lambda-at-edge/src/api-handler.ts
+++ b/packages/libs/lambda-at-edge/src/api-handler.ts
@@ -3,7 +3,11 @@ import manifest from "./manifest.json";
 // @ts-ignore
 import RoutesManifestJson from "./routes-manifest.json";
 import cloudFrontCompat from "@sls-next/next-aws-cloudfront";
-import { OriginRequestApiHandlerManifest, OriginRequestEvent } from "../types";
+import {
+  OriginRequestApiHandlerManifest,
+  OriginRequestEvent,
+  RoutesManifest
+} from "../types";
 import { CloudFrontResultResponse, CloudFrontRequest } from "aws-lambda";
 import { createRedirectResponse, getRedirectPath } from "./routing/redirector";
 
@@ -45,7 +49,7 @@ export const handler = async (
   event: OriginRequestEvent
 ): Promise<CloudFrontResultResponse | CloudFrontRequest> => {
   const request = event.Records[0].cf.request;
-  const routesManifest = RoutesManifestJson as RoutesManifestJson;
+  const routesManifest = RoutesManifestJson as RoutesManifest;
 
   // Handle custom redirects
   const customRedirect = getRedirectPath(request.uri, routesManifest);

--- a/packages/libs/lambda-at-edge/src/api-handler.ts
+++ b/packages/libs/lambda-at-edge/src/api-handler.ts
@@ -49,7 +49,7 @@ export const handler = async (
   event: OriginRequestEvent
 ): Promise<CloudFrontResultResponse | CloudFrontRequest> => {
   const request = event.Records[0].cf.request;
-  const routesManifest = RoutesManifestJson as RoutesManifest;
+  const routesManifest: RoutesManifest = RoutesManifestJson;
 
   // Handle custom redirects
   const customRedirect = getRedirectPath(request.uri, routesManifest);

--- a/packages/libs/lambda-at-edge/tests/api-handler/api-basepath-routes-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/api-handler/api-basepath-routes-manifest.json
@@ -1,1 +1,16 @@
-{"version":1,"pages404":true,"basePath":"/basepath","redirects":[],"rewrites":[],"headers":[],"dynamicRoutes":[]}
+{
+  "version": 1,
+  "pages404": true,
+  "basePath": "/basepath",
+  "redirects": [
+    {
+      "source": "/basepath/api/deprecated/getCustomers",
+      "destination": "/basepath/api/getCustomers",
+      "statusCode": 308,
+      "regex": "^/basepath/api/deprecated/getCustomers$"
+    }
+  ],
+  "rewrites": [],
+  "headers": [],
+  "dynamicRoutes": []
+}

--- a/packages/libs/lambda-at-edge/tests/api-handler/api-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/api-handler/api-handler-with-basepath.test.ts
@@ -1,6 +1,7 @@
 import { createCloudFrontEvent } from "../test-utils";
 import { handler } from "../../src/api-handler";
 import { CloudFrontResponseResult } from "next-aws-cloudfront/node_modules/@types/aws-lambda";
+import { runRedirectTestWithHandler } from "../utils/runRedirectTest";
 
 jest.mock(
   "../../src/manifest.json",
@@ -66,5 +67,36 @@ describe("API lambda handler with basePath configured", () => {
     const response = (await handler(event)) as CloudFrontResponseResult;
 
     expect(response.status).toEqual("404");
+  });
+
+  describe("Custom Redirects", () => {
+    let runRedirectTest = async (
+      path: string,
+      expectedRedirect: string,
+      statusCode: number,
+      querystring?: string
+    ): Promise<void> => {
+      await runRedirectTestWithHandler(
+        handler,
+        path,
+        expectedRedirect,
+        statusCode,
+        querystring
+      );
+    };
+
+    it.each`
+      path                                       | expectedRedirect                | expectedRedirectStatusCode
+      ${"/basepath/api/deprecated/getCustomers"} | ${"/basepath/api/getCustomers"} | ${308}
+    `(
+      "redirects path $path to $expectedRedirect, expectedRedirectStatusCode: $expectedRedirectStatusCode",
+      async ({ path, expectedRedirect, expectedRedirectStatusCode }) => {
+        await runRedirectTest(
+          path,
+          expectedRedirect,
+          expectedRedirectStatusCode
+        );
+      }
+    );
   });
 });

--- a/packages/libs/lambda-at-edge/tests/api-handler/api-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/api-handler/api-handler.test.ts
@@ -1,6 +1,7 @@
 import { createCloudFrontEvent } from "../test-utils";
 import { handler } from "../../src/api-handler";
 import { CloudFrontResponseResult } from "next-aws-cloudfront/node_modules/@types/aws-lambda";
+import { runRedirectTestWithHandler } from "../utils/runRedirectTest";
 
 jest.mock(
   "../../src/manifest.json",
@@ -66,5 +67,36 @@ describe("API lambda handler", () => {
     const response = (await handler(event)) as CloudFrontResponseResult;
 
     expect(response.status).toEqual("404");
+  });
+
+  describe("Custom Redirects", () => {
+    let runRedirectTest = async (
+      path: string,
+      expectedRedirect: string,
+      statusCode: number,
+      querystring?: string
+    ): Promise<void> => {
+      await runRedirectTestWithHandler(
+        handler,
+        path,
+        expectedRedirect,
+        statusCode,
+        querystring
+      );
+    };
+
+    it.each`
+      path                              | expectedRedirect       | expectedRedirectStatusCode
+      ${"/api/deprecated/getCustomers"} | ${"/api/getCustomers"} | ${308}
+    `(
+      "redirects path $path to $expectedRedirect, expectedRedirectStatusCode: $expectedRedirectStatusCode",
+      async ({ path, expectedRedirect, expectedRedirectStatusCode }) => {
+        await runRedirectTest(
+          path,
+          expectedRedirect,
+          expectedRedirectStatusCode
+        );
+      }
+    );
   });
 });

--- a/packages/libs/lambda-at-edge/tests/api-handler/api-routes-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/api-handler/api-routes-manifest.json
@@ -1,1 +1,16 @@
-{"version":1,"pages404":true,"basePath":"","redirects":[],"rewrites":[],"headers":[],"dynamicRoutes":[]}
+{
+  "version": 1,
+  "pages404": true,
+  "basePath": "",
+  "redirects": [
+    {
+      "source": "/api/deprecated/getCustomers",
+      "destination": "/api/getCustomers",
+      "statusCode": 308,
+      "regex": "^/api/deprecated/getCustomers$"
+    }
+  ],
+  "rewrites": [],
+  "headers": [],
+  "dynamicRoutes": []
+}

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
@@ -4,7 +4,7 @@ import {
   CloudFrontResultResponse,
   CloudFrontOrigin
 } from "aws-lambda";
-import { runRedirectTestWithHandler } from "./utils/runRedirectTest";
+import { runRedirectTestWithHandler } from "../utils/runRedirectTest";
 
 jest.mock(
   "../../src/prerender-manifest.json",

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -4,7 +4,7 @@ import {
   CloudFrontResultResponse,
   CloudFrontOrigin
 } from "aws-lambda";
-import { runRedirectTestWithHandler } from "./utils/runRedirectTest";
+import { runRedirectTestWithHandler } from "../utils/runRedirectTest";
 
 jest.mock("jsonwebtoken", () => ({
   verify: jest.fn()

--- a/packages/libs/lambda-at-edge/tests/utils/runRedirectTest.ts
+++ b/packages/libs/lambda-at-edge/tests/utils/runRedirectTest.ts
@@ -1,4 +1,4 @@
-import { createCloudFrontEvent } from "../../test-utils";
+import { createCloudFrontEvent } from "../test-utils";
 import { CloudFrontResultResponse } from "aws-lambda";
 
 export async function runRedirectTestWithHandler(


### PR DESCRIPTION
Continues redirects support from API routes (i.e API route is a source). RFC: https://github.com/serverless-nextjs/serverless-next.js/issues/587

## Testing

Updated handler unit tests, e2e tests.