### PR TITLE
chore: start e2e-tests simultaneously instead of waiting on build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,6 @@ jobs:
   start-e2e-tests:
     # Note: we only run e2e tests automatically if this PR is not from a fork, as forks won't have access to secrets
     if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
-    needs: [build]
     runs-on: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
* Will speed up CI process, doesn't really matter if e2e fails because of compile/unit test error, but this will make it faster to run things.