### PR TITLE
perf(lambda-at-edge): do not decompress content from fetch in externa…

### DIFF
--- a/packages/libs/lambda-at-edge/src/routing/rewriter.ts
+++ b/packages/libs/lambda-at-edge/src/routing/rewriter.ts
@@ -65,8 +65,7 @@ const ignoredHeaders = [
   "content-length",
   "host",
   "transfer-encoding",
-  "via",
-  "content-encoding"
+  "via"
 ];
 
 const ignoredHeaderPrefixes = ["x-amz-cf-", "x-amzn-", "x-edge-"];
@@ -107,12 +106,14 @@ export async function createExternalRewriteResponse(
     fetchResponse = await fetch(customRewrite, {
       headers: reqHeaders,
       method: req.method,
-      body: decodedBody // Must pass body as a string
+      body: decodedBody, // Must pass body as a string,
+      compress: false
     });
   } else {
     fetchResponse = await fetch(customRewrite, {
       headers: reqHeaders,
-      method: req.method
+      method: req.method,
+      compress: false
     });
   }
 
@@ -122,6 +123,5 @@ export async function createExternalRewriteResponse(
     }
   }
   res.statusCode = fetchResponse.status;
-  const text = await fetchResponse.text();
-  res.end(text);
+  res.end(await fetchResponse.buffer());
 }


### PR DESCRIPTION
…l rewrite.

* Since we aren't doing anything with the response body any, there's no need to decompress it. Send it back to CF response as buffer and do not decompress it. 
* If already compressed, it will reuse the existing compression (e.g brotli or gzip) whereas before it would decompress + then rely on CF to re-compress it
* If not already compressed, it will be same behavior and CF will auto-compress specific content types (e.g json, html, txt)

This should help with performance and I believe should help size issues like: https://github.com/serverless-nextjs/serverless-next.js/issues/870 (as long as content can be compressed)