### PR TITLE
Deploy flag as string

### DIFF
--- a/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
@@ -1053,34 +1053,37 @@ describe("Custom inputs", () => {
     });
   });
 
-  describe("Skip deployment after build", () => {
-    const fixturePath = path.join(__dirname, "./fixtures/simple-app");
-    let tmpCwd: string;
+  describe.each([false, "false"])(
+    "Skip deployment after build",
+    (deployInput) => {
+      const fixturePath = path.join(__dirname, "./fixtures/simple-app");
+      let tmpCwd: string;
 
-    beforeEach(async () => {
-      tmpCwd = process.cwd();
-      process.chdir(fixturePath);
+      beforeEach(async () => {
+        tmpCwd = process.cwd();
+        process.chdir(fixturePath);
 
-      mockServerlessComponentDependencies({ expectedDomain: undefined });
-    });
-
-    afterEach(() => {
-      process.chdir(tmpCwd);
-      return cleanupFixtureDirectory(fixturePath);
-    });
-
-    it("builds but skips deployment", async () => {
-      const result = await createNextComponent().default({
-        deploy: false
+        mockServerlessComponentDependencies({ expectedDomain: undefined });
       });
 
-      expect(result).toEqual({
-        appUrl: "SKIPPED_DEPLOY",
-        bucketName: "SKIPPED_DEPLOY",
-        distributionId: "SKIPPED_DEPLOY"
+      afterEach(() => {
+        process.chdir(tmpCwd);
+        return cleanupFixtureDirectory(fixturePath);
       });
-    });
-  });
+
+      it("builds but skips deployment", async () => {
+        const result = await createNextComponent().default({
+          deploy: deployInput
+        });
+
+        expect(result).toEqual({
+          appUrl: "SKIPPED_DEPLOY",
+          bucketName: "SKIPPED_DEPLOY",
+          distributionId: "SKIPPED_DEPLOY"
+        });
+      });
+    }
+  );
 
   describe.each([
     [undefined, "index.handler"],

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -262,7 +262,7 @@ class NextjsComponent extends Component {
   ): Promise<DeploymentResult> {
     // Skip deployment if user explicitly set deploy input to false.
     // Useful when they just want the build outputs to deploy themselves.
-    if (inputs.deploy === false) {
+    if (inputs.deploy === "false" || inputs.deploy === false) {
       return {
         appUrl: SKIPPED_DEPLOY,
         bucketName: SKIPPED_DEPLOY,

--- a/packages/serverless-components/nextjs-component/types.d.ts
+++ b/packages/serverless-components/nextjs-component/types.d.ts
@@ -31,7 +31,7 @@ export type ServerlessComponentInputs = {
   cloudfront?: CloudfrontOptions;
   minifyHandlers?: boolean;
   uploadStaticAssetsFromBuild?: boolean;
-  deploy?: boolean;
+  deploy?: boolean | string;
   enableHTTPCompression?: boolean;
   authentication?: { username: string; password: string };
   imageOptimizer?: boolean;


### PR DESCRIPTION
This is to enable setting the deployment flag from an environment variable, as all values passed from`process.env` are strings  .