### PR TITLE
fix(aws-cloudfront, nextjs-component): fix aliases updating when domain is used

### DIFF
--- a/packages/serverless-components/domain/utils.js
+++ b/packages/serverless-components/domain/utils.js
@@ -409,7 +409,6 @@ const addDomainToCloudfrontDistribution = async (
 
   // 5. then make our changes
   params.DistributionConfig.Aliases = {
-    Quantity: 1,
     Items: [subdomain.domain]
   };
 

--- a/packages/serverless-components/domain/utils.js
+++ b/packages/serverless-components/domain/utils.js
@@ -408,12 +408,16 @@ const addDomainToCloudfrontDistribution = async (
   params.Id = subdomain.distributionId;
 
   // 5. then make our changes
-  params.DistributionConfig.Aliases.Items.push(subdomain.domain);
+  params.DistributionConfig.Aliases = {
+    Quantity: 1,
+    Items: [subdomain.domain]
+  };
+
   if (subdomain.domain.startsWith("www.")) {
     if (domainType === "apex") {
-      params.DistributionConfig.Aliases.Items[
-        params.DistributionConfig.Aliases.Items.length - 1
-      ] = `${subdomain.domain.replace("www.", "")}`;
+      params.DistributionConfig.Aliases.Items = [
+        `${subdomain.domain.replace("www.", "")}`
+      ];
     } else if (domainType !== "www") {
       params.DistributionConfig.Aliases.Items.push(
         `${subdomain.domain.replace("www.", "")}`
@@ -421,6 +425,7 @@ const addDomainToCloudfrontDistribution = async (
     }
   }
 
+  // Update aliases quantity to reflect actual number of items
   params.DistributionConfig.Aliases.Quantity =
     params.DistributionConfig.Aliases.Items.length;
 


### PR DESCRIPTION
* When domain is used, it should completely manage all aliases attached to CloudFront distribution instead of trying to push onto existing aliases set. Otherwise, there could be strange behavior when it's manually updated and/or domains are changed.
* `aliases` input in `cloudfront` can be used if additional aliases apart from domain name are needed (and domain likely should be managed externally instead, as this is a more complex use case).