### PR TITLE
fix(lambda-at-edge): include all vendor files in sharp package.json s…

### DIFF
--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -16,8 +16,7 @@
     "build": "rollup --config && tsc -p tsconfig.build.json && yarn copy-sharp-modules"
   },
   "files": [
-    "dist",
-    "dist/sharp_node_modules/**"
+    "dist"
   ],
   "repository": {
     "type": "git",

--- a/packages/libs/lambda-at-edge/sharp_node_modules/sharp/package.json
+++ b/packages/libs/lambda-at-edge/sharp_node_modules/sharp/package.json
@@ -350,7 +350,8 @@
     "install/**",
     "!install/prebuild-ci.js",
     "lib/**",
-    "src/**"
+    "src/**",
+    "vendor/**"
   ],
   "funding": {
     "url": "https://opencollective.com/libvips"


### PR DESCRIPTION
…o npm publish will copy all vendor libs correctly.

* I think this is needed since npm publish may look for package.json in `sharp_node_modules/sharp` and only publish certain files. We need to explicitly specify `vendor` since we do want the pre-built binaries as well.

Related: https://github.com/serverless-nextjs/serverless-next.js/issues/840