### PR TITLE
Pass certificateArn to domain component

### DIFF
--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -633,7 +633,7 @@ class NextjsComponent extends Component {
       await createInvalidation({
         distributionId: cloudFrontOutputs.id,
         credentials: this.context.credentials.aws,
-        paths: cloudFrontPaths,
+        paths: cloudFrontPaths
       });
     }
 
@@ -647,7 +647,8 @@ class NextjsComponent extends Component {
           [subdomain]: cloudFrontOutputs
         },
         domainType: inputs.domainType || "both",
-        defaultCloudfrontInputs: cloudFrontDefaults
+        defaultCloudfrontInputs: cloudFrontDefaults,
+        certificateArn: inputs.certificateArn
       });
       appUrl = domainOutputs.domains[0];
     }

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -633,7 +633,7 @@ class NextjsComponent extends Component {
       await createInvalidation({
         distributionId: cloudFrontOutputs.id,
         credentials: this.context.credentials.aws,
-        paths: cloudFrontPaths
+        paths: cloudFrontPaths,
       });
     }
 

--- a/packages/serverless-components/nextjs-component/types.d.ts
+++ b/packages/serverless-components/nextjs-component/types.d.ts
@@ -25,6 +25,7 @@ export type ServerlessComponentInputs = {
   deploy?: boolean;
   enableHTTPCompression?: boolean;
   authentication?: { username: string; password: string };
+  certificateArn?: string;
 };
 
 type CloudfrontOptions = Record<string, any>;


### PR DESCRIPTION
Currently, declared on README.md page `certificateArn` does not passed to `domain` component, resulting in searching for domain certificate, which works bad for subdomains, i.e. app.example.com

See issue here: https://github.com/serverless-nextjs/serverless-next.js/issues/821

