### PR TITLE
fix(lambda-at-edge): serve HTML pages with no props (i.e static pages) properly on preview mode enabled

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -300,7 +300,7 @@ const handleOriginRequest = async ({
     }
   }
 
-  const isStaticPage = pages.html.nonDynamic[uri];
+  const isStaticPage = pages.html.nonDynamic[uri]; // plain page without any props
   const isPrerenderedPage = prerenderManifest.routes[uri]; // prerendered pages are also static pages like "pages.html" above, but are defined in the prerender-manifest
   const origin = request.origin as CloudFrontOrigin;
   const s3Origin = origin.s3 as CloudFrontS3Origin;
@@ -331,7 +331,9 @@ const handleOriginRequest = async ({
   s3Origin.domainName = normalisedS3DomainName;
 
   S3Check: if (
+    // Note: public files and static pages (HTML pages with no props) don't have JS files needed for preview mode, always serve from S3.
     isPublicFile ||
+    isStaticPage ||
     (isHTMLPage && !isPreviewRequest) ||
     (hasFallback && !isPreviewRequest) ||
     (isDataReq && !isPreviewRequest)


### PR DESCRIPTION
* When preview mode was enabled these HTML pages with no props were trying to be rendered via SSR but they don't exist in `ssr.nonDynamic` object in the build manifest. Hence the router was returning `pages/404.html` and then the handler was trying to require this, leading to a 503.

I don't have e2e tests for preview mode but we can add it in the near future.