### PR TITLE
fix(lambda-at-edge): fix redirect loop in Next 10.0.4 and up due to n…

### DIFF
--- a/packages/libs/lambda-at-edge/src/routing/redirector.ts
+++ b/packages/libs/lambda-at-edge/src/routing/redirector.ts
@@ -20,6 +20,11 @@ export function isTrailingSlashRedirect(
   redirect: RedirectData,
   basePath: string
 ) {
+  // Remove internal trailing slash redirects (in Next.js 10.0.4 and up)
+  if (redirect.internal === true) {
+    return true;
+  }
+
   if (basePath !== "") {
     return (
       (redirect.statusCode === 308 &&

--- a/packages/libs/lambda-at-edge/src/types.ts
+++ b/packages/libs/lambda-at-edge/src/types.ts
@@ -127,6 +127,7 @@ export type RedirectData = {
   source: string;
   destination: string;
   regex: string;
+  internal?: boolean;
 };
 
 export type RewriteData = {


### PR DESCRIPTION
…ew internal redirect regexes.

* There are more `internal` regexes added in Next 10.0.4 and up, causing a redirect loop due to interfering with our own trailing slash redirects. This fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/877