### PR TITLE
feat(lambda-at-edge): support fallback: false for getStaticPaths and fix cache-control header

### DIFF
--- a/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
@@ -3,8 +3,43 @@ describe("Pages Tests", () => {
     cy.ensureAllRoutesNotErrored();
   });
 
-  describe("Dynamic Pages with getStaticPaths()", () => {
-    [{ path: "/a" }, { path: "/b" }].forEach(({ path }) => {
+  describe("Dynamic Pages with getStaticPaths() fallback: true", () => {
+    [{ path: "/a" }, { path: "/b" }, { path: "/not-prerendered" }].forEach(
+      ({ path }) => {
+        it(`serves and caches page ${path}`, () => {
+          cy.visit(path);
+          cy.location("pathname").should("eq", path);
+
+          cy.ensureRouteCached(path);
+          cy.visit(path);
+        });
+
+        ["HEAD", "GET"].forEach((method) => {
+          it(`allows HTTP method for path ${path}: ${method}`, () => {
+            cy.request({ url: path, method: method }).then((response) => {
+              expect(response.status).to.equal(200);
+            });
+          });
+        });
+
+        ["DELETE", "POST", "OPTIONS", "PUT", "PATCH"].forEach((method) => {
+          it(`disallows HTTP method for path ${path} with 4xx error: ${method}`, () => {
+            cy.request({
+              url: path,
+              method: method,
+              failOnStatusCode: false
+            }).then((response) => {
+              expect(response.status).to.be.at.least(400);
+              expect(response.status).to.be.lessThan(500);
+            });
+          });
+        });
+      }
+    );
+  });
+
+  describe("Nested Dynamic Pages with getStaticPaths() fallback: false", () => {
+    [{ path: "/nested/a" }, { path: "/nested/b" }].forEach(({ path }) => {
       it(`serves and caches page ${path}`, () => {
         cy.visit(path);
         cy.location("pathname").should("eq", path);
@@ -28,6 +63,44 @@ describe("Pages Tests", () => {
             method: method,
             failOnStatusCode: false
           }).then((response) => {
+            expect(response.status).to.be.at.least(400);
+            expect(response.status).to.be.lessThan(500);
+          });
+        });
+      });
+    });
+
+    [{ path: "/nested/not-prerendered" }].forEach(({ path }) => {
+      it(`serves page ${path}`, () => {
+        cy.visit(path, { failOnStatusCode: false });
+        cy.location("pathname").should("eq", path);
+
+        cy.visit(path, { failOnStatusCode: false });
+      });
+
+      ["HEAD", "GET"].forEach((method) => {
+        it(`allows HTTP method for path ${path} and serves 404: ${method}`, () => {
+          cy.request({
+            url: path,
+            method: method,
+            failOnStatusCode: false
+          }).then((response) => {
+            expect(response.status).to.equal(404);
+            expect(response.headers["x-cache"]).to.equal(
+              "Error from cloudfront"
+            );
+          });
+        });
+      });
+
+      ["DELETE", "POST", "OPTIONS", "PUT", "PATCH"].forEach((method) => {
+        it(`disallows HTTP method for path ${path} with 4xx error: ${method}`, () => {
+          cy.request({
+            url: path,
+            method: method,
+            failOnStatusCode: false
+          }).then((response) => {
+            expect(response.status).to.not.equal(404);
             expect(response.status).to.be.at.least(400);
             expect(response.status).to.be.lessThan(500);
           });

--- a/packages/e2e-tests/next-app-dynamic-routes/pages/nested/[dynamic].tsx
+++ b/packages/e2e-tests/next-app-dynamic-routes/pages/nested/[dynamic].tsx
@@ -1,17 +1,17 @@
 import React from "react";
 import { NextPageContext } from "next";
 
-type DynamicIndexPageProps = {
+type DynamicNestedPageProps = {
   name: string;
 };
 
-export default function DynamicIndexPage(
-  props: DynamicIndexPageProps
+export default function DynamicNestedPage(
+  props: DynamicNestedPageProps
 ): JSX.Element {
   return (
     <React.Fragment>
       <div>
-        {`Hello ${props.name}. This is a dynamic SSG page using getStaticProps() with fallback true. It also has an image.`}
+        {`Hello ${props.name}. This is a dynamic SSG page using getStaticProps() with fallback false. It also has an image.`}
       </div>
       <img src={"/app-store-badge.png"} alt={"An image"} />
     </React.Fragment>
@@ -20,7 +20,7 @@ export default function DynamicIndexPage(
 
 export async function getStaticProps(
   ctx: NextPageContext
-): Promise<{ props: DynamicIndexPageProps }> {
+): Promise<{ props: DynamicNestedPageProps }> {
   return {
     props: { name: "serverless-next.js" }
   };
@@ -29,6 +29,6 @@ export async function getStaticProps(
 export async function getStaticPaths() {
   return {
     paths: [{ params: { dynamic: "a" } }, { params: { dynamic: "b" } }],
-    fallback: true
+    fallback: false
   };
 }

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
@@ -98,6 +98,47 @@ describe("Lambda@Edge origin response", () => {
         body: "S3Body"
       });
     });
+
+    it("serves 404 page from S3 for fallback: false", async () => {
+      const event = createCloudFrontEvent({
+        uri: "/tests/prerender-manifest/[staticPageName]",
+        host: "mydistribution.cloudfront.net",
+        config: { eventType: "origin-response" } as any,
+        response: {
+          status: "403"
+        } as any
+      });
+
+      const result = await handler(event);
+      const response = result as CloudFrontResponse;
+
+      expect(s3Client.send).toHaveBeenCalledWith({
+        Command: "GetObjectCommand",
+        Bucket: "my-bucket.s3.amazonaws.com",
+        Key: "static-pages/404.html"
+      });
+
+      expect(response).toEqual({
+        status: "404",
+        statusDescription: "Not Found",
+        headers: {
+          "cache-control": [
+            {
+              key: "Cache-Control",
+              value: "public, max-age=0, s-maxage=2678400, must-revalidate"
+            }
+          ],
+          "content-type": [
+            {
+              key: "Content-Type",
+              value: "text/html"
+            }
+          ]
+        },
+        body: "S3Body"
+      });
+    });
+
     it("renders and uploads HTML and JSON for fallback SSG data requests", async () => {
       const event = createCloudFrontEvent({
         uri: "/_next/data/build-id/fallback/not-yet-built.json",

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
@@ -82,6 +82,12 @@ describe("Lambda@Edge origin response", () => {
         status: "200",
         statusDescription: "OK",
         headers: {
+          "cache-control": [
+            {
+              key: "Cache-Control",
+              value: "public, max-age=0, s-maxage=2678400, must-revalidate"
+            }
+          ],
           "content-type": [
             {
               key: "Content-Type",


### PR DESCRIPTION
Fixes/closes: https://github.com/serverless-nextjs/serverless-next.js/issues/673

Also adds proper `cache-control` header so that CloudFront can cache the responses including the 404 page.