### PR TITLE
Support override props for CloudFront distribution

### DIFF
--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -388,7 +388,9 @@ export class NextJSLambdaEdge extends cdk.Construct {
               }
             : {}),
           ...(props.behaviours || {})
-        }
+        },
+        // Override props.
+        ...(props.cloudfrontProps || {})
       }
     );
 

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -1,5 +1,5 @@
 import { ICertificate } from "@aws-cdk/aws-certificatemanager";
-import { BehaviorOptions } from "@aws-cdk/aws-cloudfront";
+import { BehaviorOptions, DistributionProps } from "@aws-cdk/aws-cloudfront";
 import { Runtime } from "@aws-cdk/aws-lambda";
 import { IHostedZone } from "@aws-cdk/aws-route53";
 import { BucketProps } from "@aws-cdk/aws-s3";
@@ -92,4 +92,8 @@ export interface Props extends StackProps {
    * ```
    */
   invalidationPaths?: string[];
+  /**
+   * Override props passed to the underlying s3 bucket
+   */
+  cloudfrontProps?: Partial<DistributionProps>;
 }


### PR DESCRIPTION
This makes it possible to specify e.g. the price class used.