### PR TITLE
fix(README): remove s3:HeadBucket permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,6 @@ The exhaustive list of AWS actions required for a deployment:
   "s3:CreateBucket",
   "s3:GetAccelerateConfiguration",
   "s3:GetObject",                     // only if persisting state to S3 for CI/CD
-  "s3:HeadBucket",
   "s3:ListBucket",
   "s3:PutAccelerateConfiguration",
   "s3:PutBucketPolicy",


### PR DESCRIPTION
Hey,

While creating the AWS policy I found a small error in the README.

```
Invalid Action: The action s3:HeadBucket does not exist.
Did you mean s3:ListBucket? The API called HeadBucket authorizes against the IAM action s3:ListBucket
```

Here is the aws [doc](https://docs.aws.amazon.com/en_us/AmazonS3/latest/API/API_HeadBucket.html) regarding `HeadBucket`.

> To use this operation, you must have permissions to perform the `s3:ListBucket` action. 

Thank you for this amazing project !
 