### PR TITLE
Validate Existance of Cookies for Preview Mode - Default preview mode False

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -347,22 +347,21 @@ const handleOriginRequest = async ({
   const hasFallback = hasFallbackForUri(uri, prerenderManifest, manifest);
   const { now, log } = perfLogger(manifest.logLambdaExecutionTimes);
   const previewCookies = getPreviewCookies(request);
-  const isPreviewRequest =
+  let isPreviewRequest = false;
+  const containsPreviewCookies =
     previewCookies[NEXT_PREVIEW_DATA_COOKIE] &&
     previewCookies[NEXT_PRERENDER_BYPASS_COOKIE];
 
-  if (isPreviewRequest) {
+  if (containsPreviewCookies) {
     try {
       jsonwebtoken.verify(
         previewCookies[NEXT_PREVIEW_DATA_COOKIE],
         prerenderManifest.preview.previewModeSigningKey
       );
+
+      isPreviewRequest = true;
     } catch (e) {
-      console.error("Failed preview mode verification for URI:", request.uri);
-      return {
-        status: "403",
-        statusDescription: "Forbidden"
-      };
+      console.warn("Failed preview mode verification for URI:", request.uri);
     }
   }
 


### PR DESCRIPTION
Related issue: #776 

Examining how NextJS handle this, they return false in a catch after signing failure.

https://github.com/vercel/next.js/blob/a5cb28d907ad34865085d38d008130aaa4667427/packages/next/next-server/server/api-utils.ts#L350-L359

### This Change

Instead of returning 403 for requests which contain both cookies, but which are invalid, a normal response object should be returned.