### PR TITLE
fix(lambda-at-edge): use posix relative path when determining JS file…

### DIFF
--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -304,7 +304,7 @@ class Builder {
               path.extname(file) !== ".js" ||
               this.isSSRJSFile(
                 buildManifest,
-                path.relative(join(this.serverlessDir, "pages"), file)
+                path.posix.relative(join(this.serverlessDir, "pages"), file) // important: make sure to use posix path to generate forward-slash path across both posix/windows
               );
 
             return (


### PR DESCRIPTION
…s to exclude/include in default handler

May fix: https://github.com/serverless-nextjs/serverless-next.js/issues/991

I don't have a Windows machine I can test on right now, so assuming this should work...