### PR TITLE
fix(nextjs-component): don't override _next/image* and _next/static/*…

### DIFF
--- a/packages/e2e-tests/next-app/serverless.yml
+++ b/packages/e2e-tests/next-app/serverless.yml
@@ -3,8 +3,8 @@ next-app:
   inputs:
     build:
       postBuildCommands: ["node scripts/post-build-test.js"]
-    imageOptimizer: true
     cloudfront:
-      defaults:
-        forward:
-          headers: [Accept] # Needed for image optimizer
+      _next/static/*:
+        defaultTTL: 0
+        minTTL: 0
+        maxTTL: 0

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -629,12 +629,16 @@ class NextjsComponent extends Component {
       };
 
       // here we are removing configs that cannot be overridden
-      if (path === this.pathPattern("api/*", routesManifest)) {
-        // for "api/*" we need to make sure we aren't overriding the predefined lambda handler
+      if (
+        path === this.pathPattern("api/*", routesManifest) ||
+        path === this.pathPattern("_next/image*", routesManifest)
+      ) {
+        // for "api/*" or "_next/image*" we need to make sure we aren't overriding the predefined lambda handler
+        // Since these are using special API or Image handlers
         // delete is idempotent so it's safe
         delete edgeConfig["origin-request"];
-      } else if (!["static/*", "_next/*"].includes(path)) {
-        // for everything but static/* and _next/* we want to ensure that they are pointing at our lambda
+      } else if (!["static/*", "_next/static/*", "_next/*"].includes(path)) {
+        // for everything but _next/static/*, static/* and _next/* we want to ensure that they are pointing at the default lambda
         edgeConfig[
           "origin-request"
         ] = `${defaultEdgeLambdaOutputs.arn}:${defaultEdgeLambdaPublishOutputs.version}`;


### PR DESCRIPTION
… origin request lambda with the default lambda

* For `_next/static/*` and `_next/image*` cache behaviors, they should not be overridden with default lambda (`_next/static/*` should have no lambda, and `_next/image*` should retain the image lambda).
* Also clean up unneeded config in test `next-app`