### PR TITLE
chore(e2e-tests): update cypress.json to disable videos

### DIFF
--- a/packages/e2e-tests/next-app-dynamic-routes/cypress.json
+++ b/packages/e2e-tests/next-app-dynamic-routes/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/next-app-using-serverless-trace/cypress.json
+++ b/packages/e2e-tests/next-app-using-serverless-trace/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/next-app-windows/cypress.json
+++ b/packages/e2e-tests/next-app-windows/cypress.json
@@ -4,5 +4,6 @@
   "responseTimeout": 15000,
   "requestTimeout": 15000,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/next-app-with-base-path/cypress.json
+++ b/packages/e2e-tests/next-app-with-base-path/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress.json
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/next-app-with-locales/cypress.json
+++ b/packages/e2e-tests/next-app-with-locales/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/next-app-with-trailing-slash/cypress.json
+++ b/packages/e2e-tests/next-app-with-trailing-slash/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/next-app/cypress.json
+++ b/packages/e2e-tests/next-app/cypress.json
@@ -4,5 +4,6 @@
   "responseTimeout": 15000,
   "requestTimeout": 15000,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/prev-next-app-dynamic-routes/cypress.json
+++ b/packages/e2e-tests/prev-next-app-dynamic-routes/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/prev-next-app-with-base-path/cypress.json
+++ b/packages/e2e-tests/prev-next-app-with-base-path/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/prev-next-app-with-trailing-slash/cypress.json
+++ b/packages/e2e-tests/prev-next-app-with-trailing-slash/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }

--- a/packages/e2e-tests/prev-next-app/cypress.json
+++ b/packages/e2e-tests/prev-next-app/cypress.json
@@ -3,7 +3,7 @@
   "supportFile": "cypress/support/index.ts",
   "responseTimeout": 15000,
   "requestTimeout": 15000,
-  "experimentalNetworkStubbing": true,
   "experimentalFetchPolyfill": true,
-  "retries": 4
+  "retries": 4,
+  "video": false
 }


### PR DESCRIPTION
They aren't used at the moment really (and will take a long time to upload) so disabling it for now.