### PR TITLE
klaw seems to be a dependency for "lambda-at-edge"

### DIFF
--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -45,7 +45,6 @@
     "@types/klaw": "^3.0.1",
     "@types/node": "^14.0.14",
     "@types/path-to-regexp": "^1.7.0",
-    "klaw": "^3.0.0",
     "rollup": "^2.26.6",
     "rollup-plugin-node-externals": "^2.2.0",
     "rollup-plugin-terser": "^7.0.2",
@@ -61,6 +60,7 @@
     "fs-extra": "^9.0.1",
     "get-stream": "^6.0.0",
     "jsonwebtoken": "^8.5.1",
+    "klaw": "^3.0.0",
     "path-to-regexp": "^6.1.0"
   }
 }


### PR DESCRIPTION
When installing `lambda-at-edge` independently and running the example code

```
const path = require('path');
const { Builder } = require("@sls-next/lambda-at-edge");

const nextConfigDir = __dirname;
const outputDir = path.join(nextConfigDir, ".serverless_nextjs");

const builder = new Builder(
  nextConfigDir,
  outputDir,
  {
    cmd: './node_modules/.bin/next',
    cwd: process.cwd(),
    env: {},
    args: ['build']
  }
);

(async () => await builder.build())();
```

I get the following error:

```
 node build.js
node:internal/modules/cjs/loader:903
  throw err;
  ^

Error: Cannot find module 'klaw'
```

Installing `klaw` via npm / yarn fixes it.