### PR TITLE
fixes: #943 give access to underlying resources and enable custom s3 props

### DIFF
--- a/documentation/docs/cdkconstruct.md
+++ b/documentation/docs/cdkconstruct.md
@@ -88,6 +88,7 @@ new NextJSLambdaEdge(this, "NextJsApp", {
 - `runtime?: lambda.Runtime | Record<string, lambda.Runtime>` - configure the runtime of all lambdas
   or individually.
 - `withLogging?: boolean` - set debug logging on the lambda.
+- `s3Props?: Partial<BucketProps>` - pass custom s3 props
 - `whiteListedCookies?: string[]` - provide a list of cookies to forward to the
   CloudFront origin.
 - `defaultBehavior?: Partial<cloudfront.Behaviour>` - provide overrides for the

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -2,6 +2,7 @@ import { ICertificate } from "@aws-cdk/aws-certificatemanager";
 import { BehaviorOptions } from "@aws-cdk/aws-cloudfront";
 import { Runtime } from "@aws-cdk/aws-lambda";
 import { IHostedZone } from "@aws-cdk/aws-route53";
+import { BucketProps } from "@aws-cdk/aws-s3";
 import { Duration, StackProps } from "@aws-cdk/core";
 
 export type LambdaOption<T> =
@@ -24,6 +25,10 @@ export interface Props extends StackProps {
     certificate: ICertificate;
     domainName: string;
   };
+  /**
+   * Override props passed to the underlying s3 bucket
+   */
+  s3Props?: Partial<BucketProps>;
   /**
    * Lambda memory limit(s)
    */


### PR DESCRIPTION
It's quite often the case that you need to access the underlying resources, for example, to update their roles or to read their configuration to pass into another resource. This PR exposes all created resources as properties on the construct. It also allows users to pass in custom S3 configuration.