### PR TITLE
Add inputs.roleArn for existing lambda role

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ myNextApplication:
 
 ### AWS Permissions
 
-By default the Lambda@Edge functions run using AWSLambdaBasicExecutionRole which only allows uploading logs to CloudWatch. If you need permissions beyond this, like for example access to DynamoDB or any other AWS resource you will need your own custom policy arn:
+By default the Lambda@Edge functions run using AWSLambdaBasicExecutionRole which only allows uploading logs to CloudWatch. If you need permissions beyond this, like for example access to DynamoDB or any other AWS resource you will need your own custom policy or role arn:
+
+#### Specify policy:
 
 ```yml
 # serverless.yml
@@ -295,7 +297,46 @@ myNextApplication:
     policy: "arn:aws:iam::123456789012:policy/MyCustomPolicy"
 ```
 
-Make sure you add CloudWatch log permissions to your custom policy.
+#### Specify role:
+
+```yml
+# serverless.yml
+
+myNextApplication:
+  component: "@sls-next/serverless-component@{version_here}"
+  inputs:
+    roleArn: "arn:aws:iam::123456789012:policy/MyCustomLambdaRole"
+```
+
+Make sure you add CloudWatch log permissions to your custom policy or role. Minimum policy JSON example:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::s3-deployment-bucket-name/*",
+      "Action": ["s3:GetObject", "s3:PutObject"]
+    }
+  ]
+}
+```
+
+Role should include trust relationship with `lambda.amazonaws.com` and `edgelambda.amazonaws.com`.
+
+**NOTE**: Specify `bucketName` and give permissions to access that bucket via `policy` or `roleArn` so default and API lambdas can access static resources.
+
+### AWS Permissions for deployment
 
 The exhaustive list of AWS actions required for a deployment:
 
@@ -443,6 +484,7 @@ The fourth cache behaviour handles next API requests `api/*`.
 | nextStaticDir            | `string`          | `./`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | If your `static` or `public` directory is not a direct child of `nextConfigDir` this is needed                                                                                                                                                                                                                                                                                                                                                                                        |
 | description              | `string`          | `*lambda-type*@Edge for Next CloudFront distribution`                                                                                                                                                                                                                                                                                                                                                                                                                                  | The description that will be used for both lambdas. Note that "(API)" will be appended to the API lambda description.                                                                                                                                                                                                                                                                                                                                                                 |
 | policy                   | `string\|object`  | `arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole`                                                                                                                                                                                                                                                                                                                                                                                                                     | The arn or inline policy that will be assigned to both lambdas.                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| roleArn                  | `string\|object`  | null                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | The arn of role that will be assigned to both lambdas.                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | runtime                  | `string\|object`  | `nodejs12.x`                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | When assigned a value, both the default and api lambdas will be assigned the runtime defined in the value. When assigned to an object, values for the default and api lambdas can be separately defined                                                                                                                                                                                                                                                                               |  |
 | memory                   | `number\|object`  | `512`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | When assigned a number, both the default and api lambdas will be assigned memory of that value. When assigned to an object, values for the default and api lambdas can be separately defined                                                                                                                                                                                                                                                                                          |  |
 | timeout                  | `number\|object`  | `10`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Same as above                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ myNextApplication:
 myNextApplication:
   component: "@sls-next/serverless-component@{version_here}"
   inputs:
-    roleArn: "arn:aws:iam::123456789012:policy/MyCustomLambdaRole"
+    roleArn: "arn:aws:iam::123456789012:role/MyCustomLambdaRole"
 ```
 
 Make sure you add CloudWatch log permissions to your custom policy or role. Minimum policy JSON example:

--- a/packages/serverless-components/aws-lambda/serverless.js
+++ b/packages/serverless-components/aws-lambda/serverless.js
@@ -59,7 +59,7 @@ class AwsLambda extends Component {
       credentials: this.context.credentials.aws
     });
 
-    if (!config.role.arn) {
+    if (!config.role || !config.role.arn) {
       const awsIamRole = await this.load("@serverless/aws-iam-role");
       const outputsAwsIamRole = await awsIamRole(config.role);
       config.role = { arn: outputsAwsIamRole.arn };

--- a/packages/serverless-components/aws-lambda/serverless.js
+++ b/packages/serverless-components/aws-lambda/serverless.js
@@ -59,9 +59,11 @@ class AwsLambda extends Component {
       credentials: this.context.credentials.aws
     });
 
-    const awsIamRole = await this.load("@serverless/aws-iam-role");
-    const outputsAwsIamRole = await awsIamRole(config.role);
-    config.role = { arn: outputsAwsIamRole.arn };
+    if (!config.role.arn) {
+      const awsIamRole = await this.load("@serverless/aws-iam-role");
+      const outputsAwsIamRole = await awsIamRole(config.role);
+      config.role = { arn: outputsAwsIamRole.arn };
+    }
 
     this.context.status("Packaging");
     this.context.debug(`Packaging lambda code from ${config.code}.`);

--- a/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
@@ -178,6 +178,41 @@ describe("Custom inputs", () => {
     });
   });
 
+  describe("Custom role arn", () => {
+    const fixturePath = path.join(__dirname, "./fixtures/generic-fixture");
+    let tmpCwd: string;
+
+    beforeEach(async () => {
+      tmpCwd = process.cwd();
+      process.chdir(fixturePath);
+
+      mockServerlessComponentDependencies({ expectedDomain: undefined });
+
+      const component = createNextComponent();
+
+      componentOutputs = await component.default({
+        roleArn: "arn:aws:iam::aws:role/CustomRole"
+      });
+    });
+
+    afterEach(() => {
+      process.chdir(tmpCwd);
+      return cleanupFixtureDirectory(fixturePath);
+    });
+
+    it("uses custom role arn provided", () => {
+      expect(mockLambda).toBeCalledTimes(2);
+
+      expect(mockLambda).toBeCalledWith(
+        expect.objectContaining({
+          role: expect.objectContaining({
+            arn: "arn:aws:iam::aws:role/CustomRole"
+          })
+        })
+      );
+    });
+  });
+
   describe.each`
     nextConfigDir      | nextStaticDir      | fixturePath
     ${"nextConfigDir"} | ${"nextStaticDir"} | ${path.join(__dirname, "./fixtures/split-app")}
@@ -1148,7 +1183,7 @@ describe("Custom inputs", () => {
         }
       });
       expect(mockCreateInvalidation).toBeCalledWith(
-        expect.objectContaining({paths: pathsConfig})
+        expect.objectContaining({ paths: pathsConfig })
       );
     });
 

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -448,10 +448,14 @@ class NextjsComponent extends Component {
           : "API Lambda@Edge for Next CloudFront distribution",
         handler: inputs.handler || "index.handler",
         code: join(nextConfigPath, API_LAMBDA_CODE_DIR),
-        role: {
-          service: ["lambda.amazonaws.com", "edgelambda.amazonaws.com"],
-          policy
-        },
+        role: inputs.roleArn
+          ? {
+              arn: inputs.roleArn
+            }
+          : {
+              service: ["lambda.amazonaws.com", "edgelambda.amazonaws.com"],
+              policy
+            },
         memory: readLambdaInputValue("memory", "apiLambda", 512) as number,
         timeout: readLambdaInputValue("timeout", "apiLambda", 10) as number,
         runtime: readLambdaInputValue(
@@ -496,10 +500,14 @@ class NextjsComponent extends Component {
         "Default Lambda@Edge for Next CloudFront distribution",
       handler: inputs.handler || "index.handler",
       code: join(nextConfigPath, DEFAULT_LAMBDA_CODE_DIR),
-      role: {
-        service: ["lambda.amazonaws.com", "edgelambda.amazonaws.com"],
-        policy
-      },
+      role: inputs.roleArn
+        ? {
+            arn: inputs.roleArn
+          }
+        : {
+            service: ["lambda.amazonaws.com", "edgelambda.amazonaws.com"],
+            policy
+          },
       memory: readLambdaInputValue("memory", "defaultLambda", 512) as number,
       timeout: readLambdaInputValue("timeout", "defaultLambda", 10) as number,
       runtime: readLambdaInputValue(
@@ -633,7 +641,7 @@ class NextjsComponent extends Component {
       await createInvalidation({
         distributionId: cloudFrontOutputs.id,
         credentials: this.context.credentials.aws,
-        paths: cloudFrontPaths,
+        paths: cloudFrontPaths
       });
     }
 

--- a/packages/serverless-components/nextjs-component/types.d.ts
+++ b/packages/serverless-components/nextjs-component/types.d.ts
@@ -16,6 +16,7 @@ export type ServerlessComponentInputs = {
   handler?: string;
   description?: string;
   policy?: string;
+  roleArn?: string;
   domain?: string | string[];
   domainType?: "www" | "apex" | "both";
   domainRedirects?: { [key: string]: string };


### PR DESCRIPTION
Allows to specify ARN of existing role instead of creating a new one.

```yml
myNextApplication:
  component: "@sls-next/serverless-component@{version_here}"
  inputs:
    roleArn: "arn:aws:iam::123456789012:role/MyCustomLambdaRole"
```

- [x] Added to README.md
- [x] Added unit test to packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts