### PR TITLE
feat(lambda-at-edge): initial support for routing to locale-specific …

### DIFF
--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -641,7 +641,9 @@ class Builder {
 
           for (const key in ssrPages.dynamic) {
             const newKey = key === "/" ? `/${locale}` : `/${locale}${key}`;
-            localeSsrPages.dynamic[newKey] = {};
+
+            // Initial default value
+            localeSsrPages.dynamic[newKey] = { file: "", regex: "" };
             const newDynamicSsr = Object.assign(
               localeSsrPages.dynamic[newKey],
               ssrPages.dynamic[key]
@@ -670,7 +672,13 @@ class Builder {
 
           for (const key in ssgPages.nonDynamic) {
             const newKey = key === "/" ? `/${locale}` : `/${locale}${key}`;
-            localeSsgPages.nonDynamic[newKey] = {};
+
+            // Initial default value
+            localeSsgPages.nonDynamic[newKey] = {
+              initialRevalidateSeconds: false,
+              srcRoute: null,
+              dataRoute: ""
+            };
 
             const newSsgRoute = Object.assign(
               localeSsgPages.nonDynamic[newKey],

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -9,7 +9,8 @@ import {
   OriginRequestDefaultHandlerManifest,
   OriginRequestApiHandlerManifest,
   RoutesManifest,
-  OriginRequestImageHandlerManifest
+  OriginRequestImageHandlerManifest,
+  DynamicPageKeyValue
 } from "./types";
 import { isDynamicRoute, isOptionalCatchAllRoute } from "./lib/isDynamicRoute";
 import pathToPosix from "./lib/pathToPosix";
@@ -23,7 +24,7 @@ import createServerlessConfig from "./lib/createServerlessConfig";
 import { isTrailingSlashRedirect } from "./routing/redirector";
 import readDirectoryFiles from "./lib/readDirectoryFiles";
 import filterOutDirectories from "./lib/filterOutDirectories";
-import { PrerenderManifest } from "next/dist/build";
+import { DynamicSsgRoute, PrerenderManifest, SsgRoute } from "next/dist/build";
 import { Item } from "klaw";
 import { Job } from "@vercel/nft/out/node-file-trace";
 
@@ -456,7 +457,10 @@ class Builder {
     ]);
   }
 
-  async prepareBuildManifests(): Promise<{
+  async prepareBuildManifests(
+    routesManifest: RoutesManifest,
+    prerenderManifest: PrerenderManifest
+  ): Promise<{
     defaultBuildManifest: OriginRequestDefaultHandlerManifest;
     apiBuildManifest: OriginRequestApiHandlerManifest;
     imageBuildManifest: OriginRequestImageHandlerManifest;
@@ -487,6 +491,10 @@ class Builder {
         html: {
           dynamic: {},
           nonDynamic: {}
+        },
+        ssg: {
+          dynamic: {},
+          nonDynamic: {}
         }
       },
       publicFiles: {},
@@ -506,6 +514,7 @@ class Builder {
       enableHTTPCompression
     };
 
+    const ssgPages = defaultBuildManifest.pages.ssg;
     const ssrPages = defaultBuildManifest.pages.ssr;
     const htmlPages = defaultBuildManifest.pages.html;
     const apiPages = apiBuildManifest.apis;
@@ -581,6 +590,136 @@ class Builder {
         ssrPages.nonDynamic[route] = pageFile;
       }
     });
+
+    // Add non-dynamic SSG routes
+    Object.entries(prerenderManifest.routes).forEach(([route, ssgRoute]) => {
+      // Somehow Next.js generates prerender manifest with default locale prefixed, normalize it
+      const defaultLocale = routesManifest.i18n?.defaultLocale;
+      if (defaultLocale) {
+        const normalizedRoute = route.replace(`/${defaultLocale}/`, "/");
+        ssgRoute.dataRoute = ssgRoute.dataRoute.replace(
+          `/${defaultLocale}/`,
+          "/"
+        );
+        ssgPages.nonDynamic[normalizedRoute] = ssgRoute;
+      } else {
+        ssgPages.nonDynamic[route] = ssgRoute;
+      }
+    });
+
+    // Add dynamic SSG routes
+    Object.entries(prerenderManifest.dynamicRoutes ?? {}).forEach(
+      ([route, dynamicSsgRoute]) => {
+        ssgPages.dynamic[route] = dynamicSsgRoute;
+      }
+    );
+
+    // Copy routes for all specified locales
+    if (routesManifest.i18n) {
+      const defaultLocale = routesManifest.i18n.defaultLocale;
+      for (const locale of routesManifest.i18n.locales) {
+        if (locale !== defaultLocale) {
+          const localeSsrPages: {
+            nonDynamic: {
+              [key: string]: string;
+            };
+            dynamic: DynamicPageKeyValue;
+          } = {
+            nonDynamic: {},
+            dynamic: {}
+          };
+
+          for (const key in ssrPages.nonDynamic) {
+            const newKey = key === "/" ? `/${locale}` : `/${locale}${key}`;
+            localeSsrPages.nonDynamic[newKey] = ssrPages.nonDynamic[key];
+          }
+
+          ssrPages.nonDynamic = {
+            ...ssrPages.nonDynamic,
+            ...localeSsrPages.nonDynamic
+          };
+
+          for (const key in ssrPages.dynamic) {
+            const newKey = key === "/" ? `/${locale}` : `/${locale}${key}`;
+            localeSsrPages.dynamic[newKey] = {};
+            const newDynamicSsr = Object.assign(
+              localeSsrPages.dynamic[newKey],
+              ssrPages.dynamic[key]
+            );
+
+            // Need to update the regex
+            newDynamicSsr.regex = pathToRegexStr(newKey);
+          }
+
+          ssrPages.dynamic = {
+            ...ssrPages.dynamic,
+            ...localeSsrPages.dynamic
+          };
+
+          const localeSsgPages: {
+            dynamic: {
+              [key: string]: DynamicSsgRoute;
+            };
+            nonDynamic: {
+              [key: string]: SsgRoute;
+            };
+          } = {
+            dynamic: {},
+            nonDynamic: {}
+          };
+
+          for (const key in ssgPages.nonDynamic) {
+            const newKey = key === "/" ? `/${locale}` : `/${locale}${key}`;
+            localeSsgPages.nonDynamic[newKey] = {};
+
+            const newSsgRoute = Object.assign(
+              localeSsgPages.nonDynamic[newKey],
+              ssgPages.nonDynamic[key]
+            );
+
+            // Replace with localized value
+            newSsgRoute.dataRoute = newSsgRoute.dataRoute.replace(
+              `/_next/data/${buildId}/`,
+              `/_next/data/${buildId}/${locale}/`
+            );
+          }
+
+          ssgPages.nonDynamic = {
+            ...ssgPages.nonDynamic,
+            ...localeSsgPages.nonDynamic
+          };
+
+          for (const key in ssgPages.dynamic) {
+            const newKey = key === "/" ? `/${locale}` : `/${locale}${key}`;
+            localeSsgPages.dynamic[newKey] = ssgPages.dynamic[key];
+
+            const newDynamicSsgRoute = localeSsgPages.dynamic[newKey];
+
+            // Replace with localized values
+            newDynamicSsgRoute.dataRoute = newDynamicSsgRoute.dataRoute.replace(
+              `/_next/data/${buildId}/`,
+              `/_next/data/${buildId}/${locale}/`
+            );
+            newDynamicSsgRoute.dataRouteRegex = newDynamicSsgRoute.dataRouteRegex.replace(
+              `/_next/data/${buildId}/`,
+              `/_next/data/${buildId}/${locale}/`
+            );
+            newDynamicSsgRoute.fallback =
+              typeof newDynamicSsgRoute.fallback === "string"
+                ? newDynamicSsgRoute.fallback.replace("/", `/${locale}/`)
+                : newDynamicSsgRoute.fallback;
+            newDynamicSsgRoute.routeRegex = localeSsgPages.dynamic[
+              newKey
+            ].routeRegex.replace("^/", `^/${locale}/`);
+          }
+
+          ssgPages.dynamic = {
+            ...ssgPages.dynamic,
+            ...localeSsgPages.dynamic
+          };
+        }
+      }
+    }
 
     const publicFiles = await this.readPublicFiles();
 
@@ -727,26 +866,16 @@ class Builder {
           );
           const destination = path.join(
             assetOutputDirectory,
-            withBasePath(`_next/data/${buildId}/${localePrefixedJSONFileName}`)
+            withBasePath(
+              `_next/data/${buildId}/${
+                defaultLocale && defaultLocale === locale
+                  ? JSONFileName
+                  : localePrefixedJSONFileName
+              }`
+            )
           );
 
-          if (defaultLocale && defaultLocale === locale) {
-            // If this is default locale, we need to copy to two destinations
-            // the locale-prefixed path and non-locale-prefixed path
-            const defaultDestination = path.join(
-              assetOutputDirectory,
-              withBasePath(`_next/data/${buildId}/${JSONFileName}`)
-            );
-
-            return new Promise(async () => {
-              await Promise.all([
-                copyIfExists(source, destination),
-                copyIfExists(source, defaultDestination)
-              ]);
-            });
-          } else {
-            return copyIfExists(source, destination);
-          }
+          return copyIfExists(source, destination);
         })
       );
 
@@ -765,32 +894,22 @@ class Builder {
           const destination = path.join(
             assetOutputDirectory,
             withBasePath(
-              path.join("static-pages", buildId, localePrefixedPageFilePath)
+              path.join(
+                "static-pages",
+                buildId,
+                defaultLocale && defaultLocale === locale
+                  ? pageFilePath
+                  : localePrefixedPageFilePath
+              )
             )
           );
 
-          if (defaultLocale && defaultLocale === locale) {
-            // If this is default locale, we need to copy to two destinations
-            // the locale-prefixed path and non-locale-prefixed path
-            const defaultDestination = path.join(
-              assetOutputDirectory,
-              withBasePath(path.join("static-pages", buildId, pageFilePath))
-            );
-
-            return new Promise(async () => {
-              await Promise.all([
-                copyIfExists(source, destination),
-                copyIfExists(source, defaultDestination)
-              ]);
-            });
-          } else {
-            return copyIfExists(source, destination);
-          }
+          return copyIfExists(source, destination);
         })
       );
 
       fallbackHTMLPageAssets.concat(
-        Object.values(prerenderManifest.dynamicRoutes || {})
+        Object.values(prerenderManifest.dynamicRoutes ?? {})
           .filter(({ fallback }) => {
             return !!fallback;
           })
@@ -806,27 +925,17 @@ class Builder {
             const destination = path.join(
               assetOutputDirectory,
               withBasePath(
-                path.join("static-pages", buildId, localePrefixedFallback)
+                path.join(
+                  "static-pages",
+                  buildId,
+                  defaultLocale && defaultLocale === locale
+                    ? fallback
+                    : localePrefixedFallback
+                )
               )
             );
 
-            if (defaultLocale && defaultLocale === locale) {
-              // If this is default locale, we need to copy to two destinations
-              // the locale-prefixed path and non-locale-prefixed path
-              const defaultDestination = path.join(
-                assetOutputDirectory,
-                withBasePath(path.join("static-pages", buildId, fallback))
-              );
-
-              return new Promise(async () => {
-                await Promise.all([
-                  copyIfExists(source, destination),
-                  copyIfExists(source, defaultDestination)
-                ]);
-              });
-            } else {
-              return copyIfExists(source, destination);
-            }
+            return copyIfExists(source, destination);
           })
       );
     }
