### PR TITLE
Fix not found for public files with encoded characters in path

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -255,8 +255,10 @@ const handleOriginRequest = async ({
 
   const basePath = routesManifest.basePath;
   let uri = normaliseUri(request.uri);
+  const decodedUri = decodeURI(uri);
   const { pages, publicFiles } = manifest;
-  let isPublicFile = publicFiles[uri];
+
+  let isPublicFile = publicFiles[decodedUri];
   let isDataReq = isDataRequest(uri);
 
   // Handle redirects
@@ -300,7 +302,7 @@ const handleOriginRequest = async ({
   }
 
   // Check for non-dynamic pages before rewriting
-  let isNonDynamicRoute =
+  const isNonDynamicRoute =
     pages.html.nonDynamic[uri] || pages.ssr.nonDynamic[uri] || isPublicFile;
 
   // Handle custom rewrites, but don't rewrite non-dynamic pages, public files or data requests per Next.js docs: https://nextjs.org/docs/api-reference/next.config.js/rewrites
@@ -548,7 +550,7 @@ const handleOriginResponse = async ({
     if (!hasFallback) return response;
 
     // If route has fallback, return that page from S3, otherwise return 404 page
-    let s3Key = `${basePath}${basePath === "" ? "" : "/"}static-pages/${
+    const s3Key = `${basePath}${basePath === "" ? "" : "/"}static-pages/${
       manifest.buildId
     }${hasFallback.fallback || "/404.html"}`;
 

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-trailing-slash.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-trailing-slash.json
@@ -70,7 +70,8 @@
   },
   "publicFiles": {
     "/favicon.ico": "favicon.ico",
-    "/manifest.json": "manifest.json"
+    "/manifest.json": "manifest.json",
+    "/file with spaces.json": "file with spaces.json"
   },
   "trailingSlash": true,
   "domainRedirects": {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest.json
@@ -70,7 +70,8 @@
   },
   "publicFiles": {
     "/favicon.ico": "favicon.ico",
-    "/manifest.json": "manifest.json"
+    "/manifest.json": "manifest.json",
+    "/file with spaces.json": "file with spaces.json"
   },
   "trailingSlash": false,
   "domainRedirects": {


### PR DESCRIPTION
URL-decode request path before checking for public file in `manifest.json`. Prevent 404 responses when filename contains encoded characters.

Another unit test for public directory serving is added to verify functionality.

Fixes #822 