### PR TITLE
fix(core): add s-maxage=0 cache-control headers to redirect responses

### DIFF
--- a/packages/e2e-tests/test-utils/cypress/custom-commands.ts
+++ b/packages/e2e-tests/test-utils/cypress/custom-commands.ts
@@ -147,6 +147,8 @@ Cypress.Commands.add(
         } else {
           expect(response.headers["refresh"]).to.be.undefined;
         }
+
+        expect(response.headers["cache-control"]).to.equal("s-maxage=0");
       }
     );
   }

--- a/packages/libs/core/src/route/redirect.ts
+++ b/packages/libs/core/src/route/redirect.ts
@@ -39,6 +39,13 @@ export function createRedirectResponse(
         ]
       : [];
 
+  const cacheControl = [
+    {
+      key: "Cache-Control",
+      value: "s-maxage=0"
+    }
+  ];
+
   return {
     isRedirect: true,
     status: status,
@@ -50,7 +57,8 @@ export function createRedirectResponse(
           value: location
         }
       ],
-      refresh: refresh
+      refresh: refresh,
+      "cache-control": cacheControl
     }
   };
 }

--- a/packages/libs/core/tests/route/redirect.test.ts
+++ b/packages/libs/core/tests/route/redirect.test.ts
@@ -99,7 +99,8 @@ describe("Redirector Tests", () => {
               key: "Refresh",
               value: `0;url=/terms`
             }
-          ]
+          ],
+          "cache-control": "s-maxage=0"
         }
       });
     });
@@ -117,7 +118,8 @@ describe("Redirector Tests", () => {
               value: "/terms?a=123"
             }
           ],
-          refresh: []
+          refresh: [],
+          "cache-control": "s-maxage=0"
         }
       });
     });

--- a/packages/libs/core/tests/route/redirect.test.ts
+++ b/packages/libs/core/tests/route/redirect.test.ts
@@ -119,7 +119,12 @@ describe("Redirector Tests", () => {
             }
           ],
           refresh: [],
-          "cache-control": "s-maxage=0"
+          "cache-control": [
+            {
+              key: "Cache-Control",
+              value: "s-maxage=0"
+            }
+          ]
         }
       });
     });

--- a/packages/libs/core/tests/route/redirect.test.ts
+++ b/packages/libs/core/tests/route/redirect.test.ts
@@ -100,7 +100,12 @@ describe("Redirector Tests", () => {
               value: `0;url=/terms`
             }
           ],
-          "cache-control": "s-maxage=0"
+          "cache-control": [
+            {
+              key: "Cache-Control",
+              value: "s-maxage=0"
+            }
+          ]
         }
       });
     });

--- a/packages/libs/lambda-at-edge/tests/utils/runRedirectTest.ts
+++ b/packages/libs/lambda-at-edge/tests/utils/runRedirectTest.ts
@@ -40,7 +40,12 @@ export async function runRedirectTestWithHandler(
       }
     ],
     refresh: refresh,
-    "cache-control": "s-maxage=0"
+    "cache-control": [
+      {
+        key: "Cache-Control",
+        value: "s-maxage=0"
+      }
+    ]
   });
   expect(response.status.toString()).toEqual(statusCode.toString());
 }

--- a/packages/libs/lambda-at-edge/tests/utils/runRedirectTest.ts
+++ b/packages/libs/lambda-at-edge/tests/utils/runRedirectTest.ts
@@ -39,7 +39,8 @@ export async function runRedirectTestWithHandler(
         value: expectedRedirect
       }
     ],
-    refresh: refresh
+    refresh: refresh,
+    "cache-control": "s-maxage=0"
   });
   expect(response.status.toString()).toEqual(statusCode.toString());
 }


### PR DESCRIPTION
* To be consistent with Next.js (see vercel.com redirection behavior)