### PR TITLE
Update type declarations to be included in `dist` and exported at the root

### DIFF
--- a/packages/libs/lambda-at-edge/src/api-handler.ts
+++ b/packages/libs/lambda-at-edge/src/api-handler.ts
@@ -7,7 +7,7 @@ import {
   OriginRequestApiHandlerManifest,
   OriginRequestEvent,
   RoutesManifest
-} from "../types";
+} from "./types";
 import { CloudFrontResultResponse } from "aws-lambda";
 import {
   createRedirectResponse,

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -10,7 +10,7 @@ import {
   OriginRequestApiHandlerManifest,
   RoutesManifest,
   OriginRequestImageHandlerManifest
-} from "../types";
+} from "./types";
 import { isDynamicRoute, isOptionalCatchAllRoute } from "./lib/isDynamicRoute";
 import pathToPosix from "./lib/pathToPosix";
 import {

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -19,7 +19,7 @@ import {
   PerfLogger,
   PreRenderedManifest as PrerenderManifestType,
   RoutesManifest
-} from "../types";
+} from "./types";
 import { performance } from "perf_hooks";
 import { ServerResponse } from "http";
 import type { Readable } from "stream";

--- a/packages/libs/lambda-at-edge/src/headers/addHeaders.ts
+++ b/packages/libs/lambda-at-edge/src/headers/addHeaders.ts
@@ -1,5 +1,5 @@
 import { CloudFrontResultResponse } from "aws-lambda";
-import { RoutesManifest } from "../../types";
+import { RoutesManifest } from "../types";
 import { matchPath } from "../routing/matcher";
 
 export function addHeadersToResponse(

--- a/packages/libs/lambda-at-edge/src/image-handler.ts
+++ b/packages/libs/lambda-at-edge/src/image-handler.ts
@@ -7,7 +7,7 @@ import {
   OriginRequestEvent,
   OriginRequestImageHandlerManifest,
   RoutesManifest
-} from "../types";
+} from "./types";
 import { CloudFrontResultResponse } from "aws-lambda";
 import lambdaAtEdgeCompat from "@sls-next/next-aws-cloudfront";
 import { UrlWithParsedQuery } from "url";

--- a/packages/libs/lambda-at-edge/src/images/imageConfig.ts
+++ b/packages/libs/lambda-at-edge/src/images/imageConfig.ts
@@ -1,4 +1,4 @@
-import { ImageConfig } from "../../types";
+import { ImageConfig } from "../types";
 
 export const imageConfigDefault: ImageConfig = {
   deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],

--- a/packages/libs/lambda-at-edge/src/images/imageOptimizer.ts
+++ b/packages/libs/lambda-at-edge/src/images/imageOptimizer.ts
@@ -22,7 +22,7 @@ import { getContentType, getExtension } from "./serveStatic";
 import isAnimated from "is-animated";
 import Stream from "stream";
 import { sendEtagResponse } from "../lib/sendEtagResponse";
-import { ImageConfig, ImagesManifest } from "../../types";
+import { ImageConfig, ImagesManifest } from "../types";
 import { imageConfigDefault } from "./imageConfig";
 import { buildS3RetryStrategy } from "../s3/s3RetryStrategy";
 import * as fs from "fs";

--- a/packages/libs/lambda-at-edge/src/index.ts
+++ b/packages/libs/lambda-at-edge/src/index.ts
@@ -1,1 +1,3 @@
 export { default as Builder } from "./build";
+
+export * from "./types";

--- a/packages/libs/lambda-at-edge/src/routing/redirector.ts
+++ b/packages/libs/lambda-at-edge/src/routing/redirector.ts
@@ -5,7 +5,7 @@ import {
   OriginRequestImageHandlerManifest,
   RedirectData,
   RoutesManifest
-} from "../../types";
+} from "../types";
 import * as http from "http";
 import { CloudFrontRequest } from "aws-lambda";
 import { CloudFrontResultResponse } from "aws-lambda";

--- a/packages/libs/lambda-at-edge/src/routing/rewriter.ts
+++ b/packages/libs/lambda-at-edge/src/routing/rewriter.ts
@@ -1,5 +1,5 @@
 import { compileDestination, matchPath } from "./matcher";
