### PR TITLE
feat(aws-cloudfront, nextjs-component): support setting certificate input in cloudfront

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ myNextApplication:
         geoRestriction:
           restrictionType: "blacklist" # valid values are whitelist/blacklist/none. Set to "none" and omit items to disable restrictions
           items: ["AA"] # ISO 3166 alpha-2 country codes
+      certificate:
+        acmCertificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+        iamCertificateId: "iam-certificate-id" # specify either ACM or IAM certificate, not both
+        sslSupportMethod: "sni-only" # can be omitted, defaults to "sni-only"
+        minimumProtocolVersion: "TLSv1.2_2018" # can be omitted, defaults to "TLSv1.2_2018"
 ```
 
 This is particularly useful for caching any of your Next.js pages at CloudFront's edge locations. See [this](https://github.com/serverless-nextjs/serverless-next.js/tree/master/packages/serverless-components/nextjs-component/examples/app-with-custom-caching-config) for an example application with custom cache configuration.

--- a/README.md
+++ b/README.md
@@ -218,10 +218,11 @@ myNextApplication:
           restrictionType: "blacklist" # valid values are whitelist/blacklist/none. Set to "none" and omit items to disable restrictions
           items: ["AA"] # ISO 3166 alpha-2 country codes
       certificate:
+        cloudFrontDefaultCertificate: false # specify false and one of IAM/ACM certificates, or specify true and omit IAM/ACM inputs for default certificate
         acmCertificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
         iamCertificateId: "iam-certificate-id" # specify either ACM or IAM certificate, not both
         sslSupportMethod: "sni-only" # can be omitted, defaults to "sni-only"
-        minimumProtocolVersion: "TLSv1.2_2018" # can be omitted, defaults to "TLSv1.2_2018"
+        minimumProtocolVersion: "TLSv1.2_2019" # can be omitted, defaults to "TLSv1.2_2019"
 ```
 
 This is particularly useful for caching any of your Next.js pages at CloudFront's edge locations. See [this](https://github.com/serverless-nextjs/serverless-next.js/tree/master/packages/serverless-components/nextjs-component/examples/app-with-custom-caching-config) for an example application with custom cache configuration.

--- a/packages/serverless-components/aws-cloudfront/__tests__/general-options.test.js
+++ b/packages/serverless-components/aws-cloudfront/__tests__/general-options.test.js
@@ -356,4 +356,90 @@ describe("General options propagation", () => {
       })
     });
   });
+
+  it("create distribution with certificate arn and updates it", async () => {
+    // Create
+    await component.default({
+      certificate: {
+        acmCertificateArn:
+          "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+      },
+      origins
+    });
+
+    expect(mockCreateDistribution).toBeCalledWith(
+      expect.objectContaining({
+        DistributionConfig: expect.objectContaining({
+          ViewerCertificate: {
+            ACMCertificateArn:
+              "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012",
+            SSLSupportMethod: "sni-only",
+            MinimumProtocolVersion: "TLSv1.2_2018"
+          }
+        })
+      })
+    );
+
+    // Update
+    await component.default({
+      certificate: {
+        acmCertificateArn:
+          "arn:aws:acm:us-east-1:123456789012:certificate/updated"
+      },
+      origins
+    });
+
+    expect(mockUpdateDistribution).toBeCalledWith(
+      expect.objectContaining({
+        DistributionConfig: expect.objectContaining({
+          ViewerCertificate: {
+            ACMCertificateArn:
+              "arn:aws:acm:us-east-1:123456789012:certificate/updated",
+            SSLSupportMethod: "sni-only",
+            MinimumProtocolVersion: "TLSv1.2_2018"
+          }
+        })
+      })
+    );
+  });
+
+  it("create distribution with default certificate", async () => {
+    // Create
+    await component.default({
+      certificate: "default",
+      origins
+    });
+
+    expect(mockCreateDistribution).toBeCalledWith(
+      expect.objectContaining({
+        DistributionConfig: expect.objectContaining({
+          ViewerCertificate: {
+            CloudFrontDefaultCertificate: true
+          }
+        })
+      })
+    );
+  });
+
+  it("create distribution with IAM certificate", async () => {
+    // Create
+    await component.default({
+      certificate: {
+        iamCertificateId: "12345"
+      },
+      origins
+    });
+
+    expect(mockCreateDistribution).toBeCalledWith(
+      expect.objectContaining({
+        DistributionConfig: expect.objectContaining({
+          ViewerCertificate: {
+            IAMCertificateId: "12345",
+            SSLSupportMethod: "sni-only",
+            MinimumProtocolVersion: "TLSv1.2_2018"
+          }
+        })
+      })
+    );
+  });
 });

