### PR TITLE
Remove comment from "lambda:DeleteFunction"

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ The exhaustive list of AWS actions required for a deployment:
   "iam:PassRole",
   "lambda:CreateFunction",
   "lambda:EnableReplication",
-  "lambda:DeleteFunction",            // only for custom domains
+  "lambda:DeleteFunction",
   "lambda:GetFunction",
   "lambda:GetFunctionConfiguration",
   "lambda:PublishVersion",


### PR DESCRIPTION
In attempt to deploy serverless-nextjs without the use of custom domains, this permission is still required or an error message like this comes up:

AccessDeniedException: User: arn:aws:sts::***:assumed-role/myRole/Role is not authorized to perform: lambda:DeleteFunction