### PR TITLE
Remove shorter no-next-config timeout

### DIFF
--- a/packages/libs/lambda-at-edge/tests/integration/no-next-config/no-next-config.test.ts
+++ b/packages/libs/lambda-at-edge/tests/integration/no-next-config/no-next-config.test.ts
@@ -6,8 +6,6 @@ import { remove, pathExists } from "fs-extra";
 
 jest.unmock("execa");
 
-jest.setTimeout(15000);
-
 describe("No Next Config Build Test", () => {
   const nextBinary = getNextBinary();
   const fixtureDir = path.join(__dirname, "./fixture");


### PR DESCRIPTION
This test has started timing out, with uncached next builds becoming slower in newer versions.

Remove the timeout setting, since global integration test timeout is 35s.

E.g. https://github.com/serverless-nextjs/serverless-next.js/pull/1258/checks?check_run_id=2863612447#step:6:16