### PR TITLE
chore: add AWS default region to e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -115,6 +115,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AT }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ST }}
+          AWS_DEFAULT_REGION: us-east-1
           WAIT_TIMEOUT: 600
           APP_NAME: ${{ matrix.app }}
           CYPRESS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed for testing external rewrites to GitHub API without getting throttled


### PR DESCRIPTION
GH actions recently started using Ubuntu 20 which uses aws cli v2. Without setting region there may be problems, e.g: https://github.com/actions/virtual-environments/issues/2791

Setting region to fix this.