### PR TITLE
Images lambda is not needed with non-default loader

### DIFF
--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -1170,9 +1170,17 @@ class Builder {
     }
 
     // If using Next.j 10, then images-manifest.json is present and image optimizer can be used
-    const hasImageOptimizer = fse.existsSync(
+    const hasImagesManifest = fse.existsSync(
       join(this.dotNextDir, "images-manifest.json")
     );
+
+    // However if using a non-default loader, the lambda is not needed
+    const imagesManifest = hasImagesManifest
+      ? await fse.readJSON(join(this.dotNextDir, "images-manifest.json"))
+      : null;
+    const imageLoader = imagesManifest?.images?.loader;
+    const isDefaultLoader = !imageLoader || imageLoader === "default";
+    const hasImageOptimizer = hasImagesManifest && isDefaultLoader;
 
     if (hasImageOptimizer) {
       await this.buildImageLambda(imageBuildManifest);

--- a/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
@@ -2,7 +2,11 @@ import { join } from "path";
 import fse from "fs-extra";
 import execa from "execa";
 import Builder from "../../src/build";
-import { DEFAULT_LAMBDA_CODE_DIR, API_LAMBDA_CODE_DIR } from "../../src/build";
+import {
+  DEFAULT_LAMBDA_CODE_DIR,
+  API_LAMBDA_CODE_DIR,
+  IMAGE_LAMBDA_CODE_DIR
+} from "../../src/build";
 import { cleanupDir, removeNewLineChars } from "../test-utils";
 import { OriginRequestDefaultHandlerManifest } from "../../src/types";
 
@@ -139,6 +143,18 @@ describe("Builder Tests (no API routes)", () => {
 
       const apiDir = await fse.readdir(
         join(outputDir, `${API_LAMBDA_CODE_DIR}`)
+      );
+
+      expect(apiDir).toEqual([]);
+    });
+  });
+
+  describe("Images Handler", () => {
+    it("has empty images handler directory", async () => {
+      expect.assertions(1);
+
+      const apiDir = await fse.readdir(
+        join(outputDir, `${IMAGE_LAMBDA_CODE_DIR}`)
       );
 
       expect(apiDir).toEqual([]);

--- a/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-no-api/.next/images-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-no-api/.next/images-manifest.json
@@ -4,8 +4,8 @@
     "deviceSizes": [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     "imageSizes": [16, 32, 48, 64, 96, 128, 256, 384],
     "domains": [],
-    "path": "/_next/image",
-    "loader": "default",
+    "path": "https://example.com/",
+    "loader": "imgix",
     "sizes": [
       640,
       750,

--- a/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-no-api/next.config.js
+++ b/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-no-api/next.config.js
@@ -1,1 +1,7 @@
-module.exports = { target: "serverless" };
+module.exports = {
+  target: "serverless",
+  images: {
+    loader: "imgix",
+    path: "https://example.com/"
+  }
+};


### PR DESCRIPTION
With a non-default loader declaration there's no way to use the image lambda from image components, so no need to generate it. 

Would be nice to not need it if `next/image` isn't used, but it doesn't seem like there's a way to tell from the build artifacts.