### PR TITLE
test: add image component page to next-app e2e test

### DIFF
--- a/packages/e2e-tests/next-app/pages/image-component.tsx
+++ b/packages/e2e-tests/next-app/pages/image-component.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { GetStaticPropsContext } from "next";
+import Image from "next/image";
+
+type ImageComponentProps = {
+  name: string;
+};
+
+export default function ImageComponentPage(props: any): JSX.Element {
+  return (
+    <React.Fragment>
+      {`Hello ${props.name}! This is an SSG Page using getStaticProps() and with the new Image component.`}
+      <Image
+        src="/app-store-badge.png"
+        alt="Appstore"
+        width={564}
+        height={168}
+      />
+    </React.Fragment>
+  );
+}
+
+export async function getStaticProps(
+  ctx: GetStaticPropsContext
+): Promise<{ props: ImageComponentProps }> {
+  return {
+    props: { name: "serverless-next.js" }
+  };
+}


### PR DESCRIPTION
Just adds a simple page for the new Image component: https://github.com/serverless-nextjs/serverless-next.js/issues/725. Not tested yet - still need to port the image optimizer code into this component.