### PR TITLE
Fix locale rewrites to dynamic ssr

### DIFF
--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/rewrites.test.ts
@@ -26,6 +26,11 @@ describe("Rewrites Tests", () => {
         expectedStatus: 200
       },
       {
+        path: "/wildcard-rewrite-2/foo",
+        expectedRewrite: "/dynamic-ssr/foo",
+        expectedStatus: 200
+      },
+      {
         path: "/regex-rewrite-1/123",
         expectedRewrite: "/ssr-page?slug=123",
         expectedStatus: 200

--- a/packages/e2e-tests/next-app-with-locales/next.config.js
+++ b/packages/e2e-tests/next-app-with-locales/next.config.js
@@ -81,6 +81,10 @@ module.exports = {
         destination: "/ssr-page"
       },
       {
+        source: "/wildcard-rewrite-2/:slug",
+        destination: "/dynamic-ssr/:slug"
+      },
+      {
         source: "/regex-rewrite-1/:slug(\\d{1,})",
         destination: "/ssr-page"
       },

--- a/packages/e2e-tests/next-app-with-locales/pages/dynamic-ssr/[slug].tsx
+++ b/packages/e2e-tests/next-app-with-locales/pages/dynamic-ssr/[slug].tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { NextPageContext } from "next";
+import { useRouter } from "next/router";
+
+type SSRPageProps = {
+  name: string;
+};
+
+export default function SSRPage(props: SSRPageProps): JSX.Element {
+  const { query } = useRouter();
+  return (
+    <React.Fragment>
+      {`Hello ${props.name} at ${query.slug}! This is an SSR Page using getInitialProps().`}
+    </React.Fragment>
+  );
+}
+
+// getInitialProps() is the old way of doing SSR
+SSRPage.getInitialProps = async (
+  ctx: NextPageContext
+): Promise<SSRPageProps> => {
+  return { name: "serverless-next.js" };
+};

--- a/packages/libs/core/src/handle/default.ts
+++ b/packages/libs/core/src/handle/default.ts
@@ -3,6 +3,7 @@ import { setCustomHeaders } from "./headers";
 import { redirect } from "./redirect";
 import { toRequest } from "./request";
 import { routeDefault } from "../route";
+import { addDefaultLocaleToPath } from "../route/locale";
 import {
   Event,
   ExternalRoute,
@@ -25,6 +26,11 @@ export const renderRoute = async (
 ) => {
   const { req, res } = event;
   setCustomHeaders(event, routesManifest);
+
+  // For SSR rewrites to work the page needs to be passed a localized url
+  if (req.url && routesManifest.i18n) {
+    req.url = addDefaultLocaleToPath(req.url, routesManifest);
+  }
 
   // If page is _error.js, set status to 404 so _error.js will render a 404 page
   if (route.page === "pages/_error.js") {

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-locales.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-locales.test.ts
@@ -901,14 +901,17 @@ describe("Lambda@Edge", () => {
 
     describe("Custom Rewrites pass correct Request URL to page render", () => {
       it.each`
-        path               | expectedPage
-        ${"/promise-page"} | ${"pages/async-page.js"}
+        path                  | expectedPage             | expectedUrl
+        ${"/promise-page"}    | ${"pages/async-page.js"} | ${"/en/promise-page"}
+        ${"/en/promise-page"} | ${"pages/async-page.js"} | ${"/en/promise-page"}
+        ${"/nl/promise-page"} | ${"pages/async-page.js"} | ${"/nl/promise-page"}
       `(
         "serves page $expectedPage for rewritten path $path with correct request url",
-        async ({ path, expectedPage }) => {
+        async ({ path, expectedPage, expectedUrl }) => {
           // If trailingSlash = true, append "/" to get the non-redirected path
           if (trailingSlash && !path.endsWith("/")) {
             path += "/";
+            expectedUrl += "/";
           }
 
           mockPageRequire(expectedPage);
@@ -922,7 +925,7 @@ describe("Lambda@Edge", () => {
           const result = await handler(event);
           const call = page.render.mock.calls[0];
           const firstArgument = call[0];
-          expect(firstArgument).toMatchObject({ url: path });
+          expect(firstArgument).toMatchObject({ url: expectedUrl });
           const decodedBody = Buffer.from(
             result.body as string,
             "base64"


### PR DESCRIPTION
Fixes #1131

Next.js routing requirements are pretty odd here. It needs the "original" url (before rewrites) to support asPath, but cannot cope with locales.

SSG routes (fallback or ISR) already get the locale added for fetching the static page.