### PR TITLE
fix(s3-static-assets): fix s3 directory read for fast-glob on windows

### DIFF
--- a/packages/libs/s3-static-assets/src/lib/readDirectoryFiles.ts
+++ b/packages/libs/s3-static-assets/src/lib/readDirectoryFiles.ts
@@ -12,6 +12,12 @@ const readDirectoryFiles = (directory: string): Array<Entry> => {
   // we need to split directory by separator and use path.posix.join specifically to rejoin it
   // this should enable it to work on windows
   const directorySplit = directory.split(path.sep);
+
+  // Ensure absolute path is preserved
+  if (directorySplit.length > 0 && directorySplit[0] === "") {
+    directorySplit[0] = "/";
+  }
+
   return glob.sync(path.posix.join(...directorySplit, "**", "*"), {
     onlyFiles: true,
     stats: true

--- a/packages/libs/s3-static-assets/src/lib/readDirectoryFiles.ts
+++ b/packages/libs/s3-static-assets/src/lib/readDirectoryFiles.ts
@@ -8,8 +8,11 @@ const readDirectoryFiles = (directory: string): Array<Entry> => {
     return [];
   }
 
-  // fast-glob only accepts posix paths, hence why we don't use path.join, which will cause empty directory list on Windows filesystems.
-  return glob.sync(path.posix.join(directory, "**/*"), {
+  // fast-glob only accepts posix paths
+  // we need to split directory by separator and use path.posix.join specifically to rejoin it
+  // this should enable it to work on windows
+  const directorySplit = directory.split(path.sep);
+  return glob.sync(path.posix.join(...directorySplit, "**", "*"), {
     onlyFiles: true,
     stats: true
   });


### PR DESCRIPTION
Hopefully fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/932

It looks like if `directory` was not properly split out by separator, even using `path.posix.join` would not join properly. For example if directory is `C:\test`, then `path.posix.join("C:\test", "**/*")` would result in `C:\test/**/*`. So we need to first remove the separator (either windows or posix separator) before joining.

This will result in a join of `path.posix.join("C:", "test", "**", "*")` which results in `C:/test/**/*` correctly.

I haven't tested on windows due to not having a local machine to test, but tested based on simulating windows paths and `split(path.win32.sep)`, it seems this should work.