### PR TITLE
fix(lambda-at-edge): non-dynamic pages (SSG, SSR) should be prioritized over dynamic fallback pages

### DIFF
--- a/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
@@ -3,7 +3,7 @@ describe("Pages Tests", () => {
     cy.ensureAllRoutesNotErrored();
   });
 
-  describe("Dynamic Pages with getStaticPaths() fallback: true", () => {
+  describe("Dynamic Page at root level with getStaticPaths() fallback: true", () => {
     [{ path: "/a" }, { path: "/b" }, { path: "/not-prerendered" }].forEach(
       ({ path }) => {
         it(`serves and caches page ${path}`, () => {
@@ -36,9 +36,29 @@ describe("Pages Tests", () => {
         });
       }
     );
+
+    it("serves non-dynamic SSG page at same level", () => {
+      const path = "/ssg-page";
+
+      cy.request({
+        url: path
+      }).then((response) => {
+        expect(response.body).to.contain("SSG Page");
+      });
+    });
+
+    it("serves non-dynamic SSR page at same level", () => {
+      const path = "/ssr-page";
+
+      cy.request({
+        url: path
+      }).then((response) => {
+        expect(response.body).to.contain("SSR Page");
+      });
+    });
   });
 
-  describe("Nested Dynamic Pages with getStaticPaths() fallback: false", () => {
+  describe("Nested Dynamic Page with getStaticPaths() fallback: false", () => {
     [{ path: "/nested/a" }, { path: "/nested/b" }].forEach(({ path }) => {
       it(`serves and caches page ${path}`, () => {
         cy.visit(path);
@@ -86,9 +106,6 @@ describe("Pages Tests", () => {
             failOnStatusCode: false
           }).then((response) => {
             expect(response.status).to.equal(404);
-            expect(response.headers["x-cache"]).to.equal(
-              "Error from cloudfront"
-            );
           });
         });
       });

--- a/packages/e2e-tests/next-app-dynamic-routes/pages/index.tsx
+++ b/packages/e2e-tests/next-app-dynamic-routes/pages/index.tsx
@@ -11,7 +11,7 @@ export default function IndexPage(props: IndexPageProps): JSX.Element {
       <div>
         {`Hello ${props.name}. This is an SSR page using getServerSideProps(). It also has an image.`}
       </div>
-      <img src={"/basepath/app-store-badge.png"} alt={"An image"} />
+      <img src={"/app-store-badge.png"} alt={"An image"} />
     </React.Fragment>
   );
 }


### PR DESCRIPTION
* When fallback pages for dynamic routes are used, it shouldn't interfere with SSG and SSR pages - those should take precedence as defined here: https://nextjs.org/docs/routing/dynamic-routes#caveats

## Tests

Added e2e tests to ensure this doesn't break.