### PR TITLE
fix(s3-static-assets): always use posix path join for fast-glob in re…

### DIFF
--- a/packages/libs/s3-static-assets/src/lib/readDirectoryFiles.ts
+++ b/packages/libs/s3-static-assets/src/lib/readDirectoryFiles.ts
@@ -8,6 +8,7 @@ const readDirectoryFiles = (directory: string): Array<Entry> => {
     return [];
   }
 
+  // fast-glob only accepts posix paths, hence why we don't use path.join, which will cause empty directory list on Windows filesystems.
   return glob.sync(path.posix.join(directory, "**/*"), {
     onlyFiles: true,
     stats: true

--- a/packages/libs/s3-static-assets/src/lib/readDirectoryFiles.ts
+++ b/packages/libs/s3-static-assets/src/lib/readDirectoryFiles.ts
@@ -8,7 +8,7 @@ const readDirectoryFiles = (directory: string): Array<Entry> => {
     return [];
   }
 
-  return glob.sync(path.join(directory, "**/*"), {
+  return glob.sync(path.posix.join(directory, "**/*"), {
     onlyFiles: true,
     stats: true
   });


### PR DESCRIPTION
…adDirectoryFiles

* On windows, `path.join` returns paths separated by backslashes, but `fast-glob` only accepts posix paths.

In the future, we should run at least the unit tests on Windows workflow to ensure it doesn't break.

Should fix: https://github.com/serverless-nextjs/serverless-next.js/issues/932