### PR TITLE
fix(lambda-at-edge): do not follow redirect in fetch during rewrite

### DIFF
--- a/packages/libs/lambda-at-edge/src/routing/rewriter.ts
+++ b/packages/libs/lambda-at-edge/src/routing/rewriter.ts
@@ -135,13 +135,15 @@ export async function createExternalRewriteResponse(
       headers: reqHeaders,
       method: req.method,
       body: decodedBody, // Must pass body as a string,
-      compress: false
+      compress: false,
+      redirect: "manual"
     });
   } else {
     fetchResponse = await fetch(customRewrite, {
       headers: reqHeaders,
       method: req.method,
-      compress: false
+      compress: false,
+      redirect: "manual"
     });
   }
 


### PR DESCRIPTION
Next.js doesn't follow redirect during a rewrite, so we should be in sync with it.

Fixes https://github.com/serverless-nextjs/serverless-next.js/issues/929