### PR TITLE
fix(lambda-at-edge): fix possible redirect loop in API handler

### DIFF
--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -338,7 +338,7 @@ class Builder {
         join(this.outputDir, API_LAMBDA_CODE_DIR, "manifest.json"),
         apiBuildManifest
       ),
-      fse.copy(
+      this.processAndCopyRoutesManifest(
         join(this.dotNextDir, "routes-manifest.json"),
         join(this.outputDir, API_LAMBDA_CODE_DIR, "routes-manifest.json")
       )


### PR DESCRIPTION
Due to trailing slash redirects not removed from routesManifest, when trailingSlash: true is enabled, the API could get stuck in a redirect loop. We will manually implement trailing slash redirects for API routes.