### PR TITLE
fix(core): use JS page path from manifest instead of manually constru…

### DIFF
--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -50,7 +50,7 @@ export const handlePageReq = (
       isData: false,
       isStatic: true,
       file: pageHtml(localeUri),
-      page: pages.ssr.nonDynamic[localeUri], // page JS path is from SSR entries in manifest
+      page: pages.ssr.nonDynamic[route], // page JS path is from SSR entries in manifest
       revalidate: ssg.initialRevalidateSeconds,
       statusCode
     };
@@ -94,7 +94,7 @@ export const handlePageReq = (
       isData: false,
       isStatic: true,
       file: pageHtml(localeUri),
-      page: pages.ssr.dynamic[localeUri], // page JS path is from SSR entries in manifest
+      page: dynamic ? pages.ssr.dynamic[dynamic] : undefined, // page JS path is from SSR entries in manifest
       fallback: dynamicSSG.fallback
     };
   }

--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -50,7 +50,7 @@ export const handlePageReq = (
       isData: false,
       isStatic: true,
       file: pageHtml(localeUri),
-      page: `pages${dropLocaleFromPath(route, routesManifest)}.js`,
+      page: pages.ssr.nonDynamic[localeUri], // page JS path is from SSR entries in manifest
       revalidate: ssg.initialRevalidateSeconds,
       statusCode
     };
@@ -94,7 +94,7 @@ export const handlePageReq = (
       isData: false,
       isStatic: true,
       file: pageHtml(localeUri),
-      page: `pages${dropLocaleFromPath(dynamic as string, routesManifest)}.js`,
+      page: pages.ssr.dynamic[localeUri], // page JS path is from SSR entries in manifest
       fallback: dynamicSSG.fallback
     };
   }


### PR DESCRIPTION
…cting.

Paths like "/" could not work because it was resulting in page path of "pages/.js" but should actually be normalized to "pages/index.js". Instead of manually constructing it, we might as well use the SSR paths that are already built in Next.js manifests.

May fix: https://github.com/serverless-nextjs/serverless-next.js/issues/1098#issuecomment-862636828