### PR TITLE
Fix router path in fallback SSG

### DIFF
--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
@@ -147,6 +147,12 @@ describe("Pages Tests", () => {
         cy.visit(path);
         cy.location("pathname").should("eq", path);
         cy.contains(`Hello ${path.slice(-1)}`);
+        cy.request({ url: path }).then((response) => {
+          // Next.js asPath does not include locale prefixes or basepath
+          expect(response.body).to.contain(
+            `|/fallback-blocking/${path.slice(-1)}|`
+          );
+        });
       });
     });
   });

--- a/packages/e2e-tests/next-app-with-locales/pages/fallback-blocking/[slug].tsx
+++ b/packages/e2e-tests/next-app-with-locales/pages/fallback-blocking/[slug].tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { GetStaticProps } from "next";
+import { useRouter } from "next/router";
 
 type DynamicIndexPageProps = {
   slug: string;
@@ -8,11 +9,13 @@ type DynamicIndexPageProps = {
 export default function DynamicIndexPage(
   props: DynamicIndexPageProps
 ): JSX.Element {
+  const router = useRouter();
   return (
     <React.Fragment>
       <div>
         {`Hello ${props.slug}. This is a dynamic SSG page using getStaticProps() with fallback blocking.`}
       </div>
+      <div>{`|${router.asPath}|`}</div>
     </React.Fragment>
   );
 }

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -642,6 +642,13 @@ const handleOriginResponse = async ({
   ) {
     // eslint-disable-next-line
     const page = require(`./${pagePath}`);
+    // Reconstruct original uri for next/router
+    if (uri.endsWith(".html")) {
+      request.uri = uri.slice(0, uri.length - 5);
+      if (manifest.trailingSlash) {
+        request.uri += "/";
+      }
+    }
     const { req, res, responsePromise } = lambdaAtEdgeCompat(
       event.Records[0].cf,
       {


### PR DESCRIPTION
Fixes a bug in #1007 – with fallback: blocking the page render function gets passed the S3 uri with .html which makes the backend router disagree with the front-end about the page path.

This complexity results from the split between request and response lambdas. If they are combined the request object can have the correct uri throughout.