### PR TITLE
Check if image component is used

### DIFF
--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -1184,7 +1184,15 @@ class Builder {
     const isDefaultLoader = !imageLoader || imageLoader === "default";
     const hasImageOptimizer = hasImagesManifest && isDefaultLoader;
 
-    if (hasImageOptimizer) {
+    // ...nor if the image component is not used
+    const exportMarker = fse.existsSync(
+      join(this.dotNextDir, "export-marker.json")
+    )
+      ? await fse.readJSON(path.join(this.dotNextDir, "export-marker.json"))
+      : {};
+    const isNextImageImported = exportMarker.isNextImageImported !== false;
+
+    if (hasImageOptimizer && isNextImageImported) {
       await this.buildImageLambda(imageBuildManifest);
     }
 

--- a/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
@@ -2,7 +2,11 @@ import { join } from "path";
 import fse from "fs-extra";
 import execa from "execa";
 import Builder, { ASSETS_DIR } from "../../src/build";
-import { DEFAULT_LAMBDA_CODE_DIR, API_LAMBDA_CODE_DIR } from "../../src/build";
+import {
+  DEFAULT_LAMBDA_CODE_DIR,
+  API_LAMBDA_CODE_DIR,
+  IMAGE_LAMBDA_CODE_DIR
+} from "../../src/build";
 import { cleanupDir, removeNewLineChars } from "../test-utils";
 import { OriginRequestDefaultHandlerManifest } from "../../src/types";
 
@@ -374,6 +378,18 @@ describe("Builder Tests (dynamic)", () => {
       );
 
       expect(apiDir).toEqual([]);
+    });
+  });
+
+  describe("Images Handler", () => {
+    it("has empty images handler directory", async () => {
+      expect.assertions(1);
+
+      const imageDir = await fse.readdir(
+        join(outputDir, `${IMAGE_LAMBDA_CODE_DIR}`)
+      );
+
+      expect(imageDir).toEqual([]);
     });
   });
 

--- a/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
@@ -153,11 +153,11 @@ describe("Builder Tests (no API routes)", () => {
     it("has empty images handler directory", async () => {
       expect.assertions(1);
 
-      const apiDir = await fse.readdir(
+      const imageDir = await fse.readdir(
         join(outputDir, `${IMAGE_LAMBDA_CODE_DIR}`)
       );
 
-      expect(apiDir).toEqual([]);
+      expect(imageDir).toEqual([]);
     });
   });
 

--- a/packages/libs/lambda-at-edge/tests/build/dynamic-app-fixture/.next/export-marker.json
+++ b/packages/libs/lambda-at-edge/tests/build/dynamic-app-fixture/.next/export-marker.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "hasExportPathMap": false,
+  "exportTrailingSlash": false,
+  "isNextImageImported": false
+}


### PR DESCRIPTION
The past couple of versions of Next.js have an indication of whether the image component is imported in .next/export-marker.json so use it to avoid building image handler when not used.

Should prevent issues like #1030 for people upgrading with a restricted role.