### PR TITLE
Fix ISR, make tests retryable

### DIFF
--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -50,7 +50,8 @@ export const handlePageReq = (
       isData: false,
       isStatic: true,
       file: pageHtml(localeUri),
-      page: pages.ssr.nonDynamic[route], // page JS path is from SSR entries in manifest
+      // page JS path is from SSR entries in manifest
+      page: pages.ssr.nonDynamic[route] || pages.ssr.dynamic[route],
       revalidate: ssg.initialRevalidateSeconds,
       statusCode
     };


### PR DESCRIPTION
Fixes prerendered dynamic ISR broken in #1238

Also, makes the ISR tests retryable so that failures can be trusted.