### PR TITLE
fix(lambda-at-edge): minor fix to optional catch-all base route at ro…

### DIFF
--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -476,6 +476,7 @@ class Builder {
       } else if (isOptionalCatchAllDynamicRoute) {
         expressRoute = expressifyOptionalCatchAllDynamicRoute(route);
         optionalBaseRoute = route.split("/[[")[0]; // The base path of optional catch-all without parameter
+        optionalBaseRoute = optionalBaseRoute === "" ? "/" : optionalBaseRoute;
       }
 
       if (isHtmlPage(pageFile)) {


### PR DESCRIPTION
…ot level.

* minor fix to correct nonDynamic key from "" to "/" at root page level. Even without this, the route should still work because it should still match on the dynamic route (which catches all), but this should help with route precedence.