### PR TITLE
chore: set registry to npmjs to try to prevent build errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - run: yarn config set registry https://registry.npmjs.org
+
       - run: yarn --frozen-lockfile
 
       - run: yarn test

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           node-version: "12.x"
 
+      - name: Set registry
+        run: yarn config set registry https://registry.npmjs.org
+
       - name: Build
         run: yarn --frozen-lockfile
 


### PR DESCRIPTION
* Try to resolve some registry issues causing yarn build errors (still won't fix the success error code despite errors, though).