--- a/packages/serverless-components/aws-cloudfront/__tests__/general-options.test.js
+++ b/packages/serverless-components/aws-cloudfront/__tests__/general-options.test.js
@@ -361,6 +361,7 @@ describe("General options propagation", () => {
     // Create
     await component.default({
       certificate: {
+        cloudFrontDefaultCertificate: false,
         acmCertificateArn:
           "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
       },
@@ -371,10 +372,11 @@ describe("General options propagation", () => {
       expect.objectContaining({
         DistributionConfig: expect.objectContaining({
           ViewerCertificate: {
+            CloudFrontDefaultCertificate: false,
             ACMCertificateArn:
               "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012",
             SSLSupportMethod: "sni-only",
-            MinimumProtocolVersion: "TLSv1.2_2018"
+            MinimumProtocolVersion: "TLSv1.2_2019"
           }
         })
       })
@@ -383,6 +385,7 @@ describe("General options propagation", () => {
     // Update
     await component.default({
       certificate: {
+        cloudFrontDefaultCertificate: false,
         acmCertificateArn:
           "arn:aws:acm:us-east-1:123456789012:certificate/updated"
       },
@@ -393,10 +396,11 @@ describe("General options propagation", () => {
       expect.objectContaining({
         DistributionConfig: expect.objectContaining({
           ViewerCertificate: {
+            CloudFrontDefaultCertificate: false,
             ACMCertificateArn:
               "arn:aws:acm:us-east-1:123456789012:certificate/updated",
             SSLSupportMethod: "sni-only",
-            MinimumProtocolVersion: "TLSv1.2_2018"
+            MinimumProtocolVersion: "TLSv1.2_2019"
           }
         })
       })
@@ -406,7 +410,9 @@ describe("General options propagation", () => {
   it("create distribution with default certificate", async () => {
     // Create
     await component.default({
-      certificate: "default",
+      certificate: {
+        cloudFrontDefaultCertificate: true
+      },
       origins
     });
 
@@ -414,7 +420,9 @@ describe("General options propagation", () => {
       expect.objectContaining({
         DistributionConfig: expect.objectContaining({
           ViewerCertificate: {
-            CloudFrontDefaultCertificate: true
+            CloudFrontDefaultCertificate: true,
+            SSLSupportMethod: "sni-only",
+            MinimumProtocolVersion: "TLSv1.2_2019"
           }
         })
       })
@@ -425,6 +433,7 @@ describe("General options propagation", () => {
     // Create
     await component.default({
       certificate: {
+        cloudFrontDefaultCertificate: false,
         iamCertificateId: "12345"
       },
       origins
@@ -434,9 +443,10 @@ describe("General options propagation", () => {
       expect.objectContaining({
         DistributionConfig: expect.objectContaining({
           ViewerCertificate: {
+            CloudFrontDefaultCertificate: false,
             IAMCertificateId: "12345",
             SSLSupportMethod: "sni-only",
-            MinimumProtocolVersion: "TLSv1.2_2018"
+            MinimumProtocolVersion: "TLSv1.2_2019"
           }
         })
       })

--- a/packages/serverless-components/aws-cloudfront/lib/index.js
+++ b/packages/serverless-components/aws-cloudfront/lib/index.js
@@ -4,7 +4,7 @@ const createOriginAccessIdentity = require("./createOriginAccessIdentity");
 const grantCloudFrontBucketAccess = require("./grantCloudFrontBucketAccess");
 const getCustomErrorResponses = require("./getCustomErrorResponses");
 
-const DEFAULT_MINIMUM_PROTOCOL_VERSION = "TLSv1.2_2018";
+const DEFAULT_MINIMUM_PROTOCOL_VERSION = "TLSv1.2_2019";
 const DEFAULT_SSL_SUPPORT_METHOD = "sni-only";
 
 const servePrivateContentEnabled = (inputs) =>
@@ -118,21 +118,23 @@ const createCloudFrontDistribution = async (cf, s3, inputs) => {
 
   // Note this will override the certificate which is also set by domain input
   if (inputs.certificate !== undefined && inputs.certificate !== null) {
-    if (inputs.certificate === "default") {
-      params.DistributionConfig.ViewerCertificate = {
-        CloudFrontDefaultCertificate: true
-      };
-    } else {
-      params.DistributionConfig.ViewerCertificate = {
-        ACMCertificateArn: inputs.certificate.acmCertificateArn,
-        IAMCertificateId: inputs.certificate.iamCertificateId,
-        SSLSupportMethod:
-          inputs.certificate.sslSupportMethod || DEFAULT_SSL_SUPPORT_METHOD,
-        MinimumProtocolVersion:
-          inputs.certificate.minimumProtocolVersion ||
-          DEFAULT_MINIMUM_PROTOCOL_VERSION
-      };
+    if (typeof inputs.certificate !== "object") {
+      throw new Error(
+        "Certificate input must be an object with cloudFrontDefaultCertificate, acmCertificateArn, iamCertificateId, sslSupportMethod, minimumProtocolVersion."
+      );
     }
+
+    distributionConfig.ViewerCertificate = {
+      CloudFrontDefaultCertificate:
+        inputs.certificate.cloudFrontDefaultCertificate,
+      ACMCertificateArn: inputs.certificate.acmCertificateArn,
+      IAMCertificateId: inputs.certificate.iamCertificateId,
+      SSLSupportMethod:
+        inputs.certificate.sslSupportMethod || DEFAULT_SSL_SUPPORT_METHOD,
+      MinimumProtocolVersion:
+        inputs.certificate.minimumProtocolVersion ||
+        DEFAULT_MINIMUM_PROTOCOL_VERSION
+    };
   }
 
   const res = await cf.createDistribution(params).promise();
@@ -205,21 +207,22 @@ const updateCloudFrontDistribution = async (cf, s3, distributionId, inputs) => {
 
   // Note this will override the certificate which is also set by domain input
   if (inputs.certificate !== undefined && inputs.certificate !== null) {
-    if (inputs.certificate === "default") {
-      params.DistributionConfig.ViewerCertificate = {
-        CloudFrontDefaultCertificate: true
-      };
-    } else {
-      params.DistributionConfig.ViewerCertificate = {
-        ACMCertificateArn: inputs.certificate.acmCertificateArn,
-        IAMCertificateId: inputs.certificate.iamCertificateId,
-        SSLSupportMethod:
-          inputs.certificate.sslSupportMethod || DEFAULT_SSL_SUPPORT_METHOD,
-        MinimumProtocolVersion:
-          inputs.certificate.minimumProtocolVersion ||
-          DEFAULT_MINIMUM_PROTOCOL_VERSION
-      };
+    if (typeof inputs.certificate !== "object") {
+      throw new Error(
+        "Certificate input must be an object with cloudFrontDefaultCertificate, acmCertificateArn, iamCertificateId, sslSupportMethod, minimumProtocolVersion."
+      );
     }
+    params.DistributionConfig.ViewerCertificate = {
+      CloudFrontDefaultCertificate:
+        inputs.certificate.cloudFrontDefaultCertificate,
+      ACMCertificateArn: inputs.certificate.acmCertificateArn,
+      IAMCertificateId: inputs.certificate.iamCertificateId,
+      SSLSupportMethod:
+        inputs.certificate.sslSupportMethod || DEFAULT_SSL_SUPPORT_METHOD,
+      MinimumProtocolVersion:
+        inputs.certificate.minimumProtocolVersion ||
+        DEFAULT_MINIMUM_PROTOCOL_VERSION
+    };
   }
 
   let s3CanonicalUserId;

--- a/packages/serverless-components/aws-cloudfront/serverless.js
+++ b/packages/serverless-components/aws-cloudfront/serverless.js
@@ -61,7 +61,8 @@ class CloudFront extends Component {
         !equals(this.state.priceClass, inputs.priceClass) ||
         !equals(this.state.errorPages, inputs.errorPages) ||
         !equals(this.state.webACLId, inputs.webACLId) ||
-        !equals(this.state.restrictions, inputs.restrictions)
+        !equals(this.state.restrictions, inputs.restrictions) ||
+        !equals(this.state.certificate, inputs.certificate)
       ) {
         this.context.debug(
           `Updating CloudFront distribution of ID ${this.state.id}.`

--- a/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
@@ -1102,8 +1102,20 @@ describe("Custom inputs", () => {
       await createNextComponent().default({
         cloudfront: {
           certificate: {
+            cloudFrontDefaultCertificate: false,
             acmCertificateArn:
               "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+          }
+        }
+      });
+    });
+
+    it("sets certificate with an IAM certificate", async () => {
+      await createNextComponent().default({
+        cloudfront: {
+          certificate: {
+            cloudFrontDefaultCertificate: false,
+            iamCertificateId: "iam-cert-id"
           }
         }
       });
@@ -1112,7 +1124,9 @@ describe("Custom inputs", () => {
     it("sets certificate to default", async () => {
       await createNextComponent().default({
         cloudfront: {
-          certificate: "default"
+          certificate: {
+            cloudFrontDefaultCertificate: true
+          }
         }
       });
     });

--- a/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
@@ -1097,5 +1097,24 @@ describe("Custom inputs", () => {
         }
       });
     });
+
+    it("sets certificate with an ACM ARN", async () => {
+      await createNextComponent().default({
+        cloudfront: {
+          certificate: {
+            acmCertificateArn:
+              "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+          }
+        }
+      });
+    });
+
+    it("sets certificate to default", async () => {
+      await createNextComponent().default({
+        cloudfront: {
+          certificate: "default"
+        }
+      });
+    });
   });
 });

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -241,6 +241,7 @@ class NextjsComponent extends Component {
       comment: cloudFrontComment,
       webACLId: cloudFrontWebACLId,
       restrictions: cloudFrontRestrictions,
+      certificate: cloudFrontCertificate,
       ...cloudFrontOtherInputs
     } = inputs.cloudfront || {};
 
@@ -591,7 +592,8 @@ class NextjsComponent extends Component {
       }),
       comment: cloudFrontComment,
       webACLId: cloudFrontWebACLId,
-      restrictions: cloudFrontRestrictions
+      restrictions: cloudFrontRestrictions,
+      certificate: cloudFrontCertificate
     });
 
     let appUrl = cloudFrontOutputs.url;


### PR DESCRIPTION
## Motivation

There is `certificateArn` input, however it is tied to domain component: https://github.com/serverless-nextjs/serverless-next.js/search?q=certificatearn and also is less configurable.

This creates a more configurable input that's tied to the distribution but without needing to use the `domain` input (e.g if domains and certs are managed outside of this serverless component). It is especially useful in combination with the `aliases` input.

## Tests

Added unit tests, but I will also test on my own app.