### PR TITLE
Skip creating coverage for untested e2e test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
       "/fixture/",
       "/examples/",
       "/dist/",
+      "/e2e-tests/",
       "/tests/"
     ],
     "watchPathIgnorePatterns": [


### PR DESCRIPTION
Coverage takes ages if e2e tests have been built. This drops `yarn test` from several minutes to <45s for me. `yarn jest` running in parallel takes less than 25s now.