### PR TITLE
fix(core, lambda-at-edge): support static 500 page and localized stat…

### DIFF
--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/pages.test.ts
@@ -174,11 +174,14 @@ describe("Pages Tests", () => {
     ].forEach(({ path }) => {
       it(`serves 500 page ${path}`, () => {
         cy.ensureRouteHasStatusCode(path, 500);
-        cy.ensureRouteNotCached(path, false);
         cy.visit(path, { failOnStatusCode: false });
 
         // Custom static Next.js error page
         cy.contains("Custom 500");
+
+        // Check that it is not cached
+        cy.ensureRouteNotCached(path, false);
+        cy.visit(path, { failOnStatusCode: false });
       });
     });
   });

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/pages.test.ts
@@ -174,6 +174,7 @@ describe("Pages Tests", () => {
     ].forEach(({ path }) => {
       it(`serves 500 page ${path}`, () => {
         cy.ensureRouteHasStatusCode(path, 500);
+        cy.ensureRouteNotCached(path, false);
         cy.visit(path, { failOnStatusCode: false });
 
         // Custom static Next.js error page

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/pages.test.ts
@@ -157,8 +157,8 @@ describe("Pages Tests", () => {
         cy.ensureRouteHasStatusCode(path, 404);
         cy.visit(path, { failOnStatusCode: false });
 
-        // Default Next.js 404 page
-        cy.contains("404");
+        // Custom static Next.js 404 page
+        cy.contains("Custom 404");
       });
     });
   });
@@ -176,8 +176,8 @@ describe("Pages Tests", () => {
         cy.ensureRouteHasStatusCode(path, 500);
         cy.visit(path, { failOnStatusCode: false });
 
-        // Default Next.js error page
-        cy.contains("500");
+        // Custom static Next.js error page
+        cy.contains("Custom 500");
       });
     });
   });

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/pages/404.tsx
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/pages/404.tsx
@@ -1,0 +1,9 @@
+export default function Custom404() {
+  return <h1>Custom 404</h1>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {}
+  };
+}

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/pages/500.tsx
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/pages/500.tsx
@@ -1,0 +1,9 @@
+export default function Custom500() {
+  return <h1>Custom 500</h1>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {}
+  };
+}

--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
@@ -284,6 +284,7 @@ describe("Pages Tests", () => {
     ].forEach(({ path }) => {
       it(`serves 500 page ${path}`, () => {
         cy.ensureRouteHasStatusCode(path, 500);
+        cy.ensureRouteNotCached(path, false);
         cy.visit(path, { failOnStatusCode: false });
 
         // Custom static error page with getStaticProps

--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
@@ -284,12 +284,15 @@ describe("Pages Tests", () => {
     ].forEach(({ path }) => {
       it(`serves 500 page ${path}`, () => {
         cy.ensureRouteHasStatusCode(path, 500);
-        cy.ensureRouteNotCached(path, false);
         cy.visit(path, { failOnStatusCode: false });
 
         // Custom static error page with getStaticProps
         // TODO: test localization
         cy.contains("Custom 500");
+
+        // Check that it is not cached
+        cy.ensureRouteNotCached(path, false);
+        cy.visit(path, { failOnStatusCode: false });
       });
     });
   });

--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
@@ -247,8 +247,8 @@ describe("Pages Tests", () => {
         cy.ensureRouteHasStatusCode(path, 404);
         cy.visit(path, { failOnStatusCode: false });
 
-        // Default Next.js 404 page
-        cy.contains("404");
+        // Custom 404 page
+        cy.contains("Custom 404");
       });
     });
   });
@@ -266,8 +266,9 @@ describe("Pages Tests", () => {
         cy.ensureRouteHasStatusCode(path, 404);
         cy.visit(path, { failOnStatusCode: false });
 
-        // Default Next.js 404 page
-        cy.contains("404");
+        // Custom static error page with getStaticProps
+        // TODO: test localization
+        cy.contains("Custom 404");
       });
     });
   });
@@ -285,8 +286,9 @@ describe("Pages Tests", () => {
         cy.ensureRouteHasStatusCode(path, 500);
         cy.visit(path, { failOnStatusCode: false });
 
-        // Default Next.js error page
-        cy.contains("500");
+        // Custom static error page with getStaticProps
+        // TODO: test localization
+        cy.contains("Custom 500");
       });
     });
   });

--- a/packages/e2e-tests/next-app-with-locales/pages/404.tsx
+++ b/packages/e2e-tests/next-app-with-locales/pages/404.tsx
@@ -1,0 +1,9 @@
+export default function Custom404() {
+  return <h1>Custom 404</h1>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {}
+  };
+}