-import { RewriteData, RoutesManifest } from "../../types";
+import { RewriteData, RoutesManifest } from "../types";
 import { IncomingMessage, ServerResponse } from "http";
 
 /**

--- a/packages/libs/lambda-at-edge/src/types.ts
+++ b/packages/libs/lambda-at-edge/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CloudFrontRequest,
   CloudFrontEvent,
   CloudFrontResponse

--- a/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
@@ -4,7 +4,7 @@ import execa from "execa";
 import Builder from "../../src/build";
 import { DEFAULT_LAMBDA_CODE_DIR, API_LAMBDA_CODE_DIR } from "../../src/build";
 import { cleanupDir, removeNewLineChars } from "../test-utils";
-import { OriginRequestDefaultHandlerManifest } from "../../types";
+import { OriginRequestDefaultHandlerManifest } from "../../src/types";
 
 jest.mock("execa");
 

--- a/packages/libs/lambda-at-edge/tests/build/build.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build.test.ts
@@ -12,7 +12,7 @@ import {
   OriginRequestDefaultHandlerManifest,
   OriginRequestApiHandlerManifest,
   OriginRequestImageHandlerManifest
-} from "../../types";
+} from "../../src/types";
 
 jest.mock("execa");
 

--- a/packages/libs/lambda-at-edge/tests/dynamic-routes-precedence/dynamic-routes-precedence.build.test.ts
+++ b/packages/libs/lambda-at-edge/tests/dynamic-routes-precedence/dynamic-routes-precedence.build.test.ts
@@ -7,7 +7,7 @@ import { cleanupDir } from "../test-utils";
 import {
   OriginRequestDefaultHandlerManifest,
   OriginRequestApiHandlerManifest
-} from "../../types";
+} from "../../src/types";
 
 jest.mock("execa");
 

--- a/packages/libs/lambda-at-edge/tests/integration/with-trailing-slash-next-config/with-trailing-slash-next-config.test.ts
+++ b/packages/libs/lambda-at-edge/tests/integration/with-trailing-slash-next-config/with-trailing-slash-next-config.test.ts
@@ -6,7 +6,7 @@ import fse, { readFile, remove, pathExists } from "fs-extra";
 import {
   OriginRequestDefaultHandlerManifest,
   RoutesManifest
-} from "../../../types";
+} from "../../../src/types";
 
 jest.unmock("execa");
 

--- a/packages/libs/lambda-at-edge/tests/public-and-static-dir/public-and-static-dir.test.ts
+++ b/packages/libs/lambda-at-edge/tests/public-and-static-dir/public-and-static-dir.test.ts
@@ -4,7 +4,7 @@ import fse, { readJSON } from "fs-extra";
 import { join } from "path";
 import { DEFAULT_LAMBDA_CODE_DIR } from "../../src/build";
 import { cleanupDir } from "../test-utils";
-import { OriginRequestDefaultHandlerManifest } from "../../types";
+import { OriginRequestDefaultHandlerManifest } from "../../src/types";
 
 jest.mock("execa");
 

--- a/packages/libs/lambda-at-edge/tests/routing/redirector.test.ts
+++ b/packages/libs/lambda-at-edge/tests/routing/redirector.test.ts
@@ -2,7 +2,7 @@ import {
   createRedirectResponse,
   getRedirectPath
 } from "../../src/routing/redirector";
-import { RoutesManifest } from "../../types";
+import { RoutesManifest } from "../../src/types";
 
 describe("Redirector Tests", () => {
   describe("getRedirectPath()", () => {

--- a/packages/libs/lambda-at-edge/tests/routing/rewriter.test.ts
+++ b/packages/libs/lambda-at-edge/tests/routing/rewriter.test.ts
@@ -1,5 +1,5 @@
 import { getRewritePath } from "../../src/routing/rewriter";
-import { RoutesManifest } from "../../types";
+import { RoutesManifest } from "../../src/types";
 
 describe("Rewriter Tests", () => {
   describe("getRewritePath()", () => {

--- a/packages/libs/lambda-at-edge/tests/test-utils.ts
+++ b/packages/libs/lambda-at-edge/tests/test-utils.ts
@@ -5,7 +5,7 @@ import {
   CloudFrontEvent,
   CloudFrontResponse
 } from "aws-lambda";
-import { OriginRequestEvent } from "../types";
+import { OriginRequestEvent } from "../src/types";
 
 export const cleanupDir = (dir: string): Promise<void> => {
   return remove(dir);

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -2,13 +2,13 @@ import { Component } from "@serverless/core";
 import { readJSON, pathExists } from "fs-extra";
 import { resolve, join } from "path";
 import { Builder } from "@sls-next/lambda-at-edge";
-import {
+import type {
   OriginRequestDefaultHandlerManifest as BuildManifest,
   OriginRequestDefaultHandlerManifest,
   OriginRequestApiHandlerManifest,
   RoutesManifest,
   OriginRequestImageHandlerManifest
-} from "@sls-next/lambda-at-edge/types";
+} from "@sls-next/lambda-at-edge";
 import {
   deleteOldStaticAssets,
   uploadStaticAssetsFromBuild,


### PR DESCRIPTION
>closes: #860 

This PR will ensure that the types used in the `@sls-next/lambda-at-edge` are included in the distribution.

- Move the `types.d.ts` into `src/types.ts`
- Export all types from `src/types.ts` in `src/index.ts`

This means the types that have cross package uses are accessible from the root e.g:

```ts
import type { RoutesManifest } from '@sls-next/lambda-at-edge'
```

