### PR TITLE
Test for and fix data route locales

### DIFF
--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/data-requests.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/data-requests.test.ts
@@ -55,10 +55,10 @@ describe("Data Requests", () => {
 
   describe("SSR data requests", () => {
     [
-      { path: "/ssr-page-2.json" },
-      { path: "/en/ssr-page-2.json" },
-      { path: "/fr/ssr-page-2.json" }
-    ].forEach(({ path }) => {
+      { path: "/ssr-page-2.json", locale: "en" },
+      { path: "/en/ssr-page-2.json", locale: "en" },
+      { path: "/fr/ssr-page-2.json", locale: "fr" }
+    ].forEach(({ locale, path }) => {
       const fullPath = `/_next/data/${buildId}${path}`;
 
       it(`serves the SSR data request for path ${fullPath}`, () => {
@@ -70,6 +70,12 @@ describe("Data Requests", () => {
             expect(response.headers["cache-control"]).to.be.undefined;
           });
         }
+      });
+
+      it(`serves the SSR data request for path ${fullPath} with locale ${locale}`, () => {
+        cy.request(fullPath).then((response) => {
+          expect(response.body.pageProps.locale).to.equal(locale);
+        });
       });
 
       ["HEAD", "GET"].forEach((method) => {

--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
@@ -35,10 +35,10 @@ describe("Pages Tests", () => {
 
   describe("SSR pages (getServerSideProps)", () => {
     [
-      { path: "/ssr-page-2" },
-      { path: "/en/ssr-page-2" },
-      { path: "/fr/ssr-page-2" }
-    ].forEach(({ path }) => {
+      { path: "/ssr-page-2", locale: "en" },
+      { path: "/en/ssr-page-2", locale: "en" },
+      { path: "/fr/ssr-page-2", locale: "fr" }
+    ].forEach(({ locale, path }) => {
       it(`serves but does not cache page ${path}`, () => {
         if (path === "/") {
           // Somehow "/" is matching everything, need to exclude static files
@@ -51,6 +51,11 @@ describe("Pages Tests", () => {
         cy.location("pathname").should("eq", path);
 
         cy.visit(path);
+      });
+
+      it(`serves page ${path} with locale ${locale}`, () => {
+        cy.visit(path);
+        cy.get("[data-cy=locale]").contains(locale);
       });
 
       ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"].forEach(

--- a/packages/e2e-tests/next-app-with-locales/pages/ssr-page-2.tsx
+++ b/packages/e2e-tests/next-app-with-locales/pages/ssr-page-2.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { GetServerSidePropsContext } from "next";
 
 type SSGPageProps = {
+  locale?: string;
   name: string;
   preview: boolean;
 };
@@ -11,17 +12,19 @@ export default function SSRPage(props: any): JSX.Element {
     <React.Fragment>
       {`Hello ${props.name}! This is an SSR Page using getServerSideProps().`}
       <div>
+        <p data-cy="locale">{props.locale}</p>
         <p data-cy="preview-mode">{String(props.preview)}</p>
       </div>
     </React.Fragment>
   );
 }
 
-export async function getServerSideProps(
-  ctx: GetServerSidePropsContext
-): Promise<{ props: SSGPageProps }> {
+export function getServerSideProps(ctx: GetServerSidePropsContext): {
+  props: SSGPageProps;
+} {
   return {
     props: {
+      locale: ctx.locale,
       name: "serverless-next.js",
       preview: !!ctx.preview
     }

--- a/packages/libs/core/src/handle/default.ts
+++ b/packages/libs/core/src/handle/default.ts
@@ -29,7 +29,7 @@ export const renderRoute = async (
   setCustomHeaders(event, routesManifest);
 
   // For SSR rewrites to work the page needs to be passed a localized url
-  if (req.url && routesManifest.i18n) {
+  if (req.url && routesManifest.i18n && !route.isData) {
     req.url = addDefaultLocaleToPath(req.url, routesManifest);
   }
 


### PR DESCRIPTION
The default locale addition in #1132 did not take data routes into account and adds the locale in the wrong part of the uri.

Data routes always have a locale when requested by Next.js so that workaround isn't needed.

This should fix #1267