### PR TITLE
fix(lambda-at-edge): fix dynamic routes with getStaticPaths interfering with public files

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -323,20 +323,16 @@ const handleOriginRequest = async ({
     (hasFallback && !isPreviewRequest) ||
     (isDataReq && !isPreviewRequest)
   ) {
-    if (isHTMLPage || hasFallback) {
-      s3Origin.path = `${basePath}/static-pages`;
-      const pageName = uri === "/" ? "/index" : uri;
-      request.uri = `${pageName}.html`;
-    }
-
     if (isPublicFile) {
       s3Origin.path = `${basePath}/public`;
       if (basePath) {
         request.uri = request.uri.replace(basePath, "");
       }
-    }
-
-    if (isDataReq) {
+    } else if (isHTMLPage || hasFallback) {
+      s3Origin.path = `${basePath}/static-pages`;
+      const pageName = uri === "/" ? "/index" : uri;
+      request.uri = `${pageName}.html`;
+    } else if (isDataReq) {
       // We need to check whether data request is unmatched i.e routed to 404.html or _error.js
       const normalisedDataRequestUri = normaliseDataRequestUri(uri, manifest);
       const pagePath = router(manifest)(normalisedDataRequestUri);


### PR DESCRIPTION
This fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/673 and https://github.com/serverless-nextjs/serverless-next.js/issues/646

* During `S3Check` block, when there's a dynamic route at root page level that uses  fallback via `getStaticPaths`, during S3 file serving, it was interfering with public files by overriding the `request.uri` with `.html` first, then in the branch for public files, it tries to serve an incorrect file. For example, `example.png` would be served with URI such as `example.png.html` due to this.
* The fix is to use make these branches exclusive and put public files branch at the top, so they will always get served correctly.

## Tests

Existing tests pass. Tested with local serverless deployment. Will run e2e tests in CI and add new ones in another PR.