### PR TITLE
Add ability to persist cache behaviors not set in serverless

### DIFF
--- a/packages/serverless-components/aws-cloudfront/__tests__/existing-distribution.test.js
+++ b/packages/serverless-components/aws-cloudfront/__tests__/existing-distribution.test.js
@@ -138,4 +138,79 @@ describe("Working with an existing distribution", () => {
       TargetOriginId: "existingorigin2.com"
     });
   });
+
+  it("should preserve the existing origin cache behaviors", async () => {
+    mockGetDistributionConfigPromise.mockReset();
+    mockGetDistributionConfigPromise.mockResolvedValueOnce({
+      ETag: "etag",
+      DistributionConfig: {
+        Origins: {
+          Quantity: 1,
+          Items: [
+            { Id: "existingorigin1.com", DomainName: "existingorigin1.com" },
+            { Id: "existingorigin2.com", DomainName: "existingorigin2.com" }
+          ]
+        },
+        CacheBehaviors: {
+          Quantity: 1,
+          Items: [
+            {
+              PathPattern: "/existing/path1",
+              MinTTL: 10,
+              TargetOriginId: "existingorigin1.com"
+            },
+            {
+              PathPattern: "/existing/path2",
+              MinTTL: 10,
+              TargetOriginId: "existingorigin2.com"
+            }
+          ]
+        }
+      }
+    });
+
+    await component.default({
+      distributionId: "fake-distribution-id",
+      origins: [
+        {
+          url: "https://existingorigin1.com",
+          pathPatterns: {
+            "/some/path": {
+              minTTL: 10,
+              defaultTTL: 10,
+              maxTTL: 10
+            }
+          }
+        }
+      ]
+    });
+
+    assertHasOrigin(mockUpdateDistribution, {
+      Id: "existingorigin1.com",
+      DomainName: "existingorigin1.com"
+    });
+
+    assertHasOrigin(mockUpdateDistribution, {
+      Id: "existingorigin2.com",
+      DomainName: "existingorigin2.com"
+    });
+
+    assertHasCacheBehavior(mockUpdateDistribution, {
+      PathPattern: "/some/path",
+      MinTTL: 10,
+      TargetOriginId: "existingorigin1.com"
+    });
+
+    assertHasCacheBehavior(mockUpdateDistribution, {
+      PathPattern: "/existing/path1",
+      MinTTL: 10,
+      TargetOriginId: "existingorigin1.com"
+    });
+
+    assertHasCacheBehavior(mockUpdateDistribution, {
+      PathPattern: "/existing/path2",
+      MinTTL: 10,
+      TargetOriginId: "existingorigin2.com"
+    });
+  });
 });

--- a/packages/serverless-components/aws-cloudfront/lib/index.js
+++ b/packages/serverless-components/aws-cloudfront/lib/index.js
@@ -268,7 +268,19 @@ const updateCloudFrontDistribution = async (cf, s3, distributionId, inputs) => {
   });
 
   if (CacheBehaviors) {
-    params.DistributionConfig.CacheBehaviors = CacheBehaviors;
+    const behaviors = (params.DistributionConfig.CacheBehaviors = params
+      .DistributionConfig.CacheBehaviors || { Items: [] });
+    const behaviorPaths = behaviors.Items.map((b) => b.PathPattern);
+    CacheBehaviors.Items.forEach((inputBehavior) => {
+      const behaviorIndex = behaviorPaths.indexOf(inputBehavior.PathPattern);
+      if (behaviorIndex > -1) {
+        // replace origin with new input configuration
+        behaviors.Items.splice(behaviorIndex, 1, inputBehavior);
+      } else {
+        behaviors.Items.push(inputBehavior);
+      }
+    });
+    behaviors.Quantity = behaviors.Items.length;
   }
 
   const CustomErrorResponses = getCustomErrorResponses(inputs.errorPages);

--- a/packages/serverless-components/aws-cloudfront/test-utils.js
+++ b/packages/serverless-components/aws-cloudfront/test-utils.js
@@ -25,7 +25,9 @@ module.exports = {
       expect.objectContaining({
         DistributionConfig: expect.objectContaining({
           CacheBehaviors: expect.objectContaining({
-            Items: [expect.objectContaining(cacheBehavior)]
+            Items: expect.arrayContaining([
+              expect.objectContaining(cacheBehavior)
+            ])
           })
         })
       })


### PR DESCRIPTION
Work to close #805 

Due to the way that CacheBehaviors are managed we needed to persist those for origins not controlled by serverless.

Tests have been written and tested locally in our next project, but didn't run the e2e tests.