### PR TITLE
Feature flag lambda at edge compression

### DIFF
--- a/packages/compat-layers/lambda-at-edge-compat/next-aws-cloudfront.d.ts
+++ b/packages/compat-layers/lambda-at-edge-compat/next-aws-cloudfront.d.ts
@@ -1,9 +1,16 @@
 import { CloudFrontResultResponse, CloudFrontRequest } from "aws-lambda";
 import { IncomingMessage, ServerResponse } from "http";
 
-declare function lambdaAtEdgeCompat(event: {
-  request: CloudFrontRequest;
-}): {
+type CompatOptions = {
+  enableHTTPCompression: boolean;
+};
+
+declare function lambdaAtEdgeCompat(
+  event: {
+    request: CloudFrontRequest;
+  },
+  options: CompatOptions
+): {
   responsePromise: Promise<CloudFrontResultResponse>;
   req: IncomingMessage;
   res: ServerResponse;

--- a/packages/libs/lambda-at-edge/src/api-handler.ts
+++ b/packages/libs/lambda-at-edge/src/api-handler.ts
@@ -8,7 +8,7 @@ import {
   OriginRequestEvent,
   RoutesManifest
 } from "../types";
-import { CloudFrontResultResponse, CloudFrontRequest } from "aws-lambda";
+import { CloudFrontResultResponse } from "aws-lambda";
 import {
   createRedirectResponse,
   getDomainRedirectPath,
@@ -92,7 +92,9 @@ export const handler = async (
 
   // eslint-disable-next-line
   const page = require(`./${pagePath}`);
-  const { req, res, responsePromise } = cloudFrontCompat(event.Records[0].cf);
+  const { req, res, responsePromise } = cloudFrontCompat(event.Records[0].cf, {
+    enableHTTPCompression: buildManifest.enableHTTPCompression
+  });
 
   page.default(req, res);
 

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -30,6 +30,7 @@ type BuildOptions = {
   logLambdaExecutionTimes?: boolean;
   domainRedirects?: { [key: string]: string };
   minifyHandlers?: boolean;
+  enableHTTPCompression?: boolean;
 };
 
 const defaultBuildOptions = {
@@ -40,7 +41,8 @@ const defaultBuildOptions = {
   useServerlessTraceTarget: false,
   logLambdaExecutionTimes: false,
   domainRedirects: {},
-  minifyHandlers: false
+  minifyHandlers: false,
+  enableHTTPCompression: true
 };
 
 class Builder {
@@ -357,7 +359,8 @@ class Builder {
     );
     const {
       logLambdaExecutionTimes = false,
-      domainRedirects = {}
+      domainRedirects = {},
+      enableHTTPCompression = false
     } = this.buildOptions;
 
     this.normalizeDomainRedirects(domainRedirects);
@@ -377,7 +380,8 @@ class Builder {
       },
       publicFiles: {},
       trailingSlash: false,
-      domainRedirects: domainRedirects
+      domainRedirects: domainRedirects,
+      enableHTTPCompression
     };
 
     const apiBuildManifest: OriginRequestApiHandlerManifest = {
@@ -385,7 +389,8 @@ class Builder {
         dynamic: {},
         nonDynamic: {}
       },
-      domainRedirects: domainRedirects
+      domainRedirects: domainRedirects,
+      enableHTTPCompression
     };
 
     const ssrPages = defaultBuildManifest.pages.ssr;

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -375,7 +375,12 @@ const handleOriginRequest = async ({
   log("require JS execution time", tBeforePageRequire, tAfterPageRequire);
 
   const tBeforeSSR = now();
-  const { req, res, responsePromise } = lambdaAtEdgeCompat(event.Records[0].cf);
+  const { req, res, responsePromise } = lambdaAtEdgeCompat(
+    event.Records[0].cf,
+    {
+      enableHTTPCompression: manifest.enableHTTPCompression
+    }
+  );
   try {
     // If page is _error.js, set status to 404 so _error.js will render a 404 page
     if (pagePath === "pages/_error.js") {
@@ -454,7 +459,10 @@ const handleOriginResponse = async ({
     // eslint-disable-next-line
     const page = require(`./${pagePath}`);
     const { req, res, responsePromise } = lambdaAtEdgeCompat(
-      event.Records[0].cf
+      event.Records[0].cf,
+      {
+        enableHTTPCompression: manifest.enableHTTPCompression
+      }
     );
     const isSSG = !!page.getStaticProps;
     const { renderOpts, html } = await page.renderReqToHTML(

--- a/packages/libs/lambda-at-edge/types.d.ts
+++ b/packages/libs/lambda-at-edge/types.d.ts
@@ -21,6 +21,7 @@ export type OriginRequestApiHandlerManifest = {
   domainRedirects: {
     [key: string]: string;
   };
+  enableHTTPCompression: boolean;
 };
 
 export type OriginRequestDefaultHandlerManifest = {
@@ -44,6 +45,7 @@ export type OriginRequestDefaultHandlerManifest = {
     [key: string]: string;
   };
   trailingSlash: boolean;
+  enableHTTPCompression: boolean;
   domainRedirects: {
     [key: string]: string;
   };

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -187,7 +187,8 @@ class NextjsComponent extends Component {
           useServerlessTraceTarget: inputs.useServerlessTraceTarget || false,
           logLambdaExecutionTimes: inputs.logLambdaExecutionTimes || false,
           domainRedirects: inputs.domainRedirects || {},
-          minifyHandlers: inputs.minifyHandlers || false
+          minifyHandlers: inputs.minifyHandlers || false,
+          enableHTTPCompression: false
         }
       );
 


### PR DESCRIPTION
**Motivation**

We've been manually doing Gzip compression in lambda@edge so far due to CloudFront not compressing lambda@edge responses. However, seems like that [has been fixed](https://twitter.com/cristiangraz/status/1306277707353853952?s=20) after discussing with Cristian from the CloudFront team and doing some testing of my own. 

This should allow us to use Gzip and Brotli compression without extra code in the Lambda@Edge handler. Furthermore the CloudFront distributions created by serverless-next.js already [enable compression](https://github.com/serverless-nextjs/serverless-next.js/blob/fb8e61dc50b11c0e5966548a8c84b58e495ea748/packages/serverless-components/aws-cloudfront/lib/getCacheBehavior.js#L9) by default. 

From my initial findings Gzip works fine, but Brotli isn't despite [being officially supported now](https://aws.amazon.com/about-aws/whats-new/2020/09/cloudfront-brotli-compression/#:~:text=You%20can%20now%20use%20Amazon,better%20compression%20ratio%20than%20Gzip.)

Seems distributions will need to set `EnableAcceptEncodingBrotli`. 

Ref docs: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html



