### PR TITLE
Add baseDir from #779 to component to facilitate usage in monorepos

### DIFF
--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -195,6 +195,13 @@ class NextjsComponent extends Component {
         ? nextConfigPath
         : resolve(inputs.build.cwd);
 
+    const buildBaseDir =
+      typeof inputs.build === "boolean" ||
+      typeof inputs.build === "undefined" ||
+      !inputs.build.baseDir
+        ? nextConfigPath
+        : resolve(inputs.build.baseDir);
+
     const buildConfig: BuildOptions = {
       enabled: inputs.build
         ? // @ts-ignore
@@ -203,7 +210,8 @@ class NextjsComponent extends Component {
       cmd: "node_modules/.bin/next",
       args: ["build"],
       ...(typeof inputs.build === "object" ? inputs.build : {}),
-      cwd: buildCwd
+      cwd: buildCwd,
+      baseDir: buildBaseDir
     };
 
     if (buildConfig.enabled) {
@@ -223,7 +231,8 @@ class NextjsComponent extends Component {
           handler: inputs.handler
             ? `${inputs.handler.split(".")[0]}.js`
             : undefined,
-          authentication: inputs.authentication ?? undefined
+          authentication: inputs.authentication ?? undefined,
+          baseDir: buildConfig.baseDir
         },
         nextStaticPath
       );

--- a/packages/serverless-components/nextjs-component/types.d.ts
+++ b/packages/serverless-components/nextjs-component/types.d.ts
@@ -48,6 +48,7 @@ export type BuildOptions = {
   args: string[];
   env?: Record<string, string>;
   postBuildCommands?: string[];
+  baseDir?: string;
 };
 
 export type LambdaType = "defaultLambda" | "apiLambda" | "imageLambda";


### PR DESCRIPTION
As mentioned in the PR #779 , baseDir wasn't included for the component, so I've added it here.

Without it, I was unable to run the deployed web-app on the server

Scenario for how I used this:
- Using yarn workspaces and lerna
- The next.js-project is inside `<root>/packages/my-web-app`
- Dependencies are hoisted to `<root>/node_modules`, this includes next, serverless-next.js, @material-ui, et.c.
- The serverless.yml is located at `<root>/packages/my-web-app/serverless.yml`

**`serverless.yml`**:

```yml
"@my-company/my-web-app":
  component: "../../node_modules/@sls-next/serverless-component"
  inputs:
    build:
      baseDir: "../../"
    useServerlessTraceTarget: true
```

The web-app is now successfully deployed and it's able to resolve its dependencies once again.

I tracked down the issue to [nft's `base` behavior](https://www.npmjs.com/package/@vercel/nft#base), which states that anything above `process.cwd()` will be ignored. Setting the baseDir in Builder fixes this.