### PR TITLE
chore(e2e-tests): comment out random sleep for e2e tests

### DIFF
--- a/packages/e2e-tests/test-utils/scripts/run-e2e-ci.ts
+++ b/packages/e2e-tests/test-utils/scripts/run-e2e-ci.ts
@@ -290,8 +290,9 @@ async function runEndToEndTest(): Promise<boolean> {
       { stdio: "inherit" }
     );
 
-    // Sleep a few seconds to prevent exhausting API limits. TODO: smarter throttling.
-    await new Promise((resolve) => setTimeout(resolve, Math.random() * 15000));
+    // Sleep a few seconds to prevent exhausting API limits.
+    // (likely not needed anymore due to changing retry policy)
+    // await new Promise((resolve) => setTimeout(resolve, Math.random() * 15000));
 
     // Deploy
     console.info("Deploying serverless-next.js app.");


### PR DESCRIPTION
* Now that there is a longer retry policy, it may not be necessary anymore?