### PR TITLE
fix(lambda-at-edge): non-dynamic routes for rewrite should not includ…

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -282,10 +282,7 @@ const handleOriginRequest = async ({
 
   // Check for non-dynamic pages before rewriting
   let isNonDynamicRoute =
-    pages.html.nonDynamic[uri] ||
-    pages.ssr.nonDynamic[uri] ||
-    prerenderManifest.routes[uri] ||
-    isPublicFile;
+    pages.html.nonDynamic[uri] || pages.ssr.nonDynamic[uri] || isPublicFile;
 
   // Handle custom rewrites, but don't rewrite non-dynamic pages or public files per Next.js docs: https://nextjs.org/docs/api-reference/next.config.js/rewrites
   if (!isNonDynamicRoute) {


### PR DESCRIPTION
…e routes in prerender manifest

* Prerender manifest routes just mean they are rendered at build time, not that they are non-dynamic. Tests on local Next.js dev server confirm they can be rewritten too.