--- a/packages/e2e-tests/next-app-with-locales/pages/500.tsx
+++ b/packages/e2e-tests/next-app-with-locales/pages/500.tsx
@@ -1,0 +1,9 @@
+export default function Custom500() {
+  return <h1>Custom 500</h1>;
+}
+
+export async function getStaticProps() {
+  return {
+    props: {}
+  };
+}

--- a/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
@@ -126,12 +126,12 @@ describe("Pages Tests", () => {
   describe("Error pages", () => {
     [{ path: "/errored-page" }, { path: "/errored-page-new-ssr" }].forEach(
       ({ path }) => {
-        it(`serves 500 page ${path}`, () => {
+        it(`serves static 500 page ${path}`, () => {
           cy.ensureRouteHasStatusCode(path, 500);
           cy.visit(path, { failOnStatusCode: false });
 
-          // Default Next.js error page
-          cy.contains("500");
+          // Custom static error page
+          cy.contains("Custom 500");
         });
       }
     );

--- a/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
@@ -128,11 +128,14 @@ describe("Pages Tests", () => {
       ({ path }) => {
         it(`serves static 500 page ${path}`, () => {
           cy.ensureRouteHasStatusCode(path, 500);
-          cy.ensureRouteNotCached(path, false);
           cy.visit(path, { failOnStatusCode: false });
 
           // Custom static error page
           cy.contains("Custom 500");
+
+          // Check that it is not cached
+          cy.ensureRouteNotCached(path, false);
+          cy.visit(path, { failOnStatusCode: false });
         });
       }
     );

--- a/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
@@ -128,6 +128,7 @@ describe("Pages Tests", () => {
       ({ path }) => {
         it(`serves static 500 page ${path}`, () => {
           cy.ensureRouteHasStatusCode(path, 500);
+          cy.ensureRouteNotCached(path, false);
           cy.visit(path, { failOnStatusCode: false });
 
           // Custom static error page

--- a/packages/e2e-tests/next-app/pages/500.tsx
+++ b/packages/e2e-tests/next-app/pages/500.tsx
@@ -1,0 +1,3 @@
+export default function Custom500() {
+  return <h1>Custom 500</h1>;
+}

--- a/packages/e2e-tests/test-utils/cypress/custom-commands.ts
+++ b/packages/e2e-tests/test-utils/cypress/custom-commands.ts
@@ -27,10 +27,13 @@
 // Declare command definitions here so that autocomplete works
 declare namespace Cypress {
   interface Chainable {
-    ensureRouteCached: (path: string | RegExp) => Cypress.Chainable<JQuery>;
+    ensureRouteCached: (
+      path: string | RegExp,
+      throwOnError?: boolean
+    ) => Cypress.Chainable<JQuery>;
     ensureRouteNotCached: (
       path: string | RegExp,
-      failOnError: boolean = true
+      throwOnError?: boolean
     ) => Cypress.Chainable<JQuery>;
     ensureRouteNotErrored: (path: string | RegExp) => Cypress.Chainable<JQuery>;
     ensureAllRoutesNotErrored: () => Cypress.Chainable<JQuery>;
@@ -66,10 +69,10 @@ Cypress.Commands.add("ensureAllRoutesNotErrored", () => {
 
 Cypress.Commands.add(
   "ensureRouteNotCached",
-  (path: string | RegExp, failOnError = true) => {
+  (path: string | RegExp, throwOnError?: boolean) => {
     cy.intercept(path, (req) => {
       req.reply((res) => {
-        if (failOnError && res.statusCode >= 400) {
+        if (throwOnError !== false && res.statusCode >= 400) {
           throw new Error(`Response has errored with status ${res.statusCode}`);
         }
 
@@ -83,10 +86,10 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "ensureRouteCached",
-  (path: string | RegExp, failOnError = true) => {
+  (path: string | RegExp, throwOnError?: boolean) => {
     cy.intercept(path, (req) => {
       req.reply((res) => {
-        if (failOnError && res.statusCode >= 400) {
+        if (throwOnError !== false && res.statusCode >= 400) {
           throw new Error(`Response has errored with status ${res.statusCode}`);
         }
 

--- a/packages/e2e-tests/test-utils/cypress/custom-commands.ts
+++ b/packages/e2e-tests/test-utils/cypress/custom-commands.ts
@@ -28,7 +28,10 @@
 declare namespace Cypress {
   interface Chainable {
     ensureRouteCached: (path: string | RegExp) => Cypress.Chainable<JQuery>;
-    ensureRouteNotCached: (path: string | RegExp) => Cypress.Chainable<JQuery>;
+    ensureRouteNotCached: (
+      path: string | RegExp,
+      failOnError: boolean = true
+    ) => Cypress.Chainable<JQuery>;
     ensureRouteNotErrored: (path: string | RegExp) => Cypress.Chainable<JQuery>;
     ensureAllRoutesNotErrored: () => Cypress.Chainable<JQuery>;
     ensureRouteHasStatusCode: (
@@ -61,33 +64,39 @@ Cypress.Commands.add("ensureAllRoutesNotErrored", () => {
   });
 });
 
-Cypress.Commands.add("ensureRouteNotCached", (path: string | RegExp) => {
-  cy.intercept(path, (req) => {
-    req.reply((res) => {
-      if (res.statusCode >= 400) {
-        throw new Error(`Response has errored with status ${res.statusCode}`);
-      }
+Cypress.Commands.add(
+  "ensureRouteNotCached",
+  (path: string | RegExp, failOnError = true) => {
+    cy.intercept(path, (req) => {
+      req.reply((res) => {
+        if (failOnError && res.statusCode >= 400) {
+          throw new Error(`Response has errored with status ${res.statusCode}`);
+        }
 
-      if (res.headers["x-cache"] === "Hit from cloudfront") {
-        throw new Error("Response was unexpectedly cached in CloudFront.");
-      }
+        if (res.headers["x-cache"] === "Hit from cloudfront") {
+          throw new Error("Response was unexpectedly cached in CloudFront.");
+        }
+      });
     });
-  });
-});
+  }
+);
 
-Cypress.Commands.add("ensureRouteCached", (path: string | RegExp) => {
-  cy.intercept(path, (req) => {
-    req.reply((res) => {
-      if (res.statusCode >= 400) {
-        throw new Error(`Response has errored with status ${res.statusCode}`);
-      }
+Cypress.Commands.add(
+  "ensureRouteCached",
+  (path: string | RegExp, failOnError = true) => {
+    cy.intercept(path, (req) => {
+      req.reply((res) => {
+        if (failOnError && res.statusCode >= 400) {
+          throw new Error(`Response has errored with status ${res.statusCode}`);
+        }
 
-      if (res.headers["x-cache"] !== "Hit from cloudfront") {
-        throw new Error("Response was unexpectedly uncached in CloudFront.");
-      }
+        if (res.headers["x-cache"] !== "Hit from cloudfront") {
+          throw new Error("Response was unexpectedly uncached in CloudFront.");
+        }
+      });
     });
-  });
-});
+  }
+);
 
 Cypress.Commands.add("ensureRouteNotErrored", (path: string | RegExp) => {
   cy.intercept(path, (req) => {

--- a/packages/libs/core/src/handle/error.ts
+++ b/packages/libs/core/src/handle/error.ts
@@ -1,17 +1,35 @@
-import { Event } from "../types";
+import { Event, PageManifest, StaticRoute } from "../types";
 
 export const renderErrorPage = async (
   error: any,
   event: Event,
-  page: string,
+  route: { page: string; isData: boolean },
+  localePrefix: string,
+  manifest: PageManifest,
   getPage: (page: string) => any
-) => {
-  const { req, res } = event;
-  // Set status to 500 so _error.js will render a 500 page
+): Promise<void | StaticRoute> => {
   console.error(
-    `Error rendering page: ${page}. Error:\n${error}\nRendering Next.js error page.`
+    `Error rendering page: ${route.page}. Error:\n${error}\nRendering Next.js error page.`
   );
+
+  const { req, res } = event;
+
+  // Set status to 500 so _error.js will render a 500 page
   res.statusCode = 500;
-  const errorPage = getPage("./pages/_error.js");
-  await Promise.race([errorPage.render(req, res), event.responsePromise]);
+
+  // Render static error page if present by returning static route
+  const errorRoute = `${localePrefix}/500`;
+  const staticErrorPage =
+    manifest.pages.html.nonDynamic[errorRoute] ||
+    manifest.pages.ssg.nonDynamic[errorRoute];
+  if (staticErrorPage) {
+    return {
+      isData: route.isData,
+      isStatic: true,
+      file: `pages${localePrefix}/500.html`
+    };
+  } else {
+    const errorPage = getPage("./pages/_error.js");
+    await Promise.race([errorPage.render(req, res), event.responsePromise]);
+  }
 };

--- a/packages/libs/core/src/route/data.ts
+++ b/packages/libs/core/src/route/data.ts
@@ -41,7 +41,7 @@ const handle404 = (
     manifest.pages.ssg.nonDynamic[notFoundRoute];
   if (staticNotFoundPage) {
     return {
-      isData: true,
+      isData: false,
       isStatic: true,
       file: `pages${localePrefix}/404.html`
     };

--- a/packages/libs/core/src/route/data.ts
+++ b/packages/libs/core/src/route/data.ts
@@ -1,4 +1,8 @@
-import { addDefaultLocaleToPath, dropLocaleFromPath } from "./locale";
+import {
+  addDefaultLocaleToPath,
+  dropLocaleFromPath,
+  getLocalePrefixFromUri
+} from "./locale";
 import { matchDynamicRoute } from "../match";
 import { DataRoute, PageManifest, RoutesManifest, StaticRoute } from "../types";
 
@@ -27,12 +31,19 @@ const fullDataUri = (uri: string, buildId: string) => {
   return `${prefix}${uri}.json`;
 };
 
-const handle404 = (manifest: PageManifest): DataRoute | StaticRoute => {
-  if (manifest.pages.html.nonDynamic["/404"]) {
+const handle404 = (
+  localePrefix: string,
+  manifest: PageManifest
+): DataRoute | StaticRoute => {
+  const notFoundRoute = `${localePrefix}/404`;
+  const staticNotFoundPage =
+    manifest.pages.html.nonDynamic[notFoundRoute] ||
+    manifest.pages.ssg.nonDynamic[notFoundRoute];
+  if (staticNotFoundPage) {
     return {
-      isData: false,
+      isData: true,
       isStatic: true,
-      file: "pages/404.html"
+      file: `pages${localePrefix}/404.html`
     };
   }
   return {
@@ -96,5 +107,6 @@ export const handleDataReq = (
     };
   }
 
-  return handle404(manifest);
+  const localePrefix = getLocalePrefixFromUri(uri, routesManifest);
+  return handle404(localePrefix, manifest);
 };

--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -1,5 +1,9 @@
 import { normalise } from "./basepath";
-import { addDefaultLocaleToPath, dropLocaleFromPath } from "./locale";
+import {
+  addDefaultLocaleToPath,
+  dropLocaleFromPath,
+  getLocalePrefixFromUri
+} from "./locale";
 import { matchDynamicRoute } from "../match";
 import { getRewritePath, isExternalRewrite } from "./rewrite";
 import {
@@ -16,12 +20,16 @@ const pageHtml = (localeUri: string) => {
   return `pages${localeUri}.html`;
 };
 
-const handle404 = (manifest: PageManifest): PageRoute => {
-  if (manifest.pages.html.nonDynamic["/404"]) {
+const handle404 = (localePrefix: string, manifest: PageManifest): PageRoute => {
+  const notFoundRoute = `${localePrefix}/404`;
+  const staticNotFoundPage =
+    manifest.pages.html.nonDynamic[notFoundRoute] ||
+    manifest.pages.ssg.nonDynamic[notFoundRoute];
+  if (staticNotFoundPage) {
     return {
       isData: false,
       isStatic: true,
-      file: "pages/404.html"
+      file: `pages${localePrefix}/404.html`
     };
   }
   return {
@@ -121,5 +129,6 @@ export const handlePageReq = (
     };
   }
 
-  return handle404(manifest);
+  const localePrefix = getLocalePrefixFromUri(uri, routesManifest);
+  return handle404(localePrefix, manifest);
 };

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -247,6 +247,13 @@ const handleOriginResponse = async ({
       return response;
     }
 
+    // Set 500 status code for 500.html page. We do not need normalised URI as it will always be "/404.html"
+    if (s3Uri.endsWith("/500.html")) {
+      response.status = "500";
+      response.statusDescription = "Internal Server Error";
+      return response;
+    }
+
     const staticRegenerationResponse = getStaticRegenerationResponse({
       expiresHeader: response.headers?.expires?.[0]?.value || "",
       lastModifiedHeader: response.headers?.["last-modified"]?.[0]?.value || "",

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -251,6 +251,12 @@ const handleOriginResponse = async ({
     if (s3Uri.endsWith("/500.html")) {
       response.status = "500";
       response.statusDescription = "Internal Server Error";
+      response.headers["cache-control"] = [
+        {
+          key: "Cache-Control",
+          value: "public, max-age=0, s-maxage=0, must-revalidate" // server error page should not be cached
+        }
+      ];
       return response;
     }
 

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -855,6 +855,16 @@ describe("Lambda@Edge", () => {
         const response = (await handler(event)) as CloudFrontResultResponse;
 
         expect(response.status).toEqual("500");
+
+        // 500 page should never be cached
+        expect(response.headers).toEqual({
+          "cache-control": [
+            {
+              key: "Cache-Control",
+              value: "public, max-age=0, s-maxage=0, must-revalidate"
+            }
+          ]
+        });
       });
     });
 

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -841,6 +841,21 @@ describe("Lambda@Edge", () => {
 
         expect(response.status).toEqual("404");
       });
+
+      it("500.html should return 500 status after successful S3 Origin response", async () => {
+        const event = createCloudFrontEvent({
+          uri: "/500.html",
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-response" } as any,
+          response: {
+            status: "200"
+          } as any
+        });
+
+        const response = (await handler(event)) as CloudFrontResultResponse;
+
+        expect(response.status).toEqual("500");
+      });
     });
 
     describe("500 page", () => {


### PR DESCRIPTION
…ic error pages

* Also fix retrieval of localized static 404/500 pages from the locale-specific directory e.g `en/404.html` or `en/500.html`