### PR TITLE
feat(nextjs-component): add deploy input which can be set to false to skip deployment

### DIFF
--- a/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
@@ -982,4 +982,33 @@ describe("Custom inputs", () => {
       });
     });
   });
+
+  describe("Skip deployment after build", () => {
+    const fixturePath = path.join(__dirname, "./fixtures/simple-app");
+    let tmpCwd: string;
+
+    beforeEach(async () => {
+      tmpCwd = process.cwd();
+      process.chdir(fixturePath);
+
+      mockServerlessComponentDependencies({ expectedDomain: undefined });
+    });
+
+    afterEach(() => {
+      process.chdir(tmpCwd);
+      return cleanupFixtureDirectory(fixturePath);
+    });
+
+    it("builds but skips deployment", async () => {
+      const result = await createNextComponent().default({
+        deploy: false
+      });
+
+      expect(result).toEqual({
+        appUrl: "SKIPPED_DEPLOY",
+        bucketName: "SKIPPED_DEPLOY",
+        distributionId: "SKIPPED_DEPLOY"
+      });
+    });
+  });
 });

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -22,6 +22,9 @@ import type {
   LambdaInput
 } from "../types";
 
+// Message when deployment is explicitly skipped
+const SKIPPED_DEPLOY = "SKIPPED_DEPLOY";
+
 export type DeploymentResult = {
   appUrl: string;
   bucketName: string;
@@ -206,6 +209,16 @@ class NextjsComponent extends Component {
   async deploy(
     inputs: ServerlessComponentInputs = {}
   ): Promise<DeploymentResult> {
+    // Skip deployment if user explicitly set deploy input to false.
+    // Useful when they just want the build outputs to deploy themselves.
+    if (inputs.deploy === false) {
+      return {
+        appUrl: SKIPPED_DEPLOY,
+        bucketName: SKIPPED_DEPLOY,
+        distributionId: SKIPPED_DEPLOY
+      };
+    }
+
     const nextConfigPath = inputs.nextConfigDir
       ? resolve(inputs.nextConfigDir)
       : process.cwd();

--- a/packages/serverless-components/nextjs-component/types.d.ts
+++ b/packages/serverless-components/nextjs-component/types.d.ts
@@ -21,6 +21,7 @@ export type ServerlessComponentInputs = {
   cloudfront?: CloudfrontOptions;
   minifyHandlers?: boolean;
   uploadStaticAssetsFromBuild?: boolean;
+  deploy?: boolean;
 };
 
 type CloudfrontOptions = Record<string, any>;


### PR DESCRIPTION
## Motivation

This adds support for a new input, `deploy` that allows users to skip the deployment step (creating AWS resources). All build outputs will be stored in `.serverless_nextjs` folder - `default-lambda`, `api-lambda`, and `assets` (in same structure as accessed by the handler in s3).

This will give more flexibility to users who may wish to deploy using their own scripts, other IaC (e.g Terraform), etc. User is responsible for uploading all files to S3 themselves (with correct headers) and Lambdas.

This will close: https://github.com/serverless-nextjs/serverless-next.js/issues/642 and https://github.com/serverless-nextjs/serverless-next.js/issues/419

## Tests

Added a unit test.