### PR TITLE
README: clarify how to use `build.env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,29 @@ All of this happens within the Lambda@Edge origin request handlers. Please note 
 Otherwise, you can also use the manual workaround using an S3 bucket outlined [here](https://simonecarletti.com/blog/2016/08/redirect-domain-https-amazon-cloudfront/#configuring-the-amazon-s3-static-site-with-redirect).
 In summary, you will have to create a new S3 bucket and set it up with static website hosting to redirect requests to your supported subdomain type (ex. "www.example.com" or "example.com"). To be able to support HTTPS redirects, you'll need to set up a CloudFront distribution with the S3 redirect bucket as the origin. Finally, you'll need to create an "A" record in Route 53 with your newly created CloudFront distribution as the alias target.
 
+#### My environment variables set in `build.env` don't show up in my app
+
+To allow your app to access the defined environment variables, you need to expose them via the `next.config.js` as outlined [here](https://nextjs.org/docs/api-reference/next.config.js/environment-variables).
+
+Given a `servless.yml` like this
+```yml
+myApp:
+  inputs:
+    build:
+      env:
+        API_HOST: "${env.API_HOST}"
+```
+
+your next.config.js should look like that:
+
+```js
+module.exports = {
+  env: {
+    API_HOST: process.env.API_HOST,
+  },
+}
+```
+
 ## Contributing
 
 Please see the [contributing](./CONTRIBUTING.md) guide.

--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ myApp:
   inputs:
     build:
       env:
-        API_HOST: "${env.API_HOST}"
+        API_HOST: "http://example.com"
 ```
 
 your next.config.js should look like that:

--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ In summary, you will have to create a new S3 bucket and set it up with static we
 
 To allow your app to access the defined environment variables, you need to expose them via the `next.config.js` as outlined [here](https://nextjs.org/docs/api-reference/next.config.js/environment-variables).
 
-Given a `servless.yml` like this
+Given a `serverless.yml` like this
 ```yml
 myApp:
   inputs:


### PR DESCRIPTION
I'm fairly new to next.js and was only aware of this approach of loading environment variables:
https://nextjs.org/docs/basic-features/environment-variables

I could not make it work with this servlerss-next.js as it seems that the only way to forward env vars is via the `next.config.js`. It took me way too long to find out. (Especially as `.env.local`/`.env.production` did work as expected). So I've decided to add this FAQ section.