### PR TITLE
fix: tweak aws retry policy

### DIFF
--- a/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
@@ -13,6 +13,15 @@ import obtainDomains from "../src/lib/obtainDomains";
 import { DEFAULT_LAMBDA_CODE_DIR, API_LAMBDA_CODE_DIR } from "../src/constants";
 import { cleanupFixtureDirectory } from "../src/lib/test-utils";
 
+jest.mock("aws-sdk", () => {
+  return {
+    ...jest.requireActual("aws-sdk"),
+    Config: jest.fn(() => {
+      // intentionally empty
+    })
+  };
+});
+
 const createNextComponent = () => {
   const component = new NextjsComponent();
   component.context.credentials = {
@@ -880,7 +889,7 @@ describe("Custom inputs", () => {
       const fixturePath = path.join(__dirname, "./fixtures/generic-fixture");
       let tmpCwd: string;
 
-      beforeEach(async () => {
+      beforeEach(() => {
         tmpCwd = process.cwd();
         process.chdir(fixturePath);
 
@@ -935,7 +944,7 @@ describe("Custom inputs", () => {
 
     it(`allows setting custom cache behavior: ${JSON.stringify(
       cloudFrontInput
-    )}`, async () => {
+    )}`, () => {
       cloudFrontInput[pathName]["lambda@edge"] = {
         "origin-request":
           "arn:aws:lambda:us-east-1:123456789012:function:my-func:v1"
@@ -1039,7 +1048,7 @@ describe("Custom inputs", () => {
     const fixturePath = path.join(__dirname, "./fixtures/simple-app");
     let tmpCwd: string;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       tmpCwd = process.cwd();
       process.chdir(fixturePath);
 
@@ -1064,7 +1073,7 @@ describe("Custom inputs", () => {
       const fixturePath = path.join(__dirname, "./fixtures/simple-app");
       let tmpCwd: string;
 
-      beforeEach(async () => {
+      beforeEach(() => {
         tmpCwd = process.cwd();
         process.chdir(fixturePath);
 
@@ -1134,7 +1143,7 @@ describe("Custom inputs", () => {
     const fixturePath = path.join(__dirname, "./fixtures/simple-app");
     let tmpCwd: string;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       tmpCwd = process.cwd();
       process.chdir(fixturePath);
 

--- a/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/custom-inputs.test.ts
@@ -13,15 +13,6 @@ import obtainDomains from "../src/lib/obtainDomains";
 import { DEFAULT_LAMBDA_CODE_DIR, API_LAMBDA_CODE_DIR } from "../src/constants";
 import { cleanupFixtureDirectory } from "../src/lib/test-utils";
 
-jest.mock("aws-sdk", () => {
-  return {
-    ...jest.requireActual("aws-sdk"),
-    Config: jest.fn(() => {
-      // intentionally empty
-    })
-  };
-});
-
 const createNextComponent = () => {
   const component = new NextjsComponent();
   component.context.credentials = {

--- a/packages/serverless-components/nextjs-component/__tests__/initialize.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/initialize.test.ts
@@ -1,0 +1,35 @@
+import NextjsComponent from "../src/component";
+
+jest.mock("aws-sdk", () => {
+  return {
+    ...jest.requireActual("aws-sdk"),
+    Config: jest.fn(() => {
+      // intentionally empty
+    })
+  };
+});
+
+describe("Initialize tests", () => {
+  beforeEach(() => {
+    const component = new NextjsComponent();
+    component.context.credentials = {
+      aws: {
+        accessKeyId: "123",
+        secretAccessKey: "456"
+      }
+    };
+
+    component.context.instance.debugMode = true;
+
+    component.initialize();
+  });
+
+  it("sets stack trace limit", () => {
+    expect(Error.stackTraceLimit).toBe(100);
+  });
+
+  it("sets AWS config correctly", () => {
+    const AWS = require("aws-sdk");
+    expect(AWS.Config).toBeCalled();
+  });
+});

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -28,6 +28,7 @@ import type {
   LambdaInput
 } from "../types";
 import { execSync } from "child_process";
+import AWS from "aws-sdk";
 
 // Message when deployment is explicitly skipped
 const SKIPPED_DEPLOY = "SKIPPED_DEPLOY";
@@ -59,8 +60,7 @@ class NextjsComponent extends Component {
     }
 
     // Configure AWS retry policy
-    const AWS = require("aws-sdk");
-    AWS.Config.update({
+    new AWS.Config({
       maxRetries: parseInt(process.env.SLS_NEXT_MAX_RETRIES ?? "10"),
       retryDelayOptions: { base: 200 }
     });
@@ -384,8 +384,8 @@ class NextjsComponent extends Component {
       }
     };
 
-    // parse origins from inputs
-    let inputOrigins: any[] = [];
+    // parse origins from inputs d
+    let inputOrigins: (string | { [p: string]: unknown; url: string })[] = [];
     if (cloudFrontOriginsInputs) {
       const origins = cloudFrontOriginsInputs as string[];
       inputOrigins = origins.map(expandRelativeUrls);

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -385,7 +385,8 @@ class NextjsComponent extends Component {
     };
 
     // parse origins from inputs d
-    let inputOrigins: (string | { [p: string]: unknown; url: string })[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let inputOrigins: any[] = [];
     if (cloudFrontOriginsInputs) {
       const origins = cloudFrontOriginsInputs as string[];
       inputOrigins = origins.map(expandRelativeUrls);

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -57,6 +57,13 @@ class NextjsComponent extends Component {
     if (this.context.instance.debugMode) {
       Error.stackTraceLimit = 100;
     }
+
+    // Configure AWS retry policy
+    const AWS = require("aws-sdk");
+    AWS.Config.update({
+      maxRetries: parseInt(process.env.SLS_NEXT_MAX_RETRIES ?? "10"),
+      retryDelayOptions: { base: 200 }
+    });
   }
 
   readDefaultBuildManifest(

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -60,10 +60,12 @@ class NextjsComponent extends Component {
     }
 
     // Configure AWS retry policy
-    new AWS.Config({
-      maxRetries: parseInt(process.env.SLS_NEXT_MAX_RETRIES ?? "10"),
-      retryDelayOptions: { base: 200 }
-    });
+    if (AWS?.Config) {
+      new AWS.Config({
+        maxRetries: parseInt(process.env.SLS_NEXT_MAX_RETRIES ?? "10"),
+        retryDelayOptions: { base: 200 }
+      });
+    }
   }
 
   readDefaultBuildManifest(

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -384,7 +384,7 @@ class NextjsComponent extends Component {
       }
     };
 
-    // parse origins from inputs d
+    // parse origins from inputs
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let inputOrigins: any[] = [];
     if (cloudFrontOriginsInputs) {


### PR DESCRIPTION
Trying to increase # max retries to 10 which should hopefully alleviate some throttling issues by retrying for longer (up to 200ms * 2^10 or around 100 seconds)