### PR TITLE
fix(sls-next/cdk-construct): defaultBehavior.edgeLambdas only applied to defaultBehavior

### DIFF
--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -230,12 +230,10 @@ export class NextJSLambdaEdge extends cdk.Construct {
       }
     ];
 
-    const { edgeLambdas: additionalDefaultEdgeLambdas, ...defaultBehavior } =
-      props.defaultBehavior || {};
-
-    if (additionalDefaultEdgeLambdas) {
-      edgeLambdas.push(...additionalDefaultEdgeLambdas);
-    }
+    const {
+      edgeLambdas: additionalDefaultEdgeLambdas = [],
+      ...defaultBehavior
+    } = props.defaultBehavior || {};
 
     this.distribution = new cloudfront.Distribution(
       this,
@@ -253,7 +251,7 @@ export class NextJSLambdaEdge extends cdk.Construct {
           cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
           compress: true,
           cachePolicy: this.nextLambdaCachePolicy,
-          edgeLambdas,
+          edgeLambdas: [...edgeLambdas, ...additionalDefaultEdgeLambdas],
           ...(defaultBehavior || {})
         },
         additionalBehaviors: {


### PR DESCRIPTION
Passing `defaultBehavior.edgeLambdas` was being applied to `defaultBehavior` and  to `_next/data/*` behaviour. Could cause unintended side effects.