### PR TITLE
Try to fix build step return code for CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -156,6 +156,24 @@ jobs:
           yarn e2e:ci
         timeout-minutes: 30 # In case something goes wrong
 
+  finalize:
+    if: always()
+    needs: [initialize, run-e2e-tests]
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - name: Mark end-to-end tests as succeeded
+        # For manual runs (e.g for fork PRs) don't update commit status as there won't be permissions to do so
+        if: ${{ success() && github.event.inputs.pull_request_id == '' }}
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: "End-to-end Tests"
+          description: "End-to-end tests have passed"
+          state: "success"
+          sha: ${{ needs.initialize.outputs.pr_git_sha || github.event.inputs.sha || github.sha }}
+          target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
       - name: Mark end-to-end tests as failed
         # For manual runs (e.g for fork PRs) don't update commit status as there won't be permissions to do so
         if: ${{ failure() && github.event.inputs.pull_request_id == '' }}
@@ -165,22 +183,5 @@ jobs:
           context: "End-to-end Tests"
           description: "End-to-end tests have failed"
           state: "failure"
-          sha: ${{ needs.initialize.outputs.pr_git_sha || github.event.inputs.sha || github.sha }}
-          target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-  finalize:
-    needs: [initialize, run-e2e-tests]
-    runs-on: [ubuntu-latest]
-
-    steps:
-      - name: Mark end-to-end tests as succeeded
-        # For manual runs (e.g for fork PRs) don't update commit status as there won't be permissions to do so
-        if: ${{ github.event.inputs.pull_request_id == '' }}
-        uses: Sibz/github-status-action@v1
-        with:
-          authToken: ${{ secrets.GITHUB_TOKEN }}
-          context: "End-to-end Tests"
-          description: "End-to-end tests have passed"
-          state: "success"
           sha: ${{ needs.initialize.outputs.pr_git_sha || github.event.inputs.sha || github.sha }}
           target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint .",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "integration": "jest --runInBand --config jest.integration.config.json --setupTestFrameworkScriptFile=./jest.integration.setup.js",
-    "postinstall": "yarn packages-install && opencollective-postinstall || true",
+    "postinstall": "yarn packages-install && (opencollective-postinstall || true)",
     "docs": "cd documentation && yarn && yarn build"
   },
   "repository": {


### PR DESCRIPTION
Based on testing locally, it seems the exit code is lost in the `|| true` in postinstall which I think is meant to make `opencollective-postinstall` non-erroring.