@@ -927,11 +1036,21 @@ class Builder {
       await restoreUserConfig();
     }
 
+    const routesManifest = require(join(
+      this.dotNextDir,
+      "routes-manifest.json"
+    ));
+
+    const prerenderManifest = require(join(
+      this.dotNextDir,
+      "prerender-manifest.json"
+    ));
+
     const {
       defaultBuildManifest,
       apiBuildManifest,
       imageBuildManifest
-    } = await this.prepareBuildManifests();
+    } = await this.prepareBuildManifests(routesManifest, prerenderManifest);
 
     await this.buildDefaultLambda(defaultBuildManifest);
 
@@ -953,10 +1072,6 @@ class Builder {
     }
 
     // Copy static assets to .serverless_nextjs directory
-    const routesManifest = require(join(
-      this.dotNextDir,
-      "routes-manifest.json"
-    ));
     await this.buildStaticAssets(defaultBuildManifest, routesManifest);
   }
 

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -331,7 +331,7 @@ const handleOriginRequest = async ({
   }
 
   const isStaticPage = pages.html.nonDynamic[uri]; // plain page without any props
-  const isPrerenderedPage = prerenderManifest.routes[uri]; // prerendered pages are also static pages like "pages.html" above, but are defined in the prerender-manifest
+  const isPrerenderedPage = pages.ssg.nonDynamic[uri]; // prerendered/SSG pages are also static pages like "pages.html" above
   const origin = request.origin as CloudFrontOrigin;
   const s3Origin = origin.s3 as CloudFrontS3Origin;
   const isHTMLPage = isStaticPage || isPrerenderedPage;
@@ -373,7 +373,7 @@ const handleOriginRequest = async ({
         request.uri = pagePath.replace("pages", "");
       } else if (
         pagePath === "pages/_error.js" ||
-        (!prerenderManifest.routes[normalisedDataRequestUri] &&
+        (!pages.ssg.nonDynamic[normalisedDataRequestUri] &&
           !hasFallbackForUri(
             normalisedDataRequestUri,
             prerenderManifest,
@@ -611,7 +611,7 @@ const hasFallbackForUri = (
   manifest: OriginRequestDefaultHandlerManifest
 ) => {
   const {
-    pages: { ssr, html }
+    pages: { ssr, html, ssg }
   } = manifest;
   // Non-dynamic routes are prioritized over dynamic fallbacks, return false to ensure those get rendered instead
   if (ssr.nonDynamic[uri] || html.nonDynamic[uri]) {
@@ -641,19 +641,18 @@ const hasFallbackForUri = (
 
     // If any dynamic route matches, check that this isn't one of the fallback routes in prerender manifest
     if (matchesRegex) {
-      const matchesFallbackRoute = Object.keys(
-        prerenderManifest.dynamicRoutes
-      ).find((prerenderManifestRoute) => {
-        const fileMatchesPrerenderRoute =
-          dynamicRoute.file === `pages${prerenderManifestRoute}.js`;
+      const matchesFallbackRoute = Object.keys(ssg.dynamic).find(
+        (dynamicSsgRoute) => {
+          const fileMatchesPrerenderRoute =
+            dynamicRoute.file === `pages${dynamicSsgRoute}.js`;
 
-        if (fileMatchesPrerenderRoute) {
-          foundFallback =
-            prerenderManifest.dynamicRoutes[prerenderManifestRoute];
+          if (fileMatchesPrerenderRoute) {
+            foundFallback = ssg.dynamic[dynamicSsgRoute];
+          }
+
+          return fileMatchesPrerenderRoute;
         }
-
-        return fileMatchesPrerenderRoute;
-      });
+      );
 
       return !matchesFallbackRoute;
     } else {
@@ -671,7 +670,7 @@ const hasFallbackForUri = (
   }
 
   // Otherwise, try to match fallback against dynamic routes in prerender manifest
-  return Object.values(prerenderManifest.dynamicRoutes).find((routeConfig) => {
+  return Object.values(ssg.dynamic).find((routeConfig) => {
     const re = new RegExp(routeConfig.routeRegex);
     return re.test(uri);
   });

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -621,7 +621,7 @@ const hasFallbackForUri = (
   let foundFallback:
     | {
         routeRegex: string;
-        fallback: string | false;
+        fallback: string | false | null;
         dataRoute: string;
         dataRouteRegex: string;
       }

--- a/packages/libs/lambda-at-edge/src/types.ts
+++ b/packages/libs/lambda-at-edge/src/types.ts
@@ -3,6 +3,7 @@ import type {
   CloudFrontEvent,
   CloudFrontResponse
 } from "aws-lambda";
+import { DynamicSsgRoute, SsgRoute } from "next/dist/build";
 
 export type DynamicPageKeyValue = {
   [key: string]: {
@@ -57,6 +58,14 @@ export type OriginRequestDefaultHandlerManifest = {
         [path: string]: string;
       };
       dynamic: DynamicPageKeyValue;
+    };
+    ssg: {
+      nonDynamic: {
+        [path: string]: SsgRoute;
+      };
+      dynamic: {
+        [path: string]: DynamicSsgRoute;
+      };
     };
   };
   publicFiles: {

--- a/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
@@ -36,7 +36,7 @@ describe("Builder Tests (with locales)", () => {
   afterEach(() => {
     fseEmptyDirSpy.mockRestore();
     fseRemoveSpy.mockRestore();
-    //return cleanupDir(outputDir);
+    return cleanupDir(outputDir);
   });
 
   describe("Cleanup", () => {
@@ -96,6 +96,26 @@ describe("Builder Tests (with locales)", () => {
         "/customers/:catchAll*": {
           file: "pages/customers/[...catchAll].js",
           regex: expect.any(String)
+        },
+        "/nl/:root": {
+          file: "pages/[root].js",
+          regex: expect.any(String)
+        },
+        "/nl/customers/:catchAll*": {
+          file: "pages/customers/[...catchAll].js",
+          regex: expect.any(String)
+        },
+        "/nl/customers/:customer": {
+          file: "pages/customers/[customer].js",
+          regex: expect.any(String)
+        },
+        "/nl/customers/:customer/:post": {
+          file: "pages/customers/[customer]/[post].js",
+          regex: expect.any(String)
+        },
+        "/nl/customers/:customer/profile": {
+          file: "pages/customers/[customer]/profile.js",
+          regex: expect.any(String)
         }
       });
 
@@ -103,7 +123,11 @@ describe("Builder Tests (with locales)", () => {
         "/customers/new": "pages/customers/new.js",
         "/": "pages/index.js",
         "/_app": "pages/_app.js",
-        "/_document": "pages/_document.js"
+        "/_document": "pages/_document.js",
+        "/nl": "pages/index.js",
+        "/nl/_app": "pages/_app.js",
+        "/nl/_document": "pages/_document.js",
+        "/nl/customers/new": "pages/customers/new.js"
       });
 
       expect(html).toEqual({
@@ -191,38 +215,12 @@ describe("Builder Tests (with locales)", () => {
 
   describe("Assets", () => {
     it("copies locale-specific asset files", async () => {
-      expect.assertions(11);
+      expect.assertions(7);
       // Root
       const nextDataFiles = await fse.readdir(
         join(outputDir, `${ASSETS_DIR}/_next/data/test-build-id`)
       );
-      expect(nextDataFiles).toEqual(["contact.json", "en", "index.json", "nl"]);
-
-      // English
-      const enNextDataFiles = await fse.readdir(
-        join(outputDir, `${ASSETS_DIR}/_next/data/test-build-id/en`)
-      );
-      expect(enNextDataFiles).toEqual(["contact.json", "index.json"]);
-
-      const enIndexJson = await fse.readFile(
-        join(outputDir, `${ASSETS_DIR}/_next/data/test-build-id/en/index.json`),
-        "utf8"
-      );
-      expect(enIndexJson).toBe('"en"');
-
-      const enPageFiles = await fse.readdir(
-        join(outputDir, `${ASSETS_DIR}/static-pages/test-build-id/en`)
-      );
-      expect(enPageFiles).toEqual(["contact.html", "index.html"]);
-
-      const enIndexHtml = await fse.readFile(
-        join(
-          outputDir,
-          `${ASSETS_DIR}/static-pages/test-build-id/en/index.html`
-        ),
-        "utf8"
-      );
-      expect(enIndexHtml).toBe("en");
+      expect(nextDataFiles).toEqual(["contact.json", "index.json", "nl"]);
 
       // Dutch
       const nlNextDataFiles = await fse.readdir(
@@ -250,7 +248,7 @@ describe("Builder Tests (with locales)", () => {
       );
       expect(nlIndexHtml).toBe("nl");
 
-      // Default locale: English
+      // Default locale: English. Note it is not generated in /en/ directory
       const defaultIndexJson = await fse.readFile(
         join(outputDir, `${ASSETS_DIR}/_next/data/test-build-id/index.json`),
         "utf8"

--- a/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-no-api/.next/prerender-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-no-api/.next/prerender-manifest.json
@@ -11,5 +11,6 @@
       "srcRoute": null,
       "dataRoute": "/_next/data/zsWqBqLjpgRmswfQomanp/contact.json"
     }
-  }
+  },
+  "dynamicRoutes": {}
 }

--- a/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-with-locales/.next/prerender-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-with-locales/.next/prerender-manifest.json
@@ -11,5 +11,6 @@
       "srcRoute": null,
       "dataRoute": "/_next/data/test-build-id/contact.json"
     }
-  }
+  },
+  "dynamicRoutes": {}
 }

--- a/packages/libs/lambda-at-edge/tests/build/simple-app-fixture/.next/prerender-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/build/simple-app-fixture/.next/prerender-manifest.json
@@ -11,5 +11,6 @@
       "srcRoute": null,
       "dataRoute": "/_next/data/zsWqBqLjpgRmswfQomanp/contact.json"
     }
-  }
+  },
+  "dynamicRoutes": {}
 }

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-404.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-404.json
@@ -57,6 +57,39 @@
           "regex": "^/([^/]+?)/([^/]+?)(?:/)?$"
         }
       }
+    },
+    "ssg": {
+      "nonDynamic": {
+        "/": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null,
+          "dataRoute": "/_next/data/test-build-id/index.json"
+        },
+        "/tests/prerender-manifest/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/tests/prerender-manifest/[staticPageName]",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest/example-static-page.json"
+        },
+        "/preview": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null,
+          "dataRoute": "/_next/data/build-id/preview.json"
+        }
+      },
+      "dynamic": {
+        "/tests/prerender-manifest/[staticPageName]": {
+          "routeRegex": "^/tests/prerender-manifest/(?:([^/]+?))/?$",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest/[staticPageName].json",
+          "fallback": false,
+          "dataRouteRegex": "^/_next/data/test-build-id/tests/prerender-manifest/(?:([^/]+?)).json/?$"
+        },
+        "/tests/prerender-manifest-fallback/[fallback]": {
+          "routeRegex": "^/tests/prerender-manifest-fallback/(?:([^/]+?))/?$",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest-fallback/[staticPageName].json",
+          "fallback": "/tests/prerender-manifest-fallback/[fallback].html",
+          "dataRouteRegex": "^/_next/data/test-build-id/tests/prerender-manifest-fallback/(?:([^/]+?)).json/?$"
+        }
+      }
     }
   },
   "publicFiles": {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-basic-auth.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-basic-auth.json
@@ -57,6 +57,39 @@
           "regex": "^/([^/]+?)/([^/]+?)(?:/)?$"
         }
       }
+    },
+    "ssg": {
+      "nonDynamic": {
+        "/": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null,
+          "dataRoute": "/_next/data/test-build-id/index.json"
+        },
+        "/tests/prerender-manifest/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/tests/prerender-manifest/[staticPageName]",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest/example-static-page.json"
+        },
+        "/preview": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null,
+          "dataRoute": "/_next/data/build-id/preview.json"
+        }
+      },
+      "dynamic": {
+        "/tests/prerender-manifest/[staticPageName]": {
+          "routeRegex": "^/tests/prerender-manifest/(?:([^/]+?))/?$",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest/[staticPageName].json",
+          "fallback": false,
+          "dataRouteRegex": "^/_next/data/test-build-id/tests/prerender-manifest/(?:([^/]+?)).json/?$"
+        },
+        "/tests/prerender-manifest-fallback/[fallback]": {
+          "routeRegex": "^/tests/prerender-manifest-fallback/(?:([^/]+?))/?$",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest-fallback/[staticPageName].json",
+          "fallback": "/tests/prerender-manifest-fallback/[fallback].html",
+          "dataRouteRegex": "^/_next/data/test-build-id/tests/prerender-manifest-fallback/(?:([^/]+?)).json/?$"
+        }
+      }
     }
   },
   "publicFiles": {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-trailing-slash.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-trailing-slash.json
@@ -67,6 +67,39 @@
           "regex": "^/([^/]+?)/([^/]+?)(?:/)?$"
         }
       }
+    },
+    "ssg": {
+      "nonDynamic": {
+        "/": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null,
+          "dataRoute": "/_next/data/test-build-id/index.json"
+        },
+        "/tests/prerender-manifest/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/tests/prerender-manifest/[staticPageName]",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest/example-static-page.json"
+        },
+        "/preview": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null,
+          "dataRoute": "/_next/data/build-id/preview.json"
+        }
+      },
+      "dynamic": {
+        "/tests/prerender-manifest/[staticPageName]": {
+          "routeRegex": "^/tests/prerender-manifest/(?:([^/]+?))/?$",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest/[staticPageName].json",
+          "fallback": false,
+          "dataRouteRegex": "^/_next/data/test-build-id/tests/prerender-manifest/(?:([^/]+?)).json/?$"
+        },
+        "/tests/prerender-manifest-fallback/[fallback]": {
+          "routeRegex": "^/tests/prerender-manifest-fallback/(?:([^/]+?))/?$",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest-fallback/[staticPageName].json",
+          "fallback": "/tests/prerender-manifest-fallback/[fallback].html",
+          "dataRouteRegex": "^/_next/data/test-build-id/tests/prerender-manifest-fallback/(?:([^/]+?)).json/?$"
+        }
+      }
     }
   },
   "publicFiles": {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest.json
@@ -67,6 +67,39 @@
           "regex": "^/([^/]+?)/([^/]+?)(?:/)?$"
         }
       }
