### PR TITLE
docs: adds the build arg to Builder in CDK docs

### DIFF
--- a/documentation/docs/cdkconstruct.md
+++ b/documentation/docs/cdkconstruct.md
@@ -34,7 +34,7 @@ import { Builder } from "@sls-next/lambda-at-edge";
 import { MyStack } from "./stack";
 
 // Run the serverless builder, this could be done elsewhere in your workflow
-const builder = new Builder(".", "./build");
+const builder = new Builder(".", "./build", {args: ['build']});
 
 builder
   .build()


### PR DESCRIPTION
Some background in @ibrahimcesar's comment [here](https://github.com/serverless-nextjs/serverless-next.js/pull/878#issuecomment-787217436).

When running the builder with the defaults, e.g. `new Builder('.', './build').build()` the process will hang as the builder just runs `next` with no args, which in-turn starts the next dev server. Not sure whether this is intended or something has changed as I don't recall this behavior - high chance I've just forgotten. Either way, this PR just updates the docs to avoid confusion.