### PR TITLE
Set error status codes in core, refactor error handling

### DIFF
--- a/packages/libs/core/src/handle/default.ts
+++ b/packages/libs/core/src/handle/default.ts
@@ -3,10 +3,7 @@ import { setCustomHeaders } from "./headers";
 import { redirect } from "./redirect";
 import { toRequest } from "./request";
 import { routeDefault } from "../route";
-import {
-  addDefaultLocaleToPath,
-  getLocalePrefixFromUri
-} from "../route/locale";
+import { addDefaultLocaleToPath } from "../route/locale";
 import {
   Event,
   ExternalRoute,
@@ -36,9 +33,9 @@ export const renderRoute = async (
     req.url = addDefaultLocaleToPath(req.url, routesManifest);
   }
 
-  // If page is _error.js, set status to 404 so _error.js will render a 404 page
-  if (route.page === "pages/_error.js") {
-    res.statusCode = 404;
+  // Sets error page status code so _error renders the right page
+  if (route.statusCode) {
+    res.statusCode = route.statusCode;
   }
 
   const page = getPage(route.page);
@@ -55,13 +52,12 @@ export const renderRoute = async (
       await Promise.race([page.render(req, res), event.responsePromise]);
     }
   } catch (error) {
-    const localePrefix = getLocalePrefixFromUri(req.url ?? "", routesManifest);
     return renderErrorPage(
       error,
       event,
       route,
-      localePrefix,
       manifest,
+      routesManifest,
       getPage
     );
   }

--- a/packages/libs/core/src/handle/error.ts
+++ b/packages/libs/core/src/handle/error.ts
@@ -1,11 +1,12 @@
-import { Event, PageManifest, StaticRoute } from "../types";
+import { getLocalePrefixFromUri } from "../route/locale";
+import { Event, PageManifest, RoutesManifest, StaticRoute } from "../types";
 
 export const renderErrorPage = async (
   error: any,
   event: Event,
   route: { page: string; isData: boolean },
-  localePrefix: string,
   manifest: PageManifest,
+  routesManifest: RoutesManifest,
   getPage: (page: string) => any
 ): Promise<void | StaticRoute> => {
   console.error(
@@ -13,9 +14,7 @@ export const renderErrorPage = async (
   );
 
   const { req, res } = event;
-
-  // Set status to 500 so _error.js will render a 500 page
-  res.statusCode = 500;
+  const localePrefix = getLocalePrefixFromUri(req.url ?? "", routesManifest);
 
   // Render static error page if present by returning static route
   const errorRoute = `${localePrefix}/500`;
@@ -26,9 +25,12 @@ export const renderErrorPage = async (
     return {
       isData: route.isData,
       isStatic: true,
-      file: `pages${localePrefix}/500.html`
+      file: `pages${localePrefix}/500.html`,
+      statusCode: 500
     };
   } else {
+    // Set status to 500 so _error.js will render a 500 page
+    res.statusCode = 500;
     const errorPage = getPage("./pages/_error.js");
     await Promise.race([errorPage.render(req, res), event.responsePromise]);
   }

--- a/packages/libs/core/src/handle/fallback.ts
+++ b/packages/libs/core/src/handle/fallback.ts
@@ -10,7 +10,6 @@ import {
   StaticRoute
 } from "../types";
 import { notFoundPage } from "../route/notfound";
-import { getLocalePrefixFromUri } from "../route/locale";
 
 type FallbackRoute = StaticRoute & {
   fallback: string | null;
@@ -43,13 +42,12 @@ const renderFallback = async (
     );
     return { isStatic: false, route, html, renderOpts };
   } catch (error) {
-    const localePrefix = getLocalePrefixFromUri(req.url ?? "", routesManifest);
     return renderErrorPage(
       error,
       event,
       route,
-      localePrefix,
       manifest,
+      routesManifest,
       getPage
     );
   }

--- a/packages/libs/core/src/route/data.ts
+++ b/packages/libs/core/src/route/data.ts
@@ -1,9 +1,6 @@
-import {
-  addDefaultLocaleToPath,
-  dropLocaleFromPath,
-  getLocalePrefixFromUri
-} from "./locale";
+import { addDefaultLocaleToPath, dropLocaleFromPath } from "./locale";
 import { matchDynamicRoute } from "../match";
+import { notFoundData } from "./notfound";
 import { DataRoute, PageManifest, RoutesManifest, StaticRoute } from "../types";
 
 /*
@@ -29,28 +26,6 @@ const fullDataUri = (uri: string, buildId: string) => {
     return `${prefix}/index.json`;
   }
   return `${prefix}${uri}.json`;
-};
-
-const handle404 = (
-  localePrefix: string,
-  manifest: PageManifest
-): DataRoute | StaticRoute => {
-  const notFoundRoute = `${localePrefix}/404`;
-  const staticNotFoundPage =
-    manifest.pages.html.nonDynamic[notFoundRoute] ||
-    manifest.pages.ssg.nonDynamic[notFoundRoute];
-  if (staticNotFoundPage) {
-    return {
-      isData: false,
-      isStatic: true,
-      file: `pages${localePrefix}/404.html`
-    };
-  }
-  return {
-    isData: true,
-    isRender: true,
-    page: "pages/_error.js"
-  };
 };
 
 /*
@@ -107,6 +82,5 @@ export const handleDataReq = (
     };
   }
 
-  const localePrefix = getLocalePrefixFromUri(uri, routesManifest);
-  return handle404(localePrefix, manifest);
+  return notFoundData(uri, manifest, routesManifest);
 };

--- a/packages/libs/core/src/route/notfound.ts
+++ b/packages/libs/core/src/route/notfound.ts
@@ -1,38 +1,58 @@
 import { getLocalePrefixFromUri } from "./locale";
 import {
+  DataRoute,
   PageManifest,
-  RenderRoute,
+  PageRoute,
   RoutesManifest,
   StaticRoute
 } from "../types";
+
+export const staticNotFound = (
+  uri: string,
+  manifest: PageManifest,
+  routesManifest: RoutesManifest
+): (StaticRoute & PageRoute) | undefined => {
+  const localePrefix = getLocalePrefixFromUri(uri, routesManifest);
+  const notFoundUri = `${localePrefix}/404`;
+  const static404 =
+    manifest.pages.html.nonDynamic[notFoundUri] ||
+    manifest.pages.ssg.nonDynamic[notFoundUri];
+  if (static404) {
+    return {
+      isData: false,
+      isStatic: true,
+      file: `pages${notFoundUri}.html`,
+      statusCode: 404
+    };
+  }
+};
+
+export const notFoundData = (
+  uri: string,
+  manifest: PageManifest,
+  routesManifest: RoutesManifest
+): DataRoute | StaticRoute => {
+  return (
+    staticNotFound(uri, manifest, routesManifest) || {
+      isData: true,
+      isRender: true,
+      page: "pages/_error.js",
+      statusCode: 404
+    }
+  );
+};
 
 export const notFoundPage = (
   uri: string,
   manifest: PageManifest,
   routesManifest: RoutesManifest
-): RenderRoute | StaticRoute => {
-  const localePrefix = getLocalePrefixFromUri(uri, routesManifest);
-  const notFoundUri = `${localePrefix}/404`;
-  const html = manifest.pages.html.nonDynamic[notFoundUri];
-  if (html) {
-    return {
+): PageRoute => {
+  return (
+    staticNotFound(uri, manifest, routesManifest) || {
       isData: false,
-      isStatic: true,
-      file: html
-    };
-  }
-  const ssg = manifest.pages.ssg.nonDynamic[notFoundUri];
-  if (ssg) {
-    return {
-      isData: false,
-      isStatic: true,
-      file: `pages${notFoundUri}.html`
-    };
-  }
-  // Only possible in old versions of Next.js
-  return {
-    isData: false,
-    isRender: true,
-    page: "pages/_error.js"
-  };
+      isRender: true,
+      page: "pages/_error.js",
+      statusCode: 404
+    }
+  );
 };

--- a/packages/libs/core/src/types.ts
+++ b/packages/libs/core/src/types.ts
@@ -141,6 +141,7 @@ export interface AnyRoute {
   file?: string;
   headers?: Headers;
   querystring?: string;
+  statusCode?: number;
   isApi?: boolean;
   isExternal?: boolean;
   isPublicFile?: boolean;

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-locales.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-locales.test.ts
@@ -685,7 +685,7 @@ describe("Lambda@Edge", () => {
 
       it("404.html should return 404 status after successful S3 Origin response", async () => {
         const event = createCloudFrontEvent({
-          uri: "/404.html",
+          uri: "/en/404.html",
           host: "mydistribution.cloudfront.net",
           config: { eventType: "origin-response" } as any,
           response: {
@@ -722,6 +722,31 @@ describe("Lambda@Edge", () => {
         expect(request.headers.host[0].value).toEqual(
           "my-bucket.s3.amazonaws.com"
         );
+      });
+
+      it("500.html should return 500 status after successful S3 Origin response", async () => {
+        const event = createCloudFrontEvent({
+          uri: "/en/500.html",
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-response" } as any,
+          response: {
+            status: "200"
+          } as any
+        });
+
+        const response = (await handler(event)) as CloudFrontResultResponse;
+
+        expect(response.status).toEqual("500");
+
+        // 500 page should never be cached
+        expect(response.headers).toEqual({
+          "cache-control": [
+            {
+              key: "Cache-Control",
+              value: "public, max-age=0, s-maxage=0, must-revalidate"
+            }
+          ]
+        });
       });
     });
 

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -842,9 +842,9 @@ describe("Lambda@Edge", () => {
         expect(response.status).toEqual("404");
       });
 
-      it("500.html should return 500 status after successful S3 Origin response", async () => {
+      it("path ending 404 should return 200 status after successful S3 Origin response", async () => {
         const event = createCloudFrontEvent({
-          uri: "/500.html",
+          uri: "/fallback/404.html",
           host: "mydistribution.cloudfront.net",
           config: { eventType: "origin-response" } as any,
           response: {
@@ -854,17 +854,7 @@ describe("Lambda@Edge", () => {
 
         const response = (await handler(event)) as CloudFrontResultResponse;
 
-        expect(response.status).toEqual("500");
-
-        // 500 page should never be cached
-        expect(response.headers).toEqual({
-          "cache-control": [
-            {
-              key: "Cache-Control",
-              value: "public, max-age=0, s-maxage=0, must-revalidate"
-            }
-          ]
-        });
+        expect(response.status).toEqual("200");
       });
     });
 
@@ -884,6 +874,21 @@ describe("Lambda@Edge", () => {
 
         expect(decodedBody).toEqual("pages/_error.js - 500");
         expect(response.status).toEqual(500);
+      });
+
+      it("path ending 500 should return 200 status after successful S3 Origin response", async () => {
+        const event = createCloudFrontEvent({
+          uri: "/fallback/500.html",
+          host: "mydistribution.cloudfront.net",
+          config: { eventType: "origin-response" } as any,
+          response: {
+            status: "200"
+          } as any
+        });
+
+        const response = (await handler(event)) as CloudFrontResultResponse;
+
+        expect(response.status).toEqual("200");
       });
     });
 


### PR DESCRIPTION
Fixes the status code of normal static pages ending /404 or /500 (e.g. dynamic SSG page id).

Also adds tests for the different cases.
