### PR TITLE
fix(lambda-at-edge): remove blacklisted CloudFront headers before ret…

### DIFF
--- a/packages/libs/lambda-at-edge/src/api-handler.ts
+++ b/packages/libs/lambda-at-edge/src/api-handler.ts
@@ -23,6 +23,7 @@ import { addHeadersToResponse } from "./headers/addHeaders";
 import { getUnauthenticatedResponse } from "./auth/authenticator";
 import lambdaAtEdgeCompat from "@sls-next/next-aws-cloudfront";
 import { removeLocalePrefixFromUri } from "./routing/locale-utils";
+import { removeBlacklistedHeaders } from "./headers/removeBlacklistedHeaders";
 
 const basePath = RoutesManifestJson.basePath;
 
@@ -168,6 +169,10 @@ export const handler = async (
 
   // Add custom headers before returning response
   addHeadersToResponse(request.uri, response, routesManifest);
+
+  if (response.headers) {
+    removeBlacklistedHeaders(response.headers);
+  }
 
   return response;
 };

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -42,6 +42,7 @@ import {
   isLocalePrefixedUri,
   removeLocalePrefixFromUri
 } from "./routing/locale-utils";
+import { removeBlacklistedHeaders } from "./headers/removeBlacklistedHeaders";
 
 const basePath = RoutesManifestJson.basePath;
 
@@ -246,6 +247,11 @@ export const handler = async (
       response as CloudFrontResultResponse,
       routesManifest
     );
+  }
+
+  // Remove blacklisted headers
+  if (response.headers) {
+    removeBlacklistedHeaders(response.headers);
   }
 
   const tHandlerEnd = now();

--- a/packages/libs/lambda-at-edge/src/headers/removeBlacklistedHeaders.ts
+++ b/packages/libs/lambda-at-edge/src/headers/removeBlacklistedHeaders.ts
@@ -1,0 +1,42 @@
+// Blacklisted or read-only headers in CloudFront
+import { CloudFrontHeaders } from "aws-lambda";
+
+const blacklistedHeaders = [
+  "connection",
+  "expect",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "trailer",
+  "upgrade",
+  "x-accel-buffering",
+  "x-accel-charset",
+  "x-accel-limit-rate",
+  "x-accel-redirect",
+  "x-cache",
+  "x-forwarded-proto",
+  "x-real-ip"
+];
+
+const blacklistedHeaderPrefixes = ["x-amz-cf-", "x-amzn-", "x-edge-"];
+
+export function isBlacklistedHeader(name: string): boolean {
+  const lowerCaseName = name.toLowerCase();
+
+  for (const prefix of blacklistedHeaderPrefixes) {
+    if (lowerCaseName.startsWith(prefix)) {
+      return true;
+    }
+  }
+
+  return blacklistedHeaders.includes(lowerCaseName);
+}
+
+export function removeBlacklistedHeaders(headers: CloudFrontHeaders): void {
+  for (const header in headers) {
+    if (isBlacklistedHeader(header)) {
+      delete headers[header];
+    }
+  }
+}

--- a/packages/libs/lambda-at-edge/src/image-handler.ts
+++ b/packages/libs/lambda-at-edge/src/image-handler.ts
@@ -19,6 +19,7 @@ import {
   getDomainRedirectPath
 } from "./routing/redirector";
 import { getUnauthenticatedResponse } from "./auth/authenticator";
+import { removeBlacklistedHeaders } from "./headers/removeBlacklistedHeaders";
 
 const basePath = RoutesManifestJson.basePath;
 
@@ -101,6 +102,10 @@ export const handler = async (
     const response = await responsePromise;
 
     addHeadersToResponse(request.uri, response, routesManifest);
+
+    if (response.headers) {
+      removeBlacklistedHeaders(response.headers);
+    }
 
     return response;
   } else {

--- a/packages/libs/lambda-at-edge/tests/api-handler/api-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/api-handler/api-handler.test.ts
@@ -3,6 +3,7 @@ import { handler } from "../../src/api-handler";
 import { CloudFrontResponseResult } from "next-aws-cloudfront/node_modules/@types/aws-lambda";
 import { runRedirectTestWithHandler } from "../utils/runRedirectTest";
 import { CloudFrontResultResponse } from "aws-lambda";
+import { isBlacklistedHeader } from "../../src/headers/removeBlacklistedHeaders";
 
 jest.mock("node-fetch", () => require("fetch-mock-jest").sandbox());
 
@@ -230,6 +231,11 @@ describe("API lambda handler", () => {
             key: header,
             value: expectedHeaders[header]
           });
+        }
+
+        // Verify no blacklisted headers are present
+        for (const header in response.headers) {
+          expect(isBlacklistedHeader(header)).toBe(false);
         }
       }
     );

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -5,6 +5,7 @@ import {
   CloudFrontOrigin
 } from "aws-lambda";
 import { runRedirectTestWithHandler } from "../utils/runRedirectTest";
+import { isBlacklistedHeader } from "../../src/headers/removeBlacklistedHeaders";
 
 jest.mock("node-fetch", () => require("fetch-mock-jest").sandbox());
 
@@ -363,6 +364,11 @@ describe("Lambda@Edge", () => {
 
           expect(decodedBody).toEqual(expectedPage);
           expect(cfResponse.status).toEqual(200);
+
+          // Verify no blacklisted headers are present
+          for (const header in response.headers) {
+            expect(isBlacklistedHeader(header)).toBe(false);
+          }
         }
       );
 

--- a/packages/libs/lambda-at-edge/tests/shared-fixtures/built-artifact/pages/api/getCustomers.js
+++ b/packages/libs/lambda-at-edge/tests/shared-fixtures/built-artifact/pages/api/getCustomers.js
@@ -1,5 +1,6 @@
 module.exports = {
   default: (req, res) => {
+    res.setHeader("connection", "keep-alive"); // AWS Blacklisted header will be removed
     res.end("pages/api/getCustomers");
   }
 };

--- a/packages/libs/lambda-at-edge/tests/shared-fixtures/built-artifact/pages/customers/index.js
+++ b/packages/libs/lambda-at-edge/tests/shared-fixtures/built-artifact/pages/customers/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   render: (req, res) => {
+    res.setHeader("connection", "keep-alive"); // AWS Blacklisted header will be removed
     res.end("pages/customers/index.js");
   },
   renderReqToHTML: (req, res) => {


### PR DESCRIPTION
…urning api/default/image handler response

Should fix: https://github.com/serverless-nextjs/serverless-next.js/issues/898