### PR TITLE
chore: upload code coverage on node 12.x workflow only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,7 @@ jobs:
       - run: yarn integration
 
       - name: Upload code coverage
+        if: ${{ matrix.node-version == '12.x' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: npx codecov


### PR DESCRIPTION
* 12.x workflow has more coverage and we only need to upload it once