### PR TITLE
chore: downgrade CI workflow to ubuntu-18

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
 
     strategy:
       matrix:


### PR DESCRIPTION
Due to some flakiness in yarn internal package installation, seems ubuntu-latest (ubuntu 20) may not be stable yet?