### PR TITLE
fix: unique construct id for each domain name

### DIFF
--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -375,8 +375,8 @@ export class NextJSLambdaEdge extends cdk.Construct {
     });
 
     if (props.domain) {
-      props.domain.domainNames.forEach((domainName) => {
-        this.aRecord = new ARecord(this, "AliasRecord", {
+      props.domain.domainNames.forEach((domainName, index) => {
+        this.aRecord = new ARecord(this, `AliasRecord_${index}`, {
           recordName: domainName,
           zone: props.domain!.hostedZone, // not sure why ! is needed here
           target: RecordTarget.fromAlias(


### PR DESCRIPTION
The problem:
My last pull request, https://github.com/serverless-nextjs/serverless-next.js/pull/1009, for adding support for multiple domains in the app, has a problem that I missed to handle.
When creating more than one Domain nome for the app, it loops through the domain name list and create one Route53 Record for each, the problem is that I forgot to make it generate different id's for each item of the list, so when we have more than one item it's going to fail the deploy with the fowling error:
```
Error: There is already a Construct with name 'AliasRecord' in NextJSLambdaEdge [AppName]
    at Node.addChild (.../node_modules/constructs/src/construct.ts:534:13)
    at new Node (.../node_modules/constructs/src/construct.ts:75:22)
    at new ConstructNode (.../node_modules/@aws-cdk/core/lib/construct-compat.ts:277:24)
    at Object.createNode (.../node_modules/@aws-cdk/core/lib/construct-compat.ts:71:11)
    at new Construct (.../node_modules/constructs/src/construct.ts:575:26)
    at new Construct (.../node_modules/@aws-cdk/core/lib/construct-compat.ts:68:5)
    at new Resource (.../node_modules/@aws-cdk/core/lib/resource.ts:139:5)
    at new RecordSet (.../node_modules/@aws-cdk/aws-route53/lib/record-set.ts:213:5)
    at new ARecord (.../node_modules/@aws-cdk/aws-route53/lib/record-set.ts:256:5)
    at .../node_modules/@sls-next/cdk-construct/src/index.ts:379:24
Subprocess exited with error 1
```

The solution:
While looping the domain name list, use the index of the item to generate each item with it's own id.