### PR TITLE
fix(serverless-component): when adding primary domain name to CloudFront distribution aliases, don't replace other aliases

### DIFF
--- a/packages/serverless-components/domain/utils.js
+++ b/packages/serverless-components/domain/utils.js
@@ -393,21 +393,19 @@ const addDomainToCloudfrontDistribution = async (
   params.Id = subdomain.distributionId;
 
   // 5. then make our changes
-  params.DistributionConfig.Aliases = {
-    Quantity: 1,
-    Items: [subdomain.domain]
-  };
-
+  params.DistributionConfig.Aliases.Items.push(subdomain.domain);
+  params.DistributionConfig.Aliases.Quantity += 1;
   if (subdomain.domain.startsWith("www.")) {
     if (domainType === "apex") {
-      params.DistributionConfig.Aliases.Items = [
-        `${subdomain.domain.replace("www.", "")}`
-      ];
+      params.DistributionConfig.Aliases.Items[-1] = `${subdomain.domain.replace(
+        "www.",
+        ""
+      )}`;
     } else if (domainType !== "www") {
-      params.DistributionConfig.Aliases.Quantity = 2;
       params.DistributionConfig.Aliases.Items.push(
         `${subdomain.domain.replace("www.", "")}`
       );
+      params.DistributionConfig.Aliases.Quantity += 1;
     }
   }
 


### PR DESCRIPTION
I missed this in ea180e67515ee5dceed1c3e19731291615a7cbbb, where the domain alias being added to the distribution would overwrite aliases that were added when we create the distribution. Append the domain alias(es) to the list instead of creating a new Aliases.Items to preserve those.

There don't seem to be any tests for this component, so I manually verified running the built component locally. If I overlooked a test suite that should be updated, let me know.