### PR TITLE
fix(lambda-at-edge): ensure dist/sharp_node_modules empty before copying

### DIFF
--- a/packages/libs/lambda-at-edge/scripts/copy-sharp-modules.ts
+++ b/packages/libs/lambda-at-edge/scripts/copy-sharp-modules.ts
@@ -1,6 +1,9 @@
 import fse from "fs-extra";
 import { join } from "path";
 
+// Ensure old contents empty before copying
+fse.emptyDirSync(join(process.cwd(), "dist", "sharp_node_modules"));
+
 // Copy sharp node_modules to the dist directory
 fse.copySync(
   join(process.cwd(), "sharp_node_modules"),


### PR DESCRIPTION
Fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/979 - seems this directory was growing indefinitely with each publish from my machine without this fix, it was not caught in e2e tests since that doesn't deploy from a published package, but instead builds locally from scratch (so dist/sharp_node_modules would not exist on each CI run).

Will likely deprecate last few versions which may cause this issue (and unnecessarily use Lambda space)