### PR TITLE
fix(lambda-at-edge): downgrade @rollup/plugin-commonjs to 18.1.0 to f…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     # No point updating @sls-next/* dependencies as they are linked
     ignore:
       - dependency-name: "@sls-next/*"
+        # FIXME: don't update plugin-commonjs, v19.0.0 had breaking change causing some decodeHTML functions not to be bundled
+      - dependency-name: "@rollup/plugin-commonjs"
         # FIXME: don't update plugin-node-resolve yet, versions >10 seems to be bundling browser version of uuid etc: https://github.com/rollup/plugins/blob/master/packages/node-resolve/CHANGELOG.md#v1100
       - dependency-name: "@rollup/plugin-node-resolve"
         # FIXME: CDK dependencies must be updated together but Dependabot cannot group updates

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/serverless-nextjs/serverless-next.js#readme",
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^19.0.0",
+    "@rollup/plugin-commonjs": "^18.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^10.0.0",
     "@types/aws-lambda": "^8.10.57",

--- a/packages/libs/lambda-at-edge/yarn.lock
+++ b/packages/libs/lambda-at-edge/yarn.lock
@@ -1066,10 +1066,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@rollup/plugin-commonjs@^19.0.0":
-  version "19.0.0"
-  resolved "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.0.tgz#8c3e71f9a66908e60d70cc1be205834ef3e45f71"
-  integrity sha512-adTpD6ATGbehdaQoZQ6ipDFhdjqsTgpOAhFiPwl+dzre4pPshsecptDPyEFb61JMJ1+mGljktaC4jI8ARMSNyw==
+"@rollup/plugin-commonjs@^18.1.0":
+  version "18.1.0"
+  resolved "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-18.1.0.tgz#5a760d757af168a50727c0ae080251fbfcc5eb02"
+  integrity sha512-h3e6T9rUxVMAQswpDIobfUHn/doMzM9sgkMrsMWCFLmB84PSoC8mV8tOloAJjSRwdqhXBqstlX2BwBpHJvbhxg==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     commondir "^1.0.1"
@@ -1116,13 +1116,8 @@
     picomatch "^2.2.2"
 
 "@sls-next/core@link:../core":
-  version "1.0.0-alpha.22"
-  dependencies:
-    "@hapi/accept" "^5.0.1"
-    cookie "^0.4.1"
-    jsonwebtoken "^8.5.1"
-    path-to-regexp "^6.1.0"
-    regex-parser "^2.2.10"
+  version "0.0.0"
+  uid ""
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.7"


### PR DESCRIPTION
…ix bundling issue of decodeHTML functions in SQS client

Fix for ISR issue here: https://github.com/serverless-nextjs/serverless-next.js/issues/1098#issuecomment-861732670