### PR TITLE
Refactor locale build

### DIFF
--- a/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
@@ -80,11 +80,6 @@ describe("Builder Tests (dynamic)", () => {
 
       expect(dynamic).toEqual([
         {
-          route: "/catchall/[...slug]",
-          regex:
-            "^\\/catchall(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-        },
-        {
           route: "/en/catchall/[...slug]",
           regex:
             "^\\/en\\/catchall(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
@@ -107,14 +102,6 @@ describe("Builder Tests (dynamic)", () => {
             "^\\/en\\/optional-catchall(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
         },
         {
-          route: "/fallback/[slug]",
-          regex: "^\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-        },
-        {
-          route: "/fallback-blocking/[slug]",
-          regex: "^\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-        },
-        {
           route: "/nl/catchall/[...slug]",
           regex:
             "^\\/nl\\/catchall(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
@@ -135,42 +122,25 @@ describe("Builder Tests (dynamic)", () => {
           route: "/nl/optional-catchall/[[...slug]]",
           regex:
             "^\\/nl\\/optional-catchall(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-        },
-        {
-          route: "/no-fallback/[slug]",
-          regex: "^\\/no-fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-        },
-        {
-          route: "/optional-catchall/[[...slug]]",
-          regex:
-            "^\\/optional-catchall(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
         }
       ]);
 
-      // Should non-localized variants be removed?
       expect(ssr).toEqual({
         dynamic: {
-          "/catchall/[...slug]": "pages/catchall/[...slug].js",
           "/en/catchall/[...slug]": "pages/catchall/[...slug].js",
           "/en/fallback-blocking/[slug]": "pages/fallback-blocking/[slug].js",
           "/en/fallback/[slug]": "pages/fallback/[slug].js",
           "/en/no-fallback/[slug]": "pages/no-fallback/[slug].js",
           "/en/optional-catchall/[[...slug]]":
             "pages/optional-catchall/[[...slug]].js",
-          "/fallback-blocking/[slug]": "pages/fallback-blocking/[slug].js",
-          "/fallback/[slug]": "pages/fallback/[slug].js",
           "/nl/catchall/[...slug]": "pages/catchall/[...slug].js",
           "/nl/fallback-blocking/[slug]": "pages/fallback-blocking/[slug].js",
           "/nl/fallback/[slug]": "pages/fallback/[slug].js",
           "/nl/no-fallback/[slug]": "pages/no-fallback/[slug].js",
           "/nl/optional-catchall/[[...slug]]":
-            "pages/optional-catchall/[[...slug]].js",
-          "/no-fallback/[slug]": "pages/no-fallback/[slug].js",
-          "/optional-catchall/[[...slug]]":
             "pages/optional-catchall/[[...slug]].js"
         },
         nonDynamic: {
-          "/_error": "pages/_error.js",
           "/en/_error": "pages/_error.js",
           "/en/optional-catchall": "pages/optional-catchall/[[...slug]].js",
           "/en/ssg": "pages/ssg.js",
@@ -178,10 +148,7 @@ describe("Builder Tests (dynamic)", () => {
           "/nl/_error": "pages/_error.js",
           "/nl/optional-catchall": "pages/optional-catchall/[[...slug]].js",
           "/nl/ssg": "pages/ssg.js",
-          "/nl/ssr": "pages/ssr.js",
-          "/optional-catchall": "pages/optional-catchall/[[...slug]].js",
-          "/ssg": "pages/ssg.js",
-          "/ssr": "pages/ssr.js"
+          "/nl/ssr": "pages/ssr.js"
         }
       });
 
@@ -197,7 +164,6 @@ describe("Builder Tests (dynamic)", () => {
         }
       });
 
-      // Should non-localized variants be removed?
       expect(ssg).toEqual({
         dynamic: {
           "/en/fallback-blocking/[slug]": {
@@ -209,12 +175,6 @@ describe("Builder Tests (dynamic)", () => {
           "/en/no-fallback/[slug]": {
             fallback: false
           },
-          "/fallback-blocking/[slug]": {
-            fallback: null
-          },
-          "/fallback/[slug]": {
-            fallback: "/fallback/[slug].html"
-          },
           "/nl/fallback-blocking/[slug]": {
             fallback: null
           },
@@ -223,17 +183,10 @@ describe("Builder Tests (dynamic)", () => {
           },
           "/nl/no-fallback/[slug]": {
             fallback: false
-          },
-          "/no-fallback/[slug]": {
-            fallback: false
           }
         },
         nonDynamic: {
           "/en": {
-            initialRevalidateSeconds: false,
-            srcRoute: null
-          },
-          "/en/en": {
             initialRevalidateSeconds: false,
             srcRoute: null
           },
@@ -244,14 +197,6 @@ describe("Builder Tests (dynamic)", () => {
           "/en/fallback/a": {
             initialRevalidateSeconds: false,
             srcRoute: "/fallback/[slug]"
-          },
-          "/en/nl": {
-            initialRevalidateSeconds: false,
-            srcRoute: null
-          },
-          "/en/nl/ssg": {
-            initialRevalidateSeconds: 60,
-            srcRoute: null
           },
           "/en/no-fallback/a": {
             initialRevalidateSeconds: 60,
@@ -265,23 +210,7 @@ describe("Builder Tests (dynamic)", () => {
             initialRevalidateSeconds: false,
             srcRoute: null
           },
-          "/nl/en": {
-            initialRevalidateSeconds: false,
-            srcRoute: null
-          },
-          "/nl/nl": {
-            initialRevalidateSeconds: false,
-            srcRoute: null
-          },
-          "/nl/nl/ssg": {
-            initialRevalidateSeconds: 60,
-            srcRoute: null
-          },
           "/nl/ssg": {
-            initialRevalidateSeconds: 60,
-            srcRoute: null
-          },
-          "/ssg": {
             initialRevalidateSeconds: 60,
             srcRoute: null
           }

--- a/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
@@ -76,28 +76,6 @@ describe("Builder Tests (with locales)", () => {
 
       expect(dynamic).toEqual([
         {
-          regex: "^\\/blog(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$",
-          route: "/blog/[post]"
-        },
-        {
-          regex: "^\\/customers(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$",
-          route: "/customers/[customer]"
-        },
-        {
-          regex: "^\\/customers(?:\\/([^\\/#\\?]+?))\\/profile[\\/#\\?]?$",
-          route: "/customers/[customer]/profile"
-        },
-        {
-          regex:
-            "^\\/customers(?:\\/([^\\/#\\?]+?))(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$",
-          route: "/customers/[customer]/[post]"
-        },
-        {
-          regex:
-            "^\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$",
-          route: "/customers/[...catchAll]"
-        },
-        {
           regex: "^\\/en\\/blog(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$",
           route: "/en/blog/[post]"
         },
@@ -148,22 +126,11 @@ describe("Builder Tests (with locales)", () => {
         {
           regex: "^\\/nl(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$",
           route: "/nl/[root]"
-        },
-        {
-          regex: "^(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$",
-          route: "/[root]"
         }
       ]);
 
       expect(ssr).toEqual({
         dynamic: {
-          "/[root]": "pages/[root].js",
-          "/customers/[...catchAll]": "pages/customers/[...catchAll].js",
-          "/customers/[customer]": "pages/customers/[customer].js",
-          "/customers/[customer]/[post]":
-            "pages/customers/[customer]/[post].js",
-          "/customers/[customer]/profile":
-            "pages/customers/[customer]/profile.js",
           "/en/[root]": "pages/[root].js",
           "/en/customers/[...catchAll]": "pages/customers/[...catchAll].js",
           "/en/customers/[customer]": "pages/customers/[customer].js",
@@ -180,9 +147,6 @@ describe("Builder Tests (with locales)", () => {
             "pages/customers/[customer]/profile.js"
         },
         nonDynamic: {
-          "/customers/new": "pages/customers/new.js",
-          "/_app": "pages/_app.js",
-          "/_document": "pages/_document.js",
           "/en/_app": "pages/_app.js",
           "/en/_document": "pages/_document.js",
           "/en/customers/new": "pages/customers/new.js",
@@ -194,9 +158,6 @@ describe("Builder Tests (with locales)", () => {
 
       expect(html).toEqual({
         nonDynamic: {
-          "/404": "pages/404.html",
-          "/terms": "pages/terms.html",
-          "/about": "pages/about.html",
           "/en/404": "pages/en/404.html",
           "/en/terms": "pages/en/terms.html",
           "/en/about": "pages/en/about.html",
@@ -205,7 +166,6 @@ describe("Builder Tests (with locales)", () => {
           "/nl/about": "pages/nl/about.html"
         },
         dynamic: {
-          "/blog/[post]": "pages/blog/[post].html",
           "/en/blog/[post]": "pages/en/blog/[post].html",
           "/nl/blog/[post]": "pages/nl/blog/[post].html"
         }
@@ -213,14 +173,6 @@ describe("Builder Tests (with locales)", () => {
 
       expect(ssg).toEqual({
         nonDynamic: {
-          "/": {
-            initialRevalidateSeconds: false,
-            srcRoute: null
-          },
-          "/contact": {
-            initialRevalidateSeconds: false,
-            srcRoute: null
-          },
           "/en": {
             initialRevalidateSeconds: false,
             srcRoute: null
@@ -345,7 +297,7 @@ describe("Builder Tests (with locales)", () => {
       const enPageFiles = await fse.readdir(
         join(outputDir, `${ASSETS_DIR}/static-pages/test-build-id/en`)
       );
-      expect(enPageFiles).toEqual(["contact.html"]);
+      expect(enPageFiles).toEqual(["about.html", "contact.html", "terms.html"]);
 
       const enIndexHtml = await fse.readFile(
         join(outputDir, `${ASSETS_DIR}/static-pages/test-build-id/en.html`),
@@ -371,7 +323,7 @@ describe("Builder Tests (with locales)", () => {
       const nlPageFiles = await fse.readdir(
         join(outputDir, `${ASSETS_DIR}/static-pages/test-build-id/nl`)
       );
-      expect(nlPageFiles).toEqual(["contact.html"]);
+      expect(nlPageFiles).toEqual(["about.html", "contact.html", "terms.html"]);
 
       const nlIndexHtml = await fse.readFile(
         join(

--- a/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-with-locales/.next/prerender-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-with-locales/.next/prerender-manifest.json
@@ -1,15 +1,25 @@
 {
-  "version": 2,
+  "version": 3,
   "routes": {
-    "/": {
+    "/en": {
       "initialRevalidateSeconds": false,
       "srcRoute": null,
-      "dataRoute": "/_next/data/test-build-id/index.json"
+      "dataRoute": "/_next/data/test-build-id/en.json"
     },
-    "/contact": {
+    "/nl": {
       "initialRevalidateSeconds": false,
       "srcRoute": null,
-      "dataRoute": "/_next/data/test-build-id/contact.json"
+      "dataRoute": "/_next/data/test-build-id/nl.json"
+    },
+    "/en/contact": {
+      "initialRevalidateSeconds": false,
+      "srcRoute": null,
+      "dataRoute": "/_next/data/test-build-id/en/contact.json"
+    },
+    "/nl/contact": {
+      "initialRevalidateSeconds": false,
+      "srcRoute": null,
+      "dataRoute": "/_next/data/test-build-id/nl/contact.json"
     }
   },
   "dynamicRoutes": {}

--- a/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-with-locales/.next/serverless/pages-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/build/simple-app-fixture-with-locales/.next/serverless/pages-manifest.json
@@ -5,11 +5,15 @@
   "/customers/new": "pages/customers/new.js",
   "/customers/[customer]/profile": "pages/customers/[customer]/profile.js",
   "/customers/[...catchAll]": "pages/customers/[...catchAll].js",
-  "/terms": "pages/terms.html",
-  "/about": "pages/about.html",
-  "/blog/[post]": "pages/blog/[post].html",
+  "/en/terms": "pages/en/terms.html",
+  "/en/about": "pages/en/about.html",
+  "/en/blog/[post]": "pages/en/blog/[post].html",
+  "/nl/terms": "pages/nl/terms.html",
+  "/nl/about": "pages/nl/about.html",
+  "/nl/blog/[post]": "pages/nl/blog/[post].html",
   "/": "pages/index.js",
   "/_app": "pages/_app.js",
   "/_document": "pages/_document.js",
-  "/404": "pages/404.html"
+  "/en/404": "pages/en/404.html",
+  "/nl/404": "pages/nl/404.html"
 }

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-locales-with-trailing-slash.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-locales-with-trailing-slash.json
@@ -3,26 +3,6 @@
   "pages": {
     "dynamic": [
       {
-        "route": "/blog/[id]",
-        "regex": "^\\/blog(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[customer]",
-        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[customer]/profile",
-        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))\\/profile[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[customer]/[post]",
-        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[...catchAll]",
-        "regex": "^\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/en/blog/[id]",
         "regex": "^\\/en\\/blog(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
@@ -43,24 +23,12 @@
         "regex": "^\\/en\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
-        "route": "/en/en/users/[...user]",
-        "regex": "^\\/en\\/en\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/en/fallback/[slug]",
         "regex": "^\\/en\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/en/fallback-blocking/[slug]",
         "regex": "^\\/en\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/en/fr/users/[...user]",
-        "regex": "^\\/en\\/fr\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
-        "route": "/en/nl/users/[...user]",
-        "regex": "^\\/en\\/nl\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
         "route": "/en/no-fallback/[slug]",
@@ -73,14 +41,6 @@
       {
         "route": "/en/[root]",
         "regex": "^\\/en(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/fallback/[slug]",
-        "regex": "^\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/fallback-blocking/[slug]",
-        "regex": "^\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/fr/blog/[id]",
@@ -103,24 +63,12 @@
         "regex": "^\\/fr\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
-        "route": "/fr/en/users/[...user]",
-        "regex": "^\\/fr\\/en\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/fr/fallback/[slug]",
         "regex": "^\\/fr\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/fr/fallback-blocking/[slug]",
         "regex": "^\\/fr\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/fr/fr/users/[...user]",
-        "regex": "^\\/fr\\/fr\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
-        "route": "/fr/nl/users/[...user]",
-        "regex": "^\\/fr\\/nl\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
         "route": "/fr/no-fallback/[slug]",
@@ -155,24 +103,12 @@
         "regex": "^\\/nl\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
-        "route": "/nl/en/users/[...user]",
-        "regex": "^\\/nl\\/en\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/nl/fallback/[slug]",
         "regex": "^\\/nl\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/nl/fallback-blocking/[slug]",
         "regex": "^\\/nl\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/nl/fr/users/[...user]",
-        "regex": "^\\/nl\\/fr\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
-        "route": "/nl/nl/users/[...user]",
-        "regex": "^\\/nl\\/nl\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
         "route": "/nl/no-fallback/[slug]",
@@ -185,27 +121,10 @@
       {
         "route": "/nl/[root]",
         "regex": "^\\/nl(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/no-fallback/[slug]",
-        "regex": "^\\/no-fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/[root]",
-        "regex": "^(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       }
     ],
     "ssr": {
       "dynamic": {
-        "/[root]": "pages/[root].js",
-        "/blog/[id]": "pages/blog/[id].js",
-        "/customers/[...catchAll]": "pages/customers/[...catchAll].js",
-        "/customers/[customer]": "pages/customers/[customer].js",
-        "/customers/[customer]/[post]": "pages/customers/[customer]/[post].js",
-        "/customers/[customer]/profile": "pages/customers/[customer]/profile.js",
-        "/fallback-blocking/[slug]": "pages/fallback-blocking/[slug].js",
-        "/fallback/[slug]": "pages/fallback/[slug].js",
-        "/no-fallback/[slug]": "pages/no-fallback/[slug].js",
         "/en/[root]": "pages/[root].js",
         "/en/blog/[id]": "pages/blog/[id].js",
         "/en/customers/[...catchAll]": "pages/customers/[...catchAll].js",
@@ -235,13 +154,6 @@
         "/fr/no-fallback/[slug]": "pages/no-fallback/[slug].js"
       },
       "nonDynamic": {
-        "/async-page": "pages/async-page.js",
-        "/customers": "pages/customers.js",
-        "/customers/new": "pages/customers/new.js",
-        "/erroredPage": "pages/erroredPage.js",
-        "/": "pages/index.js",
-        "/preview": "pages/preview.js",
-        "/_error": "pages/_error.js",
         "/en/async-page": "pages/async-page.js",
         "/en/customers": "pages/customers.js",
         "/en/customers/new": "pages/customers/new.js",
@@ -266,6 +178,11 @@
       }
     },
     "html": {
+      "dynamic": {
+        "/en/users/[...user]": "pages/en/users/[...user].html",
+        "/nl/users/[...user]": "pages/nl/users/[...user].html",
+        "/fr/users/[...user]": "pages/fr/users/[...user].html"
+      },
       "nonDynamic": {
         "/en/404": "pages/en/404.html",
         "/nl/404": "pages/nl/404.html",
@@ -276,131 +193,10 @@
         "/en/terms": "pages/en/terms.html",
         "/nl/terms": "pages/nl/terms.html",
         "/fr/terms": "pages/fr/terms.html"
-      },
-      "dynamic": {
-        "/en/users/[...user]": "pages/en/users/[...user].html",
-        "/nl/users/[...user]": "pages/nl/users/[...user].html",
-        "/fr/users/[...user]": "pages/fr/users/[...user].html",
-        "/en/en/users/[...user]": "pages/en/en/users/[...user].html",
-        "/en/nl/users/[...user]": "pages/en/nl/users/[...user].html",
-        "/en/fr/users/[...user]": "pages/en/fr/users/[...user].html",
-        "/nl/en/users/[...user]": "pages/nl/en/users/[...user].html",
-        "/nl/nl/users/[...user]": "pages/nl/nl/users/[...user].html",
-        "/nl/fr/users/[...user]": "pages/nl/fr/users/[...user].html",
-        "/fr/en/users/[...user]": "pages/fr/en/users/[...user].html",
-        "/fr/nl/users/[...user]": "pages/fr/nl/users/[...user].html",
-        "/fr/fr/users/[...user]": "pages/fr/fr/users/[...user].html"
       }
     },
     "ssg": {
-      "nonDynamic": {
-        "/en/fallback/example-static-page": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": "/fallback/[slug]"
-        },
-        "/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/no-fallback/example-static-page": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": "/no-fallback/[slug]"
-        },
-        "/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/en/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/en/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/en/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/nl/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/nl/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/fr/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/fr/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        }
-      },
       "dynamic": {
-        "/fallback-blocking/[slug]": {
-          "fallback": null
-        },
-        "/fallback/[slug]": {
-          "fallback": "/fallback/[slug].html"
-        },
-        "/no-fallback/[slug]": {
-          "fallback": false
-        },
         "/en/fallback-blocking/[slug]": {
           "fallback": null
         },
@@ -427,6 +223,40 @@
         },
         "/fr/no-fallback/[slug]": {
           "fallback": false
+        }
+      },
+      "nonDynamic": {
+        "/en/fallback/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/fallback/[slug]"
+        },
+        "/en": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null
+        },
+        "/nl": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null
+        },
+        "/fr": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null
+        },
+        "/en/preview": {
+          "initialRevalidateSeconds": 5,
+          "srcRoute": null
+        },
+        "/nl/preview": {
+          "initialRevalidateSeconds": 5,
+          "srcRoute": null
+        },
+        "/fr/preview": {
+          "initialRevalidateSeconds": 5,
+          "srcRoute": null
+        },
+        "/en/no-fallback/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/no-fallback/[slug]"
         }
       }
     }

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-locales.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-with-locales.json
@@ -3,26 +3,6 @@
   "pages": {
     "dynamic": [
       {
-        "route": "/blog/[id]",
-        "regex": "^\\/blog(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[customer]",
-        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[customer]/profile",
-        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))\\/profile[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[customer]/[post]",
-        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[...catchAll]",
-        "regex": "^\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/en/blog/[id]",
         "regex": "^\\/en\\/blog(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
@@ -43,24 +23,12 @@
         "regex": "^\\/en\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
-        "route": "/en/en/users/[...user]",
-        "regex": "^\\/en\\/en\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/en/fallback/[slug]",
         "regex": "^\\/en\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/en/fallback-blocking/[slug]",
         "regex": "^\\/en\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/en/fr/users/[...user]",
-        "regex": "^\\/en\\/fr\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
-        "route": "/en/nl/users/[...user]",
-        "regex": "^\\/en\\/nl\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
         "route": "/en/no-fallback/[slug]",
@@ -73,14 +41,6 @@
       {
         "route": "/en/[root]",
         "regex": "^\\/en(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/fallback/[slug]",
-        "regex": "^\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/fallback-blocking/[slug]",
-        "regex": "^\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/fr/blog/[id]",
@@ -103,24 +63,12 @@
         "regex": "^\\/fr\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
-        "route": "/fr/en/users/[...user]",
-        "regex": "^\\/fr\\/en\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/fr/fallback/[slug]",
         "regex": "^\\/fr\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/fr/fallback-blocking/[slug]",
         "regex": "^\\/fr\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/fr/fr/users/[...user]",
-        "regex": "^\\/fr\\/fr\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
-        "route": "/fr/nl/users/[...user]",
-        "regex": "^\\/fr\\/nl\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
         "route": "/fr/no-fallback/[slug]",
@@ -155,24 +103,12 @@
         "regex": "^\\/nl\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
-        "route": "/nl/en/users/[...user]",
-        "regex": "^\\/nl\\/en\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/nl/fallback/[slug]",
         "regex": "^\\/nl\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/nl/fallback-blocking/[slug]",
         "regex": "^\\/nl\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/nl/fr/users/[...user]",
-        "regex": "^\\/nl\\/fr\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
-        "route": "/nl/nl/users/[...user]",
-        "regex": "^\\/nl\\/nl\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
         "route": "/nl/no-fallback/[slug]",
@@ -185,27 +121,10 @@
       {
         "route": "/nl/[root]",
         "regex": "^\\/nl(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/no-fallback/[slug]",
-        "regex": "^\\/no-fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/[root]",
-        "regex": "^(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       }
     ],
     "ssr": {
       "dynamic": {
-        "/[root]": "pages/[root].js",
-        "/blog/[id]": "pages/blog/[id].js",
-        "/customers/[...catchAll]": "pages/customers/[...catchAll].js",
-        "/customers/[customer]": "pages/customers/[customer].js",
-        "/customers/[customer]/[post]": "pages/customers/[customer]/[post].js",
-        "/customers/[customer]/profile": "pages/customers/[customer]/profile.js",
-        "/fallback-blocking/[slug]": "pages/fallback-blocking/[slug].js",
-        "/fallback/[slug]": "pages/fallback/[slug].js",
-        "/no-fallback/[slug]": "pages/no-fallback/[slug].js",
         "/en/[root]": "pages/[root].js",
         "/en/blog/[id]": "pages/blog/[id].js",
         "/en/customers/[...catchAll]": "pages/customers/[...catchAll].js",
@@ -235,13 +154,6 @@
         "/fr/no-fallback/[slug]": "pages/no-fallback/[slug].js"
       },
       "nonDynamic": {
-        "/async-page": "pages/async-page.js",
-        "/customers": "pages/customers.js",
-        "/customers/new": "pages/customers/new.js",
-        "/erroredPage": "pages/erroredPage.js",
-        "/": "pages/index.js",
-        "/preview": "pages/preview.js",
-        "/_error": "pages/_error.js",
         "/en/async-page": "pages/async-page.js",
         "/en/customers": "pages/customers.js",
         "/en/customers/new": "pages/customers/new.js",
@@ -266,6 +178,11 @@
       }
     },
     "html": {
+      "dynamic": {
+        "/en/users/[...user]": "pages/en/users/[...user].html",
+        "/nl/users/[...user]": "pages/nl/users/[...user].html",
+        "/fr/users/[...user]": "pages/fr/users/[...user].html"
+      },
       "nonDynamic": {
         "/en/404": "pages/en/404.html",
         "/nl/404": "pages/nl/404.html",
@@ -276,131 +193,10 @@
         "/en/terms": "pages/en/terms.html",
         "/nl/terms": "pages/nl/terms.html",
         "/fr/terms": "pages/fr/terms.html"
-      },
-      "dynamic": {
-        "/en/users/[...user]": "pages/en/users/[...user].html",
-        "/nl/users/[...user]": "pages/nl/users/[...user].html",
-        "/fr/users/[...user]": "pages/fr/users/[...user].html",
-        "/en/en/users/[...user]": "pages/en/en/users/[...user].html",
-        "/en/nl/users/[...user]": "pages/en/nl/users/[...user].html",
-        "/en/fr/users/[...user]": "pages/en/fr/users/[...user].html",
-        "/nl/en/users/[...user]": "pages/nl/en/users/[...user].html",
-        "/nl/nl/users/[...user]": "pages/nl/nl/users/[...user].html",
-        "/nl/fr/users/[...user]": "pages/nl/fr/users/[...user].html",
-        "/fr/en/users/[...user]": "pages/fr/en/users/[...user].html",
-        "/fr/nl/users/[...user]": "pages/fr/nl/users/[...user].html",
-        "/fr/fr/users/[...user]": "pages/fr/fr/users/[...user].html"
       }
     },
     "ssg": {
-      "nonDynamic": {
-        "/en/fallback/example-static-page": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": "/fallback/[slug]"
-        },
-        "/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/no-fallback/example-static-page": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": "/no-fallback/[slug]"
-        },
-        "/en/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/en/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/en/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/en/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/nl/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/nl/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/fr/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/fr/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        }
-      },
       "dynamic": {
-        "/fallback-blocking/[slug]": {
-          "fallback": null
-        },
-        "/fallback/[slug]": {
-          "fallback": "/fallback/[slug].html"
-        },
-        "/no-fallback/[slug]": {
-          "fallback": false
-        },
         "/en/fallback-blocking/[slug]": {
           "fallback": null
         },
@@ -427,6 +223,40 @@
         },
         "/fr/no-fallback/[slug]": {
           "fallback": false
+        }
+      },
+      "nonDynamic": {
+        "/en/fallback/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/fallback/[slug]"
+        },
+        "/en/no-fallback/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/no-fallback/[slug]"
+        },
+        "/en": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null
+        },
+        "/nl": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null
+        },
+        "/fr": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null
+        },
+        "/en/preview": {
+          "initialRevalidateSeconds": 5,
+          "srcRoute": null
+        },
+        "/nl/preview": {
+          "initialRevalidateSeconds": 5,
+          "srcRoute": null
+        },
+        "/fr/preview": {
+          "initialRevalidateSeconds": 5,
+          "srcRoute": null
         }
       }
     }

--- a/packages/libs/lambda-at-edge/tests/regeneration-handler/default-build-manifest-with-locales.json
+++ b/packages/libs/lambda-at-edge/tests/regeneration-handler/default-build-manifest-with-locales.json
@@ -3,26 +3,6 @@
   "pages": {
     "dynamic": [
       {
-        "route": "/blog/[id]",
-        "regex": "^\\/blog(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[customer]",
-        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[customer]/profile",
-        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))\\/profile[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[customer]/[post]",
-        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/customers/[...catchAll]",
-        "regex": "^\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/en/blog/[id]",
         "regex": "^\\/en\\/blog(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
@@ -43,24 +23,12 @@
         "regex": "^\\/en\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
-        "route": "/en/en/users/[...user]",
-        "regex": "^\\/en\\/en\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/en/fallback/[slug]",
         "regex": "^\\/en\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/en/fallback-blocking/[slug]",
         "regex": "^\\/en\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/en/fr/users/[...user]",
-        "regex": "^\\/en\\/fr\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
-        "route": "/en/nl/users/[...user]",
-        "regex": "^\\/en\\/nl\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
         "route": "/en/no-fallback/[slug]",
@@ -73,14 +41,6 @@
       {
         "route": "/en/[root]",
         "regex": "^\\/en(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/fallback/[slug]",
-        "regex": "^\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/fallback-blocking/[slug]",
-        "regex": "^\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/fr/blog/[id]",
@@ -103,24 +63,12 @@
         "regex": "^\\/fr\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
-        "route": "/fr/en/users/[...user]",
-        "regex": "^\\/fr\\/en\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/fr/fallback/[slug]",
         "regex": "^\\/fr\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/fr/fallback-blocking/[slug]",
         "regex": "^\\/fr\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/fr/fr/users/[...user]",
-        "regex": "^\\/fr\\/fr\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
-        "route": "/fr/nl/users/[...user]",
-        "regex": "^\\/fr\\/nl\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
         "route": "/fr/no-fallback/[slug]",
@@ -155,24 +103,12 @@
         "regex": "^\\/nl\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
-        "route": "/nl/en/users/[...user]",
-        "regex": "^\\/nl\\/en\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
         "route": "/nl/fallback/[slug]",
         "regex": "^\\/nl\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       },
       {
         "route": "/nl/fallback-blocking/[slug]",
         "regex": "^\\/nl\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/nl/fr/users/[...user]",
-        "regex": "^\\/nl\\/fr\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
-      },
-      {
-        "route": "/nl/nl/users/[...user]",
-        "regex": "^\\/nl\\/nl\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
       },
       {
         "route": "/nl/no-fallback/[slug]",
@@ -185,27 +121,10 @@
       {
         "route": "/nl/[root]",
         "regex": "^\\/nl(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/no-fallback/[slug]",
-        "regex": "^\\/no-fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
-      },
-      {
-        "route": "/[root]",
-        "regex": "^(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
       }
     ],
     "ssr": {
       "dynamic": {
-        "/[root]": "pages/[root].js",
-        "/blog/[id]": "pages/blog/[id].js",
-        "/customers/[...catchAll]": "pages/customers/[...catchAll].js",
-        "/customers/[customer]": "pages/customers/[customer].js",
-        "/customers/[customer]/[post]": "pages/customers/[customer]/[post].js",
-        "/customers/[customer]/profile": "pages/customers/[customer]/profile.js",
-        "/fallback-blocking/[slug]": "pages/fallback-blocking/[slug].js",
-        "/fallback/[slug]": "pages/fallback/[slug].js",
-        "/no-fallback/[slug]": "pages/no-fallback/[slug].js",
         "/en/[root]": "pages/[root].js",
         "/en/blog/[id]": "pages/blog/[id].js",
         "/en/customers/[...catchAll]": "pages/customers/[...catchAll].js",
@@ -235,13 +154,6 @@
         "/fr/no-fallback/[slug]": "pages/no-fallback/[slug].js"
       },
       "nonDynamic": {
-        "/async-page": "pages/async-page.js",
-        "/customers": "pages/customers.js",
-        "/customers/new": "pages/customers/new.js",
-        "/erroredPage": "pages/erroredPage.js",
-        "/": "pages/index.js",
-        "/preview": "pages/preview.js",
-        "/_error": "pages/_error.js",
         "/en/async-page": "pages/async-page.js",
         "/en/customers": "pages/customers.js",
         "/en/customers/new": "pages/customers/new.js",
@@ -266,6 +178,11 @@
       }
     },
     "html": {
+      "dynamic": {
+        "/en/users/[...user]": "pages/en/users/[...user].html",
+        "/nl/users/[...user]": "pages/nl/users/[...user].html",
+        "/fr/users/[...user]": "pages/fr/users/[...user].html"
+      },
       "nonDynamic": {
         "/en/404": "pages/en/404.html",
         "/nl/404": "pages/nl/404.html",
@@ -276,28 +193,39 @@
         "/en/terms": "pages/en/terms.html",
         "/nl/terms": "pages/nl/terms.html",
         "/fr/terms": "pages/fr/terms.html"
-      },
-      "dynamic": {
-        "/en/users/[...user]": "pages/en/users/[...user].html",
-        "/nl/users/[...user]": "pages/nl/users/[...user].html",
-        "/fr/users/[...user]": "pages/fr/users/[...user].html",
-        "/en/en/users/[...user]": "pages/en/en/users/[...user].html",
-        "/en/nl/users/[...user]": "pages/en/nl/users/[...user].html",
-        "/en/fr/users/[...user]": "pages/en/fr/users/[...user].html",
-        "/nl/en/users/[...user]": "pages/nl/en/users/[...user].html",
-        "/nl/nl/users/[...user]": "pages/nl/nl/users/[...user].html",
-        "/nl/fr/users/[...user]": "pages/nl/fr/users/[...user].html",
-        "/fr/en/users/[...user]": "pages/fr/en/users/[...user].html",
-        "/fr/nl/users/[...user]": "pages/fr/nl/users/[...user].html",
-        "/fr/fr/users/[...user]": "pages/fr/fr/users/[...user].html"
       }
     },
     "ssg": {
-      "nonDynamic": {
-        "/en/no-fallback/example-static-page": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": "/no-fallback/[slug]"
+      "dynamic": {
+        "/en/fallback-blocking/[slug]": {
+          "fallback": null
         },
+        "/en/fallback/[slug]": {
+          "fallback": "/en/fallback/[slug].html"
+        },
+        "/en/no-fallback/[slug]": {
+          "fallback": false
+        },
+        "/nl/fallback-blocking/[slug]": {
+          "fallback": null
+        },
+        "/nl/fallback/[slug]": {
+          "fallback": "/nl/fallback/[slug].html"
+        },
+        "/nl/no-fallback/[slug]": {
+          "fallback": false
+        },
+        "/fr/fallback-blocking/[slug]": {
+          "fallback": null
+        },
+        "/fr/fallback/[slug]": {
+          "fallback": "/fr/fallback/[slug].html"
+        },
+        "/fr/no-fallback/[slug]": {
+          "fallback": false
+        }
+      },
+      "nonDynamic": {
         "/en": {
           "initialRevalidateSeconds": false,
           "srcRoute": null
@@ -310,7 +238,11 @@
           "initialRevalidateSeconds": false,
           "srcRoute": null
         },
-        "/preview": {
+        "/en/fallback/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/fallback/[slug]"
+        },
+        "/en/preview": {
           "initialRevalidateSeconds": 5,
           "srcRoute": null
         },
@@ -322,111 +254,9 @@
           "initialRevalidateSeconds": 5,
           "srcRoute": null
         },
-        "/en/fallback/example-static-page": {
+        "/en/no-fallback/example-static-page": {
           "initialRevalidateSeconds": false,
-          "srcRoute": "/fallback/[slug]"
-        },
-        "/en/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/en/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/en/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/en/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/nl/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/nl/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/nl/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/fr/en": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr/nl": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr/fr": {
-          "initialRevalidateSeconds": false,
-          "srcRoute": null
-        },
-        "/fr/nl/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        },
-        "/fr/fr/preview": {
-          "initialRevalidateSeconds": 5,
-          "srcRoute": null
-        }
-      },
-      "dynamic": {
-        "/fallback-blocking/[slug]": {
-          "fallback": null
-        },
-        "/no-fallback/[slug]": {
-          "fallback": false
-        },
-        "/fallback/[slug]": {
-          "fallback": "/fallback/[slug].html"
-        },
-        "/en/fallback-blocking/[slug]": {
-          "fallback": null
-        },
-        "/en/no-fallback/[slug]": {
-          "fallback": false
-        },
-        "/en/fallback/[slug]": {
-          "fallback": "/en/fallback/[slug].html"
-        },
-        "/nl/fallback-blocking/[slug]": {
-          "fallback": null
-        },
-        "/nl/no-fallback/[slug]": {
-          "fallback": false
-        },
-        "/nl/fallback/[slug]": {
-          "fallback": "/nl/fallback/[slug].html"
-        },
-        "/fr/fallback-blocking/[slug]": {
-          "fallback": null
-        },
-        "/fr/no-fallback/[slug]": {
-          "fallback": false
-        },
-        "/fr/fallback/[slug]": {
-          "fallback": "/fr/fallback/[slug].html"
+          "srcRoute": "/no-fallback/[slug]"
         }
       }
     }


### PR DESCRIPTION
Uses build manifest for asset build step, instead of duplicating locale logic using page and prerender manifests.

Also drops unnecessary (unlocalized) and wrong (double localized) paths from the manifest now that all the routing logic uses locale uris.