### PR TITLE
feat: Add domain locale detection (#1283)

### DIFF
--- a/packages/libs/core/src/build/index.ts
+++ b/packages/libs/core/src/build/index.ts
@@ -3,7 +3,6 @@ import {
   ApiManifest,
   DynamicSSG,
   Manifest,
-  NonDynamicSSG,
   PageManifest,
   RoutesManifest
 } from "../types";
@@ -12,7 +11,6 @@ import { normaliseDomainRedirects } from "./normaliseDomainRedirects";
 import { pathToRegexStr } from "./pathToRegexStr";
 import { PrerenderManifest } from "next/dist/build";
 import { getSortedRoutes } from "./sortedRoutes";
-import { addDefaultLocaleToPath } from "../route/locale";
 import { usedSSR } from "./ssr";
 
 export const prepareBuildManifests = async (

--- a/packages/libs/core/src/handle/default.ts
+++ b/packages/libs/core/src/handle/default.ts
@@ -3,7 +3,7 @@ import { setCustomHeaders } from "./headers";
 import { redirect } from "./redirect";
 import { toRequest } from "./request";
 import { routeDefault } from "../route";
-import { addDefaultLocaleToPath } from "../route/locale";
+import { addDefaultLocaleToPath, findDomainLocale } from "../route/locale";
 import {
   Event,
   ExternalRoute,
@@ -30,7 +30,11 @@ export const renderRoute = async (
 
   // For SSR rewrites to work the page needs to be passed a localized url
   if (req.url && routesManifest.i18n && !route.isData) {
-    req.url = addDefaultLocaleToPath(req.url, routesManifest);
+    req.url = addDefaultLocaleToPath(
+      req.url,
+      routesManifest,
+      findDomainLocale(req, routesManifest)
+    );
   }
 
   // Sets error page status code so _error renders the right page

--- a/packages/libs/core/src/route/locale.ts
+++ b/packages/libs/core/src/route/locale.ts
@@ -1,11 +1,37 @@
-import { Manifest, RoutesManifest } from "../types";
+import { DomainData, Manifest, RoutesManifest } from "../types";
+import { IncomingMessage } from "http";
+
+export const findDomainLocale = (
+  req: IncomingMessage,
+  manifest: RoutesManifest
+): string | boolean => {
+  const domains =
+    manifest.i18n && manifest.i18n.domains ? manifest.i18n.domains : null;
+  if (domains) {
+    const hostHeaders = req.headers.host?.split(",");
+    if (hostHeaders && hostHeaders.length > 0) {
+      const host = hostHeaders[0];
+      const matchedDomain = domains.find(
+        (d): DomainData | boolean => d.domain === host
+      );
+
+      if (matchedDomain) {
+        return matchedDomain.defaultLocale;
+      }
+    }
+  }
+  return false;
+};
 
 export function addDefaultLocaleToPath(
   path: string,
-  routesManifest: RoutesManifest
+  routesManifest: RoutesManifest,
+  forceLocale: string | boolean = false
 ): string {
   if (routesManifest.i18n) {
-    const defaultLocale = routesManifest.i18n.defaultLocale;
+    const defaultLocale = forceLocale
+      ? forceLocale
+      : routesManifest.i18n.defaultLocale;
     const locales = routesManifest.i18n.locales;
     const basePath = path.startsWith(routesManifest.basePath)
       ? routesManifest.basePath

--- a/packages/libs/core/src/route/locale.ts
+++ b/packages/libs/core/src/route/locale.ts
@@ -4,7 +4,7 @@ import { IncomingMessage } from "http";
 export const findDomainLocale = (
   req: IncomingMessage,
   manifest: RoutesManifest
-): string | boolean => {
+): string | null => {
   const domains =
     manifest.i18n && manifest.i18n.domains ? manifest.i18n.domains : null;
   if (domains) {
@@ -20,18 +20,17 @@ export const findDomainLocale = (
       }
     }
   }
-  return false;
+  return null;
 };
 
 export function addDefaultLocaleToPath(
   path: string,
   routesManifest: RoutesManifest,
-  forceLocale: string | boolean = false
+  forceLocale: string | null = null
 ): string {
   if (routesManifest.i18n) {
-    const defaultLocale = forceLocale
-      ? forceLocale
-      : routesManifest.i18n.defaultLocale;
+    const defaultLocale = forceLocale ?? routesManifest.i18n.defaultLocale;
+
     const locales = routesManifest.i18n.locales;
     const basePath = path.startsWith(routesManifest.basePath)
       ? routesManifest.basePath
@@ -43,7 +42,9 @@ export function addDefaultLocaleToPath(
         path === `${basePath}/${locale}` ||
         path.startsWith(`${basePath}/${locale}/`)
       ) {
-        return path;
+        return typeof forceLocale === "string"
+          ? path.replace(`${locale}/`, `${forceLocale}/`)
+          : path;
       }
     }
 

--- a/packages/libs/core/src/types.ts
+++ b/packages/libs/core/src/types.ts
@@ -113,10 +113,17 @@ export type HeaderData = {
   regex: string;
 };
 
+export type DomainData = {
+  domain: string;
+  defaultLocale: string;
+  locales?: string[];
+};
+
 export type I18nData = {
   locales: string[];
   defaultLocale: string;
   localeDetection: boolean;
+  domains?: DomainData[];
 };
 
 export type RoutesManifest = {

--- a/packages/libs/core/src/types.ts
+++ b/packages/libs/core/src/types.ts
@@ -122,7 +122,7 @@ export type DomainData = {
 export type I18nData = {
   locales: string[];
   defaultLocale: string;
-  localeDetection: boolean;
+  localeDetection?: boolean;
   domains?: DomainData[];
 };
 


### PR DESCRIPTION
This implements basic domain locale detection now the `config.i18n.domains` section is respected.

I'm open for refactoring suggestions, as I'm not really deep in this project. Just wanted to get it in a pulll request, as I'm on vacation next week.