### PR TITLE
RFC S3 client revert

### DIFF
--- a/packages/libs/lambda-at-edge/rollup.config.js
+++ b/packages/libs/lambda-at-edge/rollup.config.js
@@ -9,7 +9,8 @@ const LOCAL_EXTERNALS = [
   "./manifest.json",
   "./routes-manifest.json",
   "./prerender-manifest.json",
-  "./images-manifest.json"
+  "./images-manifest.json",
+  "./s3-client.js"
 ];
 const NPM_EXTERNALS = ["aws-lambda", "aws-sdk/clients/s3"];
 

--- a/packages/libs/lambda-at-edge/rollup.config.js
+++ b/packages/libs/lambda-at-edge/rollup.config.js
@@ -47,5 +47,7 @@ export default [
   { filename: "api-handler", minify: false },
   { filename: "api-handler", minify: true },
   { filename: "image-handler", minify: false },
-  { filename: "image-handler", minify: true }
+  { filename: "image-handler", minify: true },
+  { filename: "s3-client", minify: false },
+  { filename: "s3-client", minify: true }
 ].map(generateConfig);

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -230,7 +230,11 @@ class Builder {
    * @param shouldMinify
    */
   async processAndCopyHandler(
-    handlerType: "api-handler" | "default-handler" | "image-handler",
+    handlerType:
+      | "api-handler"
+      | "default-handler"
+      | "image-handler"
+      | "s3-client",
     destination: string,
     shouldMinify: boolean
   ) {
@@ -296,6 +300,11 @@ class Builder {
       this.processAndCopyHandler(
         "default-handler",
         join(this.outputDir, DEFAULT_LAMBDA_CODE_DIR, "index.js"),
+        !!this.buildOptions.minifyHandlers
+      ),
+      this.processAndCopyHandler(
+        "s3-client",
+        join(this.outputDir, DEFAULT_LAMBDA_CODE_DIR, "s3-client.js"),
         !!this.buildOptions.minifyHandlers
       ),
       this.buildOptions?.handler

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -620,7 +620,7 @@ const handleOriginResponse = async ({
   const bucketName = domainName.replace(`.s3.${region}.amazonaws.com`, "");
 
   // Lazily import only S3Client to reduce init times until actually needed
-  const { S3Client } = await import("@aws-sdk/client-s3/S3Client");
+  const { S3Client } = require("./s3-client.js");
 
   const s3 = new S3Client({
     region: request.origin?.s3?.region,
@@ -675,9 +675,7 @@ const handleOriginResponse = async ({
         ContentType: "text/html",
         CacheControl: "public, max-age=0, s-maxage=2678400, must-revalidate"
       };
-      const { PutObjectCommand } = await import(
-        "@aws-sdk/client-s3/commands/PutObjectCommand"
-      );
+      const { PutObjectCommand } = require("./s3-client.js");
       await Promise.all([
         s3.send(new PutObjectCommand(s3JsonParams)),
         s3.send(new PutObjectCommand(s3HtmlParams))
@@ -742,9 +740,7 @@ const handleOriginResponse = async ({
         body: html
       };
     } else {
-      const { GetObjectCommand } = await import(
-        "@aws-sdk/client-s3/commands/GetObjectCommand"
-      );
+      const { GetObjectCommand } = require("./s3-client.js");
       // S3 Body is stream per: https://github.com/aws/aws-sdk-js-v3/issues/1096
       const getStream = await import("get-stream");
 

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -620,7 +620,7 @@ const handleOriginResponse = async ({
   const bucketName = domainName.replace(`.s3.${region}.amazonaws.com`, "");
 
   // Lazily import only S3Client to reduce init times until actually needed
-  const { S3Client } = require("./s3-client.js");
+  const { S3Client } = require("./s3-client");
 
   const s3 = new S3Client({
     region: request.origin?.s3?.region,
@@ -675,7 +675,7 @@ const handleOriginResponse = async ({
         ContentType: "text/html",
         CacheControl: "public, max-age=0, s-maxage=2678400, must-revalidate"
       };
-      const { PutObjectCommand } = require("./s3-client.js");
+      const { PutObjectCommand } = require("./s3-client");
       await Promise.all([
         s3.send(new PutObjectCommand(s3JsonParams)),
         s3.send(new PutObjectCommand(s3HtmlParams))
@@ -740,7 +740,7 @@ const handleOriginResponse = async ({
         body: html
       };
     } else {
-      const { GetObjectCommand } = require("./s3-client.js");
+      const { GetObjectCommand } = require("./s3-client");
       // S3 Body is stream per: https://github.com/aws/aws-sdk-js-v3/issues/1096
       const getStream = await import("get-stream");
 

--- a/packages/libs/lambda-at-edge/src/s3-client.ts
+++ b/packages/libs/lambda-at-edge/src/s3-client.ts
@@ -1,0 +1,9 @@
+import { GetObjectCommand } from "@aws-sdk/client-s3/commands/GetObjectCommand";
+import { PutObjectCommand } from "@aws-sdk/client-s3/commands/PutObjectCommand";
+import { S3Client } from "@aws-sdk/client-s3/S3Client";
+
+module.exports = {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client
+};

--- a/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
@@ -421,7 +421,8 @@ describe("Builder Tests (dynamic)", () => {
         "manifest.json",
         "pages",
         "prerender-manifest.json",
-        "routes-manifest.json"
+        "routes-manifest.json",
+        "s3-client.js"
       ]);
 
       // api pages should not be included in the default lambda

--- a/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
@@ -183,7 +183,8 @@ describe("Builder Tests (no API routes)", () => {
         "manifest.json",
         "pages",
         "prerender-manifest.json",
-        "routes-manifest.json"
+        "routes-manifest.json",
+        "s3-client.js"
       ]);
 
       // api pages should not be included in the default lambda

--- a/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
@@ -267,7 +267,8 @@ describe("Builder Tests (with locales)", () => {
         "manifest.json",
         "pages",
         "prerender-manifest.json",
-        "routes-manifest.json"
+        "routes-manifest.json",
+        "s3-client.js"
       ]);
 
       // api pages should not be included in the default lambda

--- a/packages/libs/lambda-at-edge/tests/build/build.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build.test.ts
@@ -222,7 +222,8 @@ describe("Builder Tests", () => {
           "manifest.json",
           "pages",
           "prerender-manifest.json",
-          "routes-manifest.json"
+          "routes-manifest.json",
+          "s3-client.js"
         ]);
 
         // api pages should not be included in the default lambda
@@ -490,6 +491,7 @@ describe("Builder Tests", () => {
         "pages",
         "prerender-manifest.json",
         "routes-manifest.json",
+        "s3-client.js",
         "testFile.js"
       ]);
 

--- a/packages/libs/lambda-at-edge/tsconfig.build.json
+++ b/packages/libs/lambda-at-edge/tsconfig.build.json
@@ -9,6 +9,7 @@
     "node_modules",
     "./src/api-handler.ts",
     "./src/default-handler.ts",
-    "./src/image-handler.ts"
+    "./src/image-handler.ts",
+    "./src/s3-client.ts"
   ]
 }

--- a/packages/libs/lambda-at-edge/tsconfig.bundle.json
+++ b/packages/libs/lambda-at-edge/tsconfig.bundle.json
@@ -11,5 +11,10 @@
     "allowJs": true,
     "resolveJsonModule": true
   },
-  "include": ["./src/default-handler.ts", "./src/api-handler.ts", "./src/image-handler.ts"]
+  "include": [
+    "./src/default-handler.ts",
+    "./src/api-handler.ts",
+    "./src/image-handler.ts",
+    "./src/s3-client.ts"
+  ]
 }


### PR DESCRIPTION
Looking at the generated lambda, the dynamic S3 client imports do not seem to do anything. The code for them gets bundled up and there's just a wrapper promise in place of the `await import()`.

This is a not-for-merging partial revert of f9eef458 that changes it back to the previous approach. I didn't even fix the tests yet.

There's probably a better way to solve this – I've never used rollup so I didn't try any packaging changes – but this more than halved the default-handler size:

Before:

    636K	default-handler.js
    232K	default-handler.min.js

After:

    288K	default-handler.js
    104K	default-handler.min.js

It seems to have shaved some memory and initialization time off the lambda as well, although that was just based on a few poorly controlled test runs. But I've not measured what happens to fallback response times.