### PR TITLE
Extend locale matching to secondary languages

### DIFF
--- a/packages/libs/core/src/locale.ts
+++ b/packages/libs/core/src/locale.ts
@@ -37,20 +37,22 @@ export const getAcceptLanguageLocale = (
   routesManifest: RoutesManifest
 ) => {
   if (routesManifest.i18n) {
-    const locales = routesManifest.i18n.locales;
     const defaultLocale = routesManifest.i18n.defaultLocale;
+    const locales = new Set(
+      routesManifest.i18n.locales.map((locale) => locale.toLowerCase())
+    );
 
-    const preferredLanguage = Accept.language(acceptLanguage).toLowerCase();
-
-    // Find language in locale that matches preferred language
-    for (const locale of locales) {
-      if (preferredLanguage === locale.toLowerCase()) {
-        if (locale !== defaultLocale) {
-          return `${routesManifest.basePath}/${locale}${
-            manifest.trailingSlash ? "/" : ""
-          }`;
-        }
+    // Accept.language(header, locales) prefers the locales order,
+    // so we ask for all to find the order preferred by user.
+    for (const language of Accept.languages(acceptLanguage)) {
+      const locale = language.toLowerCase();
+      if (locale === defaultLocale) {
         break;
+      }
+      if (locales.has(locale)) {
+        return `${routesManifest.basePath}/${locale}${
+          manifest.trailingSlash ? "/" : ""
+        }`;
       }
     }
   }

--- a/packages/libs/core/tests/locale.test.ts
+++ b/packages/libs/core/tests/locale.test.ts
@@ -47,9 +47,11 @@ describe("Locale Utils Tests", () => {
     });
 
     it.each`
-      acceptLang | expectedPath
-      ${"fr"}    | ${"/fr/"}
-      ${"nl"}    | ${"/nl/"}
+      acceptLang              | expectedPath
+      ${"fr"}                 | ${"/fr/"}
+      ${"nl"}                 | ${"/nl/"}
+      ${"de, fr"}             | ${"/fr/"}
+      ${"fr;q=0.7, nl;q=0.9"} | ${"/nl/"}
     `(
       "returns $expectedPath for $acceptLang",
       ({ acceptLang, expectedPath }) => {
@@ -66,7 +68,7 @@ describe("Locale Utils Tests", () => {
     it.each`
       acceptLang
       ${"en"}
-      ${"en-Uk"}
+      ${"nl;q=0.7, en;q=0.9"}
     `("returns nothing for $acceptLang", ({ acceptLang }) => {
       const newPath = getAcceptLanguageLocale(
         acceptLang,

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-locales.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-locales.test.ts
@@ -974,6 +974,8 @@ describe("Lambda@Edge", () => {
         ${"fr,nl,en"}          | ${"/fr"}
         ${"nl,fr"}             | ${"/nl"}
         ${"fr,nl"}             | ${"/fr"}
+        ${"de,nl"}             | ${"/nl"}
+        ${"fr;q=0.5,de;q=0.8"} | ${"/fr"}
         ${"en;q=0.5,nl;q=0.8"} | ${"/nl"}
       `(
         "redirects path / with accept-language [$acceptLanguageHeader] to $expectedRedirect",


### PR DESCRIPTION
This allows matching a user's language settings even if the first preference does not match the locales available.

E.g. someone whose browser is set to prefer German, but accept French, can be served a French version after this change if German is not an option.