### PR TITLE
Fix flaky image handler test

### DIFF
--- a/packages/libs/lambda-at-edge/tests/image-handler/image-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/image-handler/image-handler-with-basepath.test.ts
@@ -50,10 +50,10 @@ describe("Image lambda handler", () => {
 
   describe("Routes", () => {
     it.each`
-      imagePath                                  | expectedS3Key
-      ${"/test-image.png"}                       | ${"basepath/public/test-image.png"}
-      ${"/basepath/static/test-image.png"}       | ${"basepath/static/test-image.png"}
-      ${"/basepath/_next/static/test-image.png"} | ${"basepath/_next/static/test-image.png"}
+      imagePath                                     | expectedS3Key
+      ${"/test-image-bp.png"}                       | ${"basepath/public/test-image-bp.png"}
+      ${"/basepath/static/test-image-bp.png"}       | ${"basepath/static/test-image-bp.png"}
+      ${"/basepath/_next/static/test-image-bp.png"} | ${"basepath/_next/static/test-image-bp.png"}
     `("serves image request", async ({ imagePath, expectedS3Key }) => {
       const event = createCloudFrontEvent({
         uri: `/_next/image?url=${encodeURI(imagePath)}&q=100&w=128`,
@@ -92,11 +92,10 @@ describe("Image lambda handler", () => {
         bodyEncoding: "base64"
       });
 
-      // FIXME: flaky in CI?
-      // expect(MockGetObjectCommand).toBeCalledWith({
-      //   Bucket: "my-bucket.s3.amazonaws.com",
-      //   Key: expectedS3Key
-      // });
+      expect(MockGetObjectCommand).toBeCalledWith({
+        Bucket: "my-bucket.s3.amazonaws.com",
+        Key: expectedS3Key
+      });
     });
 
     it("return 500 response when s3 throw an error", async () => {

--- a/packages/libs/lambda-at-edge/tests/image-handler/image-handler.test.ts
+++ b/packages/libs/lambda-at-edge/tests/image-handler/image-handler.test.ts
@@ -125,6 +125,66 @@ describe("Image lambda handler", () => {
       expect(MockGetObjectCommand).toBeCalledTimes(1);
     });
 
+    it.each`
+      imagePath
+      ${"/test-image-etag.png"}
+    `("serves 304 when etag matches", async ({ imagePath }) => {
+      const event1 = createCloudFrontEvent({
+        uri: `/_next/image?url=${encodeURI(imagePath)}&q=100&w=128`,
+        host: "mydistribution.cloudfront.net",
+        requestHeaders: {
+          accept: [
+            {
+              key: "accept",
+              value: "image/webp"
+            }
+          ]
+        }
+      });
+
+      const response1 = (await handler(event1)) as CloudFrontResponseResult;
+
+      const event2 = createCloudFrontEvent({
+        uri: `/_next/image?url=${encodeURI(imagePath)}&q=100&w=128`,
+        host: "mydistribution.cloudfront.net",
+        requestHeaders: {
+          accept: [
+            {
+              key: "accept",
+              value: "image/webp"
+            }
+          ],
+          "if-none-match": [
+            {
+              key: "if-none-match",
+              value: response1.headers.etag[0].value
+            }
+          ]
+        }
+      });
+
+      const response2 = (await handler(event2)) as CloudFrontResponseResult;
+
+      expect(response2).toEqual({
+        headers: {
+          "cache-control": [
+            {
+              key: "Cache-Control",
+              value: "public, max-age=60"
+            }
+          ],
+          etag: [
+            {
+              key: "ETag",
+              value: response1.headers.etag[0].value
+            }
+          ]
+        },
+        status: 304,
+        statusDescription: "Not Modified"
+      });
+    });
+
     it("serves external image request", async () => {
       const imageBuffer: Buffer = await sharp({
         create: {


### PR DESCRIPTION
Sharing filenames with the non-basepath test meant these sometimes got served from cache.

Using `yarn jest` they could happen either order and the other would fail randomly.

This unshares the names and adds explicit tests for caching.