### PR TITLE
feat: adding support for multiple domainNames

### DIFF
--- a/packages/serverless-components/nextjs-cdk-construct/__tests__/construct.test.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/__tests__/construct.test.ts
@@ -134,7 +134,7 @@ describe("CDK Construct", () => {
       serverlessBuildOutDir: path.join(__dirname, "fixtures/next-boilerplate"),
       domain: {
         certificate,
-        domainName,
+        domainNames: [domainName],
         hostedZone
       }
     });

--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -236,7 +236,7 @@ export class NextJSLambdaEdge extends cdk.Construct {
       {
         enableLogging: props.withLogging ? true : undefined,
         certificate: props.domain?.certificate,
-        domainNames: props.domain ? [props.domain.domainName] : undefined,
+        domainNames: props.domain ? props.domain.domainNames : undefined,
         defaultRootObject: "",
         defaultBehavior: {
           viewerProtocolPolicy:
@@ -375,10 +375,14 @@ export class NextJSLambdaEdge extends cdk.Construct {
     });
 
     if (props.domain) {
-      this.aRecord = new ARecord(this, "AliasRecord", {
-        recordName: props.domain.domainName,
-        zone: props.domain.hostedZone,
-        target: RecordTarget.fromAlias(new CloudFrontTarget(this.distribution))
+      props.domain.domainNames.forEach((domainName) => {
+        this.aRecord = new ARecord(this, "AliasRecord", {
+          recordName: domainName,
+          zone: props.domain.hostedZone,
+          target: RecordTarget.fromAlias(
+            new CloudFrontTarget(this.distribution)
+          )
+        });
       });
     }
   }

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -18,12 +18,12 @@ export interface Props extends StackProps {
   serverlessBuildOutDir: string;
   /**
    * Is you'd like a custom domain for your site, you'll need to pass in a
-   * `hostedZone`, `certificate` and full `domainName`
+   * `hostedZone`, `certificate` and a list of full `domainNames`
    */
   domain?: {
     hostedZone: IHostedZone;
     certificate: ICertificate;
-    domainName: string;
+    domainNames: string[];
   };
   /**
    * Override props passed to the underlying s3 bucket


### PR DESCRIPTION
The problem: 
Not having possibility to use multiple domainNames in the app.

Case:
We are developing an app using this lib, and we want the possibility to have `www.` in our url.

Temporary solution: 
To solve this problem now, we manually updated cloudfront to accept the same url with `www.` on it and then created the route53 record for that.

Final solution: 
The lib having a way to do that by it self, so I changed the `domainName` prop to `domainNames` which is an array of strings ( Cloud front accept that ) and looped this array to create all the route53 records for the given domain list. 
