### PR TITLE
feat(cdk-construct): Support for outside hosted domain

### DIFF
--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -379,11 +379,11 @@ export class NextJSLambdaEdge extends cdk.Construct {
       });
     });
 
-    if (props.domain) {
+    if (props.domain?.hostedZone != null) {
       props.domain.domainNames.forEach((domainName, index) => {
         this.aRecord = new ARecord(this, `AliasRecord_${index}`, {
           recordName: domainName,
-          zone: props.domain!.hostedZone, // not sure why ! is needed here
+          zone: props.domain!.hostedZone!, // not sure why ! is needed here
           target: RecordTarget.fromAlias(
             new CloudFrontTarget(this.distribution)
           )

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -17,11 +17,16 @@ export interface Props extends StackProps {
    */
   serverlessBuildOutDir: string;
   /**
-   * Is you'd like a custom domain for your site, you'll need to pass in a
-   * `hostedZone`, `certificate` and a list of full `domainNames`
+   * If you'd like a custom domain for your site, you'll need to pass in a list
+   * of full `domainNames` and a `certificate`.
+   *
+   * If your domain is hosted on Route53, you can pass a `hostedZone`, for
+   * which an A record will be automatically created. Otherwise, you can access
+   * the distribution information via the `distribution` property on the
+   * `NextJSLambdaEdge` construct instance, for external DNS configuration.
    */
   domain?: {
-    hostedZone: IHostedZone;
+    hostedZone?: IHostedZone;
     certificate: ICertificate;
     domainNames: string[];
   };


### PR DESCRIPTION
Allow the user to leave `hostedZone` undefined. In this case the A record will not be created, but the CloudFront distribution will be configured with the domain name + certificate.
 
Fixes #1027.