+    },
+    "ssg": {
+      "nonDynamic": {
+        "/": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null,
+          "dataRoute": "/_next/data/test-build-id/index.json"
+        },
+        "/tests/prerender-manifest/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/tests/prerender-manifest/[staticPageName]",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest/example-static-page.json"
+        },
+        "/preview": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null,
+          "dataRoute": "/_next/data/build-id/preview.json"
+        }
+      },
+      "dynamic": {
+        "/tests/prerender-manifest/[staticPageName]": {
+          "routeRegex": "^/tests/prerender-manifest/(?:([^/]+?))/?$",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest/[staticPageName].json",
+          "fallback": false,
+          "dataRouteRegex": "^/_next/data/test-build-id/tests/prerender-manifest/(?:([^/]+?)).json/?$"
+        },
+        "/tests/prerender-manifest-fallback/[fallback]": {
+          "routeRegex": "^/tests/prerender-manifest-fallback/(?:([^/]+?))/?$",
+          "dataRoute": "/_next/data/test-build-id/tests/prerender-manifest-fallback/[staticPageName].json",
+          "fallback": "/tests/prerender-manifest-fallback/[fallback].html",
+          "dataRouteRegex": "^/_next/data/test-build-id/tests/prerender-manifest-fallback/(?:([^/]+?)).json/?$"
+        }
+      }
     }
   },
   "publicFiles": {

--- a/packages/serverless-components/nextjs-component/__tests__/fixtures/basepath-app/.next/prerender-manifest.json
+++ b/packages/serverless-components/nextjs-component/__tests__/fixtures/basepath-app/.next/prerender-manifest.json
@@ -6,5 +6,6 @@
       "srcRoute": null,
       "dataRoute": "/_next/data/zsWqBqLjpgRmswfQomanp/index.json"
     }
