### PR TITLE
chore(e2e-tests): try to sleep 1-15 seconds in e2e tests to avoid thr…

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -123,6 +123,7 @@ jobs:
         run: |
           cd packages/e2e-tests/$APP_NAME
           yarn --frozen-lockfile
+          sleep $[($RANDOM % 15) + 1]s # Sleep 1-15 seconds to try to avoid throttling
           yarn e2e:ci
 
       - name: Mark end-to-end tests as failed


### PR DESCRIPTION
…ottling.

* Obviously a deployment queue might work better but this can work as a quick, temp solution