### PR TITLE
fix(lambda-at-edge): fix reconstruction of uri for "index.html" -> "/" instead of "/index" in origin response handler

### DIFF
--- a/packages/e2e-tests/next-app/cypress/integration/data-requests.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/data-requests.test.ts
@@ -2,53 +2,55 @@ describe("Data Requests", () => {
   const buildId = Cypress.env("NEXT_BUILD_ID");
 
   describe("SSG data requests", () => {
-    [{ path: "/ssg-page.json" }].forEach(({ path }) => {
-      const fullPath = `/_next/data/${buildId}${path}`;
+    [{ path: "/ssg-page.json" }, { path: "/index.json" }].forEach(
+      ({ path }) => {
+        const fullPath = `/_next/data/${buildId}${path}`;
 
-      it(`serves the SSG data request for path ${fullPath}`, () => {
-        // Hit two times, and check that the response should definitely be cached after 2nd time
-        for (let i = 0; i < 2; i++) {
-          cy.request(fullPath).then((response) => {
-            expect(response.status).to.equal(200);
-            expect(response.headers["cache-control"]).to.not.be.undefined;
+        it(`serves the SSG data request for path ${fullPath}`, () => {
+          // Hit two times, and check that the response should definitely be cached after 2nd time
+          for (let i = 0; i < 2; i++) {
+            cy.request(fullPath).then((response) => {
+              expect(response.status).to.equal(200);
+              expect(response.headers["cache-control"]).to.not.be.undefined;
 
-            if (i === 1) {
-              cy.verifyResponseCacheStatus(response, true);
-            } else {
-              expect(response.headers["x-cache"]).to.be.oneOf([
-                "Miss from cloudfront",
-                "Hit from cloudfront"
-              ]);
-            }
-          });
-        }
-      });
+              if (i === 1) {
+                cy.verifyResponseCacheStatus(response, true);
+              } else {
+                expect(response.headers["x-cache"]).to.be.oneOf([
+                  "Miss from cloudfront",
+                  "Hit from cloudfront"
+                ]);
+              }
+            });
+          }
+        });
 
-      ["HEAD", "GET"].forEach((method) => {
-        it(`allows HTTP method for path ${fullPath}: ${method}`, () => {
-          cy.request({ url: fullPath, method: method }).then((response) => {
-            expect(response.status).to.equal(200);
+        ["HEAD", "GET"].forEach((method) => {
+          it(`allows HTTP method for path ${fullPath}: ${method}`, () => {
+            cy.request({ url: fullPath, method: method }).then((response) => {
+              expect(response.status).to.equal(200);
+            });
           });
         });
-      });
 
-      ["DELETE", "POST", "OPTIONS", "PUT", "PATCH"].forEach((method) => {
-        it(`disallows HTTP method for path ${fullPath} with 4xx error: ${method}`, () => {
-          cy.request({
-            url: fullPath,
-            method: method,
-            failOnStatusCode: false
-          }).then((response) => {
-            expect(response.status).to.be.at.least(400);
-            expect(response.status).to.be.lessThan(500);
+        ["DELETE", "POST", "OPTIONS", "PUT", "PATCH"].forEach((method) => {
+          it(`disallows HTTP method for path ${fullPath} with 4xx error: ${method}`, () => {
+            cy.request({
+              url: fullPath,
+              method: method,
+              failOnStatusCode: false
+            }).then((response) => {
+              expect(response.status).to.be.at.least(400);
+              expect(response.status).to.be.lessThan(500);
+            });
           });
         });
-      });
-    });
+      }
+    );
   });
 
   describe("SSR data requests", () => {
-    [{ path: "" }, { path: "/index.json" }].forEach(({ path }) => {
+    [{ path: "/ssr-page-2.json" }].forEach(({ path }) => {
       const fullPath = `/_next/data/${buildId}${path}`;
 
       it(`serves the SSR data request for path ${fullPath}`, () => {

--- a/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/pages.test.ts
@@ -30,7 +30,7 @@ describe("Pages Tests", () => {
   });
 
   describe("SSR pages (getServerSideProps)", () => {
-    [{ path: "/" }].forEach(({ path }) => {
+    [{ path: "/ssr-page-2" }].forEach(({ path }) => {
       it(`serves but does not cache page ${path}`, () => {
         if (path === "/") {
           // Somehow "/" is matching everything, need to exclude static files
@@ -61,7 +61,7 @@ describe("Pages Tests", () => {
   });
 
   describe("SSG pages", () => {
-    [{ path: "/ssg-page" }].forEach(({ path }) => {
+    [{ path: "/ssg-page" }, { path: "/" }].forEach(({ path }) => {
       it(`serves and caches page ${path}`, () => {
         cy.visit(path);
         cy.location("pathname").should("eq", path);

--- a/packages/e2e-tests/next-app/pages/index.tsx
+++ b/packages/e2e-tests/next-app/pages/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { NextPageContext } from "next";
 
 type IndexPageProps = {
   name: string;
@@ -9,16 +8,14 @@ export default function IndexPage(props: IndexPageProps): JSX.Element {
   return (
     <React.Fragment>
       <div>
-        {`Hello ${props.name}. This is an SSR page using getServerSideProps(). It also has an image.`}
+        {`Hello ${props.name}. This is an SSG page using getStaticProps(). It also has an image.`}
       </div>
       <img src={"/app-store-badge.png"} alt={"An image"} />
     </React.Fragment>
   );
 }
 
-export async function getServerSideProps(
-  ctx: NextPageContext
-): Promise<{ props: IndexPageProps }> {
+export function getStaticProps(): { props: IndexPageProps } {
   return {
     props: { name: "serverless-next.js" }
   };

--- a/packages/e2e-tests/next-app/pages/index.tsx
+++ b/packages/e2e-tests/next-app/pages/index.tsx
@@ -1,22 +1,29 @@
 import React from "react";
+import { GetStaticPropsContext } from "next";
 
 type IndexPageProps = {
   name: string;
+  preview: boolean;
 };
 
 export default function IndexPage(props: IndexPageProps): JSX.Element {
   return (
     <React.Fragment>
+      {`Hello ${props.name}! This is an SSG Page using getStaticProps().`}
       <div>
-        {`Hello ${props.name}. This is an SSG page using getStaticProps(). It also has an image.`}
+        <p data-cy="preview-mode">{String(props.preview)}</p>
       </div>
-      <img src={"/app-store-badge.png"} alt={"An image"} />
     </React.Fragment>
   );
 }
 
-export function getStaticProps(): { props: IndexPageProps } {
+export function getStaticProps(ctx: GetStaticPropsContext): {
+  props: IndexPageProps;
+} {
   return {
-    props: { name: "serverless-next.js" }
+    props: {
+      name: "serverless-next.js",
+      preview: !!ctx.preview
+    }
   };
 }

--- a/packages/e2e-tests/next-app/pages/ssr-page-2.tsx
+++ b/packages/e2e-tests/next-app/pages/ssr-page-2.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+type SsrPage2Props = {
+  name: string;
+};
+
+export default function SsrPage2(props: SsrPage2Props): JSX.Element {
+  return (
+    <React.Fragment>
+      <div>
+        {`Hello ${props.name}. This is an SSR page using getServerSideProps(). It also has an image.`}
+      </div>
+      <img src={"/app-store-badge.png"} alt={"An image"} />
+    </React.Fragment>
+  );
+}
+
+export function getServerSideProps(): { props: SsrPage2Props } {
+  return {
+    props: { name: "serverless-next.js" }
+  };
+}

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
@@ -255,6 +255,24 @@ describe("Lambda@Edge origin response", () => {
     });
   });
 
+  describe("SSG page requests", () => {
+    it("index page is routed properly", async () => {
+      const event = createCloudFrontEvent({
+        uri: "/index.html",
+        host: "mydistribution.cloudfront.net",
+        config: { eventType: "origin-response" } as any,
+        response: {
+          headers: {},
+          status: "200"
+        } as any
+      });
+
+      const response = await handler(event);
+      const cfResponse = response as CloudFrontResultResponse;
+      expect(cfResponse.status).toBe("200");
+    });
+  });
+
   describe("SSR data requests", () => {
     it("does not upload to S3", async () => {
       const event = createCloudFrontEvent({


### PR DESCRIPTION
As a result, for static pages, in the origin response handler the route is wrong and it cannot find a route for "/index" and it leads to setting a status code of 404.

Fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/1277