-  }
+  },
+  "dynamicRoutes": {}
 }

--- a/packages/serverless-components/nextjs-component/__tests__/fixtures/generic-fixture/.next/prerender-manifest.json
+++ b/packages/serverless-components/nextjs-component/__tests__/fixtures/generic-fixture/.next/prerender-manifest.json
@@ -6,5 +6,6 @@
       "srcRoute": null,
       "dataRoute": "/_next/data/zsWqBqLjpgRmswfQomanp/index.json"
     }
-  }
+  },
+  "dynamicRoutes": {}
 }

--- a/packages/serverless-components/nextjs-component/__tests__/fixtures/simple-app/.next/prerender-manifest.json
+++ b/packages/serverless-components/nextjs-component/__tests__/fixtures/simple-app/.next/prerender-manifest.json
@@ -6,5 +6,6 @@
       "srcRoute": null,
       "dataRoute": "/_next/data/zsWqBqLjpgRmswfQomanp/index.json"
     }
-  }
+  },
+  "dynamicRoutes": {}
 }

--- a/packages/serverless-components/nextjs-component/__tests__/fixtures/split-app/nextConfigDir/.next/prerender-manifest.json
+++ b/packages/serverless-components/nextjs-component/__tests__/fixtures/split-app/nextConfigDir/.next/prerender-manifest.json
@@ -6,5 +6,6 @@
       "srcRoute": null,
       "dataRoute": "/_next/data/zsWqBqLjpgRmswfQomanp/index.json"
     }
-  }
+  },
+  "dynamicRoutes": {}
 }


### PR DESCRIPTION
…pages

* Continuation of: https://github.com/serverless-nextjs/serverless-next.js/issues/721
* Subpath routing only per https://nextjs.org/docs/advanced-features/i18n-routing
* Also minor fixes to typo in unit test & not needing to copy default locale to a locale-prefixed path
* TODO: Accept-Language support (https://nextjs.org/docs/advanced-features/i18n-routing#automatic-locale-detection)
* TODO: test and add e2e tests in next PR