### PR TITLE
perf(lambda-at-edge): fix rollup bundling for dynamic imports perf

### DIFF
--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -51,7 +51,7 @@
     "@types/send": "^0.14.5",
     "@types/sharp": "^0.26.1",
     "fetch-mock-jest": "^1.5.1",
-    "rollup": "^2.26.6",
+    "rollup": "^2.46.0",
     "rollup-plugin-node-externals": "^2.2.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.27.2",

--- a/packages/libs/lambda-at-edge/rollup.config.js
+++ b/packages/libs/lambda-at-edge/rollup.config.js
@@ -16,7 +16,8 @@ const NPM_EXTERNALS = ["aws-lambda", "aws-sdk/clients/s3"];
 const generateConfig = (input) => ({
   input: `./src/${input.filename}.ts`,
   output: {
-    file: `./dist/${input.filename}${input.minify ? ".min" : ""}.js`,
+    dir: `./dist/${input.filename}/${input.minify ? "minified" : "standard"}`,
+    entryFileNames: `index.js`,
     format: "cjs"
   },
   plugins: [
@@ -37,8 +38,7 @@ const generateConfig = (input) => ({
         })
       : undefined
   ],
-  external: [...NPM_EXTERNALS, ...LOCAL_EXTERNALS],
-  inlineDynamicImports: true
+  external: [...NPM_EXTERNALS, ...LOCAL_EXTERNALS]
 });
 
 export default [

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -234,10 +234,12 @@ class Builder {
     destination: string,
     shouldMinify: boolean
   ) {
-    const source = require.resolve(
-      `@sls-next/lambda-at-edge/dist/${handlerType}${
-        shouldMinify ? ".min" : ""
-      }.js`
+    const source = path.dirname(
+      require.resolve(
+        `@sls-next/lambda-at-edge/dist/${handlerType}${
+          shouldMinify ? "minified" : "standard"
+        }`
+      )
     );
 
     await fse.copy(source, destination);
@@ -295,7 +297,7 @@ class Builder {
       ...copyTraces,
       this.processAndCopyHandler(
         "default-handler",
-        join(this.outputDir, DEFAULT_LAMBDA_CODE_DIR, "index.js"),
+        join(this.outputDir, DEFAULT_LAMBDA_CODE_DIR),
         !!this.buildOptions.minifyHandlers
       ),
       this.buildOptions?.handler
@@ -388,7 +390,7 @@ class Builder {
       ...copyTraces,
       this.processAndCopyHandler(
         "api-handler",
-        join(this.outputDir, API_LAMBDA_CODE_DIR, "index.js"),
+        join(this.outputDir, API_LAMBDA_CODE_DIR),
         !!this.buildOptions.minifyHandlers
       ),
       this.buildOptions?.handler
@@ -422,7 +424,7 @@ class Builder {
     return Promise.all([
       this.processAndCopyHandler(
         "image-handler",
-        join(this.outputDir, IMAGE_LAMBDA_CODE_DIR, "index.js"),
+        join(this.outputDir, IMAGE_LAMBDA_CODE_DIR),
         !!this.buildOptions.minifyHandlers
       ),
       this.buildOptions?.handler

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -236,7 +236,7 @@ class Builder {
   ) {
     const source = path.dirname(
       require.resolve(
-        `@sls-next/lambda-at-edge/dist/${handlerType}${
+        `@sls-next/lambda-at-edge/dist/${handlerType}/${
           shouldMinify ? "minified" : "standard"
         }`
       )

--- a/packages/libs/lambda-at-edge/src/s3-client.ts
+++ b/packages/libs/lambda-at-edge/src/s3-client.ts
@@ -1,0 +1,5 @@
+import { GetObjectCommand } from "@aws-sdk/client-s3/commands/GetObjectCommand";
+import { PutObjectCommand } from "@aws-sdk/client-s3/commands/PutObjectCommand";
+import { S3Client } from "@aws-sdk/client-s3/S3Client";
+
+export { GetObjectCommand, PutObjectCommand, S3Client };

--- a/packages/libs/lambda-at-edge/src/s3-client.ts
+++ b/packages/libs/lambda-at-edge/src/s3-client.ts
@@ -1,5 +1,0 @@
-import { GetObjectCommand } from "@aws-sdk/client-s3/commands/GetObjectCommand";
-import { PutObjectCommand } from "@aws-sdk/client-s3/commands/PutObjectCommand";
-import { S3Client } from "@aws-sdk/client-s3/S3Client";
-
-export { GetObjectCommand, PutObjectCommand, S3Client };

--- a/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
@@ -416,13 +416,15 @@ describe("Builder Tests (dynamic)", () => {
         join(outputDir, `${DEFAULT_LAMBDA_CODE_DIR}/pages/api`)
       );
 
-      expect(files).toEqual([
-        "index.js",
-        "manifest.json",
-        "pages",
-        "prerender-manifest.json",
-        "routes-manifest.json"
-      ]);
+      expect(files).toEqual(
+        expect.arrayContaining([
+          "index.js", // there are more chunks but it should at least contain the entry point
+          "manifest.json",
+          "pages",
+          "prerender-manifest.json",
+          "routes-manifest.json"
+        ])
+      );
 
       // api pages should not be included in the default lambda
       expect(apiDirExists).toEqual(false);

--- a/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
@@ -178,13 +178,15 @@ describe("Builder Tests (no API routes)", () => {
         join(outputDir, `${DEFAULT_LAMBDA_CODE_DIR}/pages/api`)
       );
 
-      expect(files).toEqual([
-        "index.js",
-        "manifest.json",
-        "pages",
-        "prerender-manifest.json",
-        "routes-manifest.json"
-      ]);
+      expect(files).toEqual(
+        expect.arrayContaining([
+          "index.js", // there are more chunks but it should at least contain the entry point
+          "manifest.json",
+          "pages",
+          "prerender-manifest.json",
+          "routes-manifest.json"
+        ])
+      );
 
       // api pages should not be included in the default lambda
       expect(apiDirExists).toEqual(false);

--- a/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
@@ -262,13 +262,15 @@ describe("Builder Tests (with locales)", () => {
         join(outputDir, `${DEFAULT_LAMBDA_CODE_DIR}/pages/api`)
       );
 
-      expect(files).toEqual([
-        "index.js",
-        "manifest.json",
-        "pages",
-        "prerender-manifest.json",
-        "routes-manifest.json"
-      ]);
+      expect(files).toEqual(
+        expect.arrayContaining([
+          "index.js", // there are more chunks but it should at least contain the entry point
+          "manifest.json",
+          "pages",
+          "prerender-manifest.json",
+          "routes-manifest.json"
+        ])
+      );
 
       // api pages should not be included in the default lambda
       expect(apiDirExists).toEqual(false);

--- a/packages/libs/lambda-at-edge/tests/build/build.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build.test.ts
@@ -217,13 +217,15 @@ describe("Builder Tests", () => {
           join(outputDir, `${DEFAULT_LAMBDA_CODE_DIR}/pages/api`)
         );
 
-        expect(files).toEqual([
-          "index.js",
-          "manifest.json",
-          "pages",
-          "prerender-manifest.json",
-          "routes-manifest.json"
-        ]);
+        expect(files).toEqual(
+          expect.arrayContaining([
+            "index.js", // there are more chunks but it should at least contain the entry point
+            "manifest.json",
+            "pages",
+            "prerender-manifest.json",
+            "routes-manifest.json"
+          ])
+        );
 
         // api pages should not be included in the default lambda
         expect(apiDirExists).toEqual(false);
@@ -260,7 +262,7 @@ describe("Builder Tests", () => {
           join(outputDir, `${DEFAULT_LAMBDA_CODE_DIR}/index.js`)
         );
 
-        expect(countLines(defaultHandler.toString())).toBeGreaterThan(100); // Arbitrary choice
+        expect(countLines(defaultHandler.toString())).toBeGreaterThan(10); // Arbitrary choice
       });
     });
 
@@ -275,12 +277,14 @@ describe("Builder Tests", () => {
           join(outputDir, `${API_LAMBDA_CODE_DIR}/pages`)
         );
 
-        expect(files).toEqual([
-          "index.js",
-          "manifest.json",
-          "pages",
-          "routes-manifest.json"
-        ]);
+        expect(files).toEqual(
+          expect.arrayContaining([
+            "index.js",
+            "manifest.json",
+            "pages",
+            "routes-manifest.json"
+          ])
+        );
         expect(pages).toEqual(["api"]);
       });
 
@@ -289,7 +293,7 @@ describe("Builder Tests", () => {
           join(outputDir, `${API_LAMBDA_CODE_DIR}/index.js`)
         );
 
-        expect(countLines(apiHandler.toString())).toBeGreaterThan(100); // Arbitrary choice
+        expect(countLines(apiHandler.toString())).toBeGreaterThan(10); // Arbitrary choice
       });
     });
 
@@ -314,13 +318,15 @@ describe("Builder Tests", () => {
           join(outputDir, `${IMAGE_LAMBDA_CODE_DIR}`)
         );
 
-        expect(files).toEqual([
-          "images-manifest.json", // Next.js default images manifest
-          "index.js",
-          "manifest.json",
-          "node_modules", // Contains sharp node modules built for Lambda Node.js 12.x
-          "routes-manifest.json"
-        ]);
+        expect(files).toEqual(
+          expect.arrayContaining([
+            "images-manifest.json", // Next.js default images manifest
+            "index.js",
+            "manifest.json",
+            "node_modules", // Contains sharp node modules built for Lambda Node.js 12.x
+            "routes-manifest.json"
+          ])
+        );
       });
 
       it("image handler is not minified", async () => {
@@ -328,7 +334,7 @@ describe("Builder Tests", () => {
           join(outputDir, `${IMAGE_LAMBDA_CODE_DIR}/index.js`)
         );
 
-        expect(countLines(imageHandler.toString())).toBeGreaterThan(100); // Arbitrary choice
+        expect(countLines(imageHandler.toString())).toBeGreaterThan(10); // Arbitrary choice
       });
     });
 
@@ -484,26 +490,30 @@ describe("Builder Tests", () => {
         join(outputDir, `${DEFAULT_LAMBDA_CODE_DIR}`)
       );
 
-      expect(defaultFiles).toEqual([
-        "index.js",
-        "manifest.json",
-        "pages",
-        "prerender-manifest.json",
-        "routes-manifest.json",
-        "testFile.js"
-      ]);
+      expect(defaultFiles).toEqual(
+        expect.arrayContaining([
+          "index.js",
+          "manifest.json",
+          "pages",
+          "prerender-manifest.json",
+          "routes-manifest.json",
+          "testFile.js"
+        ])
+      );
 
       const apiFiles = await fse.readdir(
         join(outputDir, `${API_LAMBDA_CODE_DIR}`)
       );
 
-      expect(apiFiles).toEqual([
-        "index.js",
-        "manifest.json",
-        "pages",
-        "routes-manifest.json",
-        "testFile.js"
-      ]);
+      expect(apiFiles).toEqual(
+        expect.arrayContaining([
+          "index.js",
+          "manifest.json",
+          "pages",
+          "routes-manifest.json",
+          "testFile.js"
+        ])
+      );
     });
   });
 });

--- a/packages/libs/lambda-at-edge/yarn.lock
+++ b/packages/libs/lambda-at-edge/yarn.lock
@@ -1558,10 +1558,10 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
-  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -2445,12 +2445,12 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.26.6:
-  version "2.26.6"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.26.6.tgz#0b460c1da224c6af12a1e948a28c513aa11f2b93"
-  integrity sha512-iSB7eE3k/VNQHnI7ckS++4yIqTamoUCB1xo7MswhJ/fg22oFYR5+xCrUZVviBj97jvc5A31MPbVMw1Wc3jWxmw==
+rollup@^2.46.0:
+  version "2.46.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.46.0.tgz#8cacf89d2ee31a34755f1af40a665168f592b829"
+  integrity sha512-qPGoUBNl+Z8uNu0z7pD3WPTABWRbcOwIrO/5ccDJzmrtzn0LVf6Lj91+L5CcWhXl6iWf23FQ6m8Jkl2CmN1O7Q==
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"


### PR DESCRIPTION
Note: testing rollup config to properly bundle dynamic imports like s3client which is not always needed. The cost is an additional wrapper on top of main code but this seems expected optimization from Rollup.js (preloading and parsing optimization). 

Previously, inlining dynamic imports into one file was still causing that code to be at least partially preloaded outside of the handler, e.g initializing some S3/AWS SDK related objects even if the S3Client itself was only initialized when needed. So it caused higher cold starts due to this for all paths. With this change, we split into multiple chunks. Total there should be a few chunks:

* Entry chunk (wrapper of ~20 lines on top of other code)
* Core chunk (all of the routing code bundled into one file)
* Dynamic chunks (e.g S3 client, GetObjectCommand, PutObjectCommand) which is heavy code only needed on fallback paths

Total size of all chunks remains around the same but slightly higher at 657 kB vs. 651 kB before. However, Lambda does not need to read (and preload some parts of it) ~166 kB of code for S3 unless it's needed. There is one extra file I/O due to the wrapper requiring the core code but from tests, it appears to be negligible as ~25 ms is saved in init time from my tests (195 -> 170 ms with the 512 MB Lambda function)
In the future, we can do further optimizations like getting rid of complexity of having the origin response handler, and even using Rollup again at build/deploy time to further get rid of code paths that are not used (e.g if user has no rewrites, we can get rid of that code)