### PR TITLE
Not found support in SSG fallback

### DIFF
--- a/packages/compat-layers/lambda-at-edge-compat/__tests__/next-aws-cloudfront.response.test.js
+++ b/packages/compat-layers/lambda-at-edge-compat/__tests__/next-aws-cloudfront.response.test.js
@@ -119,7 +119,36 @@ describe("Response Tests", () => {
     });
   });
 
-  it("writeHead preserves existing special CloudFront Headers", () => {
+  it("writeHead preserves existing Headers", () => {
+    expect.assertions(1);
+
+    const cloudFrontReadOnlyHeaders = {
+      "Content-Length": "1234",
+      "x-custom-1": "1"
+    };
+
+    const { res, responsePromise } = create({
+      request: {
+        uri: "/",
+        headers: {}
+      },
+      response: {
+        headers: cloudFrontReadOnlyHeaders
+      }
+    });
+
+    res.writeHead(200, {});
+    res.end();
+
+    return responsePromise.then((response) => {
+      expect(response.headers).toEqual({
+        "content-length": "1234",
+        "x-custom-1": "1"
+      });
+    });
+  });
+
+  it("writeHead does not overwrite special CloudFront Headers", () => {
     expect.assertions(1);
 
     const cloudFrontReadOnlyHeaders = {

--- a/packages/compat-layers/lambda-at-edge-compat/next-aws-cloudfront.js
+++ b/packages/compat-layers/lambda-at-edge-compat/next-aws-cloudfront.js
@@ -214,6 +214,7 @@ const handler = (
   const headerNames = {};
   res.writeHead = (status, headers) => {
     response.status = status;
+    response.statusDescription = HttpStatusCodes[status];
 
     if (headers) {
       res.headers = Object.assign(res.headers, headers);

--- a/packages/compat-layers/lambda-at-edge-compat/next-aws-cloudfront.js
+++ b/packages/compat-layers/lambda-at-edge-compat/next-aws-cloudfront.js
@@ -92,9 +92,9 @@ const HttpStatusCodes = {
 
 const toCloudFrontHeaders = (headers, headerNames, originalHeaders) => {
   const result = {};
-  const lowerCaseOriginalHeaders = {};
-  Object.entries(originalHeaders).forEach(([header, value]) => {
-    lowerCaseOriginalHeaders[header.toLowerCase()] = value;
+
+  Object.entries(originalHeaders).forEach(([headerName, headerValue]) => {
+    result[headerName.toLowerCase()] = headerValue;
   });
 
   Object.entries(headers).forEach(([headerName, headerValue]) => {
@@ -102,9 +102,6 @@ const toCloudFrontHeaders = (headers, headerNames, originalHeaders) => {
     headerName = headerNames[headerKey] || headerName;
 
     if (readOnlyCloudFrontHeaders[headerKey]) {
-      if (lowerCaseOriginalHeaders[headerKey]) {
-        result[headerKey] = lowerCaseOriginalHeaders[headerKey];
-      }
       return;
     }
 

--- a/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
@@ -454,13 +454,13 @@ describe("Pages Tests", () => {
     [{ path: "/optional-catch-all-ssg-with-fallback/not-found" }].forEach(
       ({ path }) => {
         ["HEAD", "GET"].forEach((method) => {
-          it(`allows HTTP method for path ${path}: ${method} and returns 404 status`, () => {
+          it(`allows HTTP method for path ${path}: ${method} and returns 200 status`, () => {
             cy.request({
               url: path,
               method: method,
               failOnStatusCode: false
             }).then((response) => {
-              expect(response.status).to.equal(404);
+              expect(response.status).to.equal(200);
             });
           });
         });

--- a/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
@@ -451,7 +451,7 @@ describe("Pages Tests", () => {
       });
     });
 
-    [{ path: "/optional-catch-all-ssg-fallback/not-found" }].forEach(
+    [{ path: "/optional-catch-all-ssg-with-fallback/not-found" }].forEach(
       ({ path }) => {
         ["HEAD", "GET"].forEach((method) => {
           it(`allows HTTP method for path ${path}: ${method} and returns 404 status`, () => {

--- a/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-dynamic-routes/cypress/integration/pages.test.ts
@@ -348,7 +348,7 @@ describe("Pages Tests", () => {
         prerendered: true
       },
       {
-        path: "/optional-catch-all-ssg-with-fallback/not-found",
+        path: "/optional-catch-all-ssg-with-fallback/not-prerendered",
         param: "",
         prerendered: false
       }
@@ -450,6 +450,49 @@ describe("Pages Tests", () => {
         //  However, verified manually that it works correctly.
       });
     });
+
+    [{ path: "/optional-catch-all-ssg-fallback/not-found" }].forEach(
+      ({ path }) => {
+        ["HEAD", "GET"].forEach((method) => {
+          it(`allows HTTP method for path ${path}: ${method} and returns 404 status`, () => {
+            cy.request({
+              url: path,
+              method: method,
+              failOnStatusCode: false
+            }).then((response) => {
+              expect(response.status).to.equal(404);
+            });
+          });
+        });
+
+        ["DELETE", "POST", "OPTIONS", "PUT", "PATCH"].forEach((method) => {
+          it(`disallows HTTP method for path ${path} with 4xx status code: ${method}`, () => {
+            cy.request({
+              url: path,
+              method: method,
+              failOnStatusCode: false
+            }).then((response) => {
+              expect(response.status).to.be.gte(400);
+            });
+          });
+        });
+
+        it(`returns 404 on data request for ${path}`, () => {
+          const fullPath = `/_next/data/${buildId}${path.replace(
+            /\/$/,
+            "/index"
+          )}.json`;
+
+          cy.request({
+            url: fullPath,
+            method: "GET",
+            failOnStatusCode: false
+          }).then((response) => {
+            expect(response.status).to.equal(404);
+          });
+        });
+      }
+    );
   });
 
   describe("Dynamic SSR page", () => {

--- a/packages/e2e-tests/next-app-dynamic-routes/pages/optional-catch-all-ssg-with-fallback/[[...catch]].tsx
+++ b/packages/e2e-tests/next-app-dynamic-routes/pages/optional-catch-all-ssg-with-fallback/[[...catch]].tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GetServerSidePropsContext } from "next";
+import { GetServerSidePropsContext, GetStaticPropsResult } from "next";
 
 type OptionalCatchAllPageProps = {
   name: string;
@@ -22,8 +22,14 @@ export default function OptionalCatchAllPage(
 
 export async function getStaticProps(
   ctx: GetServerSidePropsContext
-): Promise<{ props: OptionalCatchAllPageProps }> {
+): Promise<GetStaticPropsResult<OptionalCatchAllPageProps>> {
   const catchAll = ((ctx.params?.catch as string[]) ?? []).join("/");
+
+  if (catchAll === "not-found") {
+    return {
+      notFound: true
+    }
+  }
 
   return {
     props: { name: "serverless-next.js", catch: catchAll }

--- a/packages/e2e-tests/next-app-dynamic-routes/pages/optional-catch-all-ssg-with-fallback/[[...catch]].tsx
+++ b/packages/e2e-tests/next-app-dynamic-routes/pages/optional-catch-all-ssg-with-fallback/[[...catch]].tsx
@@ -28,7 +28,7 @@ export async function getStaticProps(
   if (catchAll === "not-found") {
     return {
       notFound: true
-    }
+    };
   }
 
   return {

--- a/packages/libs/core/src/build/index.ts
+++ b/packages/libs/core/src/build/index.ts
@@ -140,9 +140,11 @@ export const prepareBuildManifests = async (
   );
 
   // Add not found SSG routes
+  const notFound: { [key: string]: true } = {};
   (prerenderManifest.notFoundRoutes ?? []).forEach((route) => {
-    ssgPages.notFound[route] = true;
+    notFound[route] = true;
   });
+  ssgPages.notFound = notFound;
 
   // Include only SSR routes that are in runtime use
   const ssrPages = (pageManifest.pages.ssr = usedSSR(

--- a/packages/libs/core/src/build/index.ts
+++ b/packages/libs/core/src/build/index.ts
@@ -140,7 +140,7 @@ export const prepareBuildManifests = async (
   );
 
   // Add not found SSG routes
-  prerenderManifest.notFoundRoutes.forEach((route) => {
+  (prerenderManifest.notFoundRoutes ?? []).forEach((route) => {
     ssgPages.notFound[route] = true;
   });
 

--- a/packages/libs/core/src/build/index.ts
+++ b/packages/libs/core/src/build/index.ts
@@ -46,7 +46,8 @@ export const prepareBuildManifests = async (
       },
       ssg: {
         dynamic: {},
-        nonDynamic: {}
+        nonDynamic: {},
+        notFound: {}
       }
     },
     publicFiles: {},
@@ -137,6 +138,11 @@ export const prepareBuildManifests = async (
       };
     }
   );
+
+  // Add not found SSG routes
+  prerenderManifest.notFoundRoutes.forEach((route) => {
+    ssgPages.notFound[route] = true;
+  });
 
   // Include only SSR routes that are in runtime use
   const ssrPages = (pageManifest.pages.ssr = usedSSR(

--- a/packages/libs/core/src/handle/fallback.ts
+++ b/packages/libs/core/src/handle/fallback.ts
@@ -49,14 +49,22 @@ const renderFallback = async (
 
   const page = getPage(route.page);
   try {
-    const { html, notFound, renderOpts } = await page.renderReqToHTML(
+    const { html, renderOpts } = await page.renderReqToHTML(
       req,
       res,
       "passthrough"
     );
-    if (notFound) {
+
+    if (renderOpts.isNotFound) {
+      if (route.isData) {
+        res.setHeader("Content-Type", "application/json");
+        res.statusCode = 404;
+        res.end(JSON.stringify({ notFound: true }));
+        return;
+      }
       return renderNotFound(event, manifest, routesManifest, getPage);
     }
+
     return { isStatic: false, route, html, renderOpts };
   } catch (error) {
     return renderErrorPage(

--- a/packages/libs/core/src/route/data.ts
+++ b/packages/libs/core/src/route/data.ts
@@ -53,6 +53,9 @@ export const handleDataReq = (
       revalidate: ssg.initialRevalidateSeconds
     };
   }
+  if (pages.ssg.notFound[localeUri] && !isPreview) {
+    return notFoundData(uri, manifest, routesManifest);
+  }
   if (pages.ssr.nonDynamic[localeUri]) {
     return {
       isData: true,

--- a/packages/libs/core/src/route/data.ts
+++ b/packages/libs/core/src/route/data.ts
@@ -53,7 +53,7 @@ export const handleDataReq = (
       revalidate: ssg.initialRevalidateSeconds
     };
   }
-  if (pages.ssg.notFound[localeUri] && !isPreview) {
+  if ((pages.ssg.notFound ?? {})[localeUri] && !isPreview) {
     return notFoundData(uri, manifest, routesManifest);
   }
   if (pages.ssr.nonDynamic[localeUri]) {

--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -56,7 +56,7 @@ export const handlePageReq = (
       statusCode
     };
   }
-  if (pages.ssg.notFound[localeUri] && !isPreview) {
+  if ((pages.ssg.notFound ?? {})[localeUri] && !isPreview) {
     return notFoundPage(uri, manifest, routesManifest);
   }
   if (pages.ssr.nonDynamic[localeUri]) {

--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -56,6 +56,9 @@ export const handlePageReq = (
       statusCode
     };
   }
+  if (pages.ssg.notFound[localeUri] && !isPreview) {
+    return notFoundPage(uri, manifest, routesManifest);
+  }
   if (pages.ssr.nonDynamic[localeUri]) {
     return {
       isData: false,

--- a/packages/libs/core/src/types.ts
+++ b/packages/libs/core/src/types.ts
@@ -93,6 +93,9 @@ export type PageManifest = Manifest & {
       nonDynamic: {
         [key: string]: NonDynamicSSG;
       };
+      notFound: {
+        [key: string]: true;
+      };
     };
     ssr: {
       dynamic: { [key: string]: string };

--- a/packages/libs/core/src/types.ts
+++ b/packages/libs/core/src/types.ts
@@ -93,7 +93,7 @@ export type PageManifest = Manifest & {
       nonDynamic: {
         [key: string]: NonDynamicSSG;
       };
-      notFound: {
+      notFound?: {
         [key: string]: true;
       };
     };

--- a/packages/libs/core/tests/handle/default.test.ts
+++ b/packages/libs/core/tests/handle/default.test.ts
@@ -25,7 +25,7 @@ describe("Default handler", () => {
   beforeAll(async () => {
     prerenderManifest = {
       version: 3,
-      notFoundRoutes: [],
+      notFoundRoutes: ["/fallback/404"],
       routes: {
         "/ssg": {
           initialRevalidateSeconds: false,
@@ -262,6 +262,7 @@ describe("Default handler", () => {
       ${"/foo"}          | ${"pages/[root].html"}
       ${"/html/bar"}     | ${"pages/html/[page].html"}
       ${"/fallback/new"} | ${"pages/fallback/new.html"}
+      ${"/fallback/404"} | ${"pages/404.html"}
       ${"/rewrite-path"} | ${"pages/[root].html"}
     `("Routes static page $uri to file $file", async ({ uri, file }) => {
       const route = await handleDefault(
@@ -282,6 +283,7 @@ describe("Default handler", () => {
     it.each`
       uri                                              | file
       ${"/_next/data/test-build-id/fallback/new.json"} | ${"/_next/data/test-build-id/fallback/new.json"}
+      ${"/_next/data/test-build-id/fallback/404.json"} | ${"pages/404.html"}
       ${"/_next/data/test-build-id/not-found.json"}    | ${"pages/404.html"}
       ${"/_next/data/not-build-id/fallback/new.json"}  | ${"pages/404.html"}
     `("Routes static data route $uri to file $file", async ({ uri, file }) => {

--- a/packages/libs/core/tests/route/rewrite.test.ts
+++ b/packages/libs/core/tests/route/rewrite.test.ts
@@ -73,7 +73,8 @@ describe("Rewriter Tests", () => {
           },
           ssg: {
             dynamic: {},
-            nonDynamic: {}
+            nonDynamic: {},
+            notFound: {}
           },
           ssr: {
             dynamic: {},

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -437,12 +437,7 @@ const handleOriginResponse = async ({
   const cacheControl =
     (isrResponse && isrResponse.cacheControl) ||
     "public, max-age=0, s-maxage=2678400, must-revalidate";
-  const outHeaders: OutgoingHttpHeaders = {};
-  Object.entries(response.headers).map(([name, headers]) => {
-    outHeaders[name] = headers.map(({ value }) => value);
-  });
 
-  res.writeHead(200, outHeaders);
   res.setHeader("Cache-Control", cacheControl);
 
   if (fallbackRoute.route.isData) {

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -378,39 +378,22 @@ const handleOriginResponse = async ({
     const s3Response = await s3.send(new GetObjectCommand(s3Params));
     const bodyString = await getStream.default(s3Response.Body as Readable);
 
-    const statusCode = (fallbackRoute.statusCode || 200).toString();
-    const is404 = statusCode === "404";
-    const is500 = statusCode === "500";
-    return {
-      status: statusCode,
-      statusDescription: is500
-        ? "Internal Server Error"
-        : is404
-        ? "Not Found"
-        : "OK",
-      headers: {
-        ...response.headers,
-        ...getCustomHeaders(request.uri, routesManifest),
-        "content-type": [
-          {
-            key: "Content-Type",
-            value: "text/html"
-          }
-        ],
-        "cache-control": [
-          {
-            key: "Cache-Control",
-            value: is500
-              ? "public, max-age=0, s-maxage=0, must-revalidate" // static 500 page should never be cached
-              : s3Response.CacheControl ??
-                (fallbackRoute.fallback // Use cache-control from S3 response if possible, otherwise use defaults
-                  ? "public, max-age=0, s-maxage=0, must-revalidate" // fallback should never be cached
-                  : "public, max-age=0, s-maxage=2678400, must-revalidate")
-          }
-        ]
-      },
-      body: bodyString
-    };
+    const statusCode = fallbackRoute.statusCode || 200;
+    const is500 = statusCode === 500;
+
+    const cacheControl = is500
+      ? "public, max-age=0, s-maxage=0, must-revalidate" // static 500 page should never be cached
+      : s3Response.CacheControl ??
+        (fallbackRoute.fallback // Use cache-control from S3 response if possible, otherwise use defaults
+          ? "public, max-age=0, s-maxage=0, must-revalidate" // fallback should never be cached
+          : "public, max-age=0, s-maxage=2678400, must-revalidate");
+
+    res.writeHead(statusCode, {
+      "Cache-Control": cacheControl,
+      "Content-Type": "text/html"
+    });
+    res.end(bodyString);
+    return await responsePromise;
   }
 
   // This is a fallback route that should be stored in S3 before returning it

--- a/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-dynamic.test.ts
@@ -214,6 +214,9 @@ describe("Builder Tests (dynamic)", () => {
             initialRevalidateSeconds: 60,
             srcRoute: null
           }
+        },
+        notFound: {
+          "/fallback/not-found": true
         }
       });
 

--- a/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-no-api.test.ts
@@ -118,7 +118,8 @@ describe("Builder Tests (no API routes)", () => {
             srcRoute: null
           }
         },
-        dynamic: {}
+        dynamic: {},
+        notFound: {}
       });
 
       expect(ssr).toEqual({

--- a/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/build-with-locales.test.ts
@@ -190,7 +190,8 @@ describe("Builder Tests (with locales)", () => {
             srcRoute: null
           }
         },
-        dynamic: {}
+        dynamic: {},
+        notFound: {}
       });
 
       expect(publicFiles).toEqual({

--- a/packages/libs/lambda-at-edge/tests/build/dynamic-app-fixture/.next/prerender-manifest.json
+++ b/packages/libs/lambda-at-edge/tests/build/dynamic-app-fixture/.next/prerender-manifest.json
@@ -57,7 +57,9 @@
             "dataRouteRegex": "^/_next/data/test-build-id/fallback\\-blocking/([^/]+?)\\.json$"
         }
     },
-    "notFoundRoutes": [],
+    "notFoundRoutes": [
+        "/fallback/not-found"
+    ],
     "preview": {
         "previewModeId": "815c0e1086134f5f9a666832bd0b2a95",
         "previewModeSigningKey": "0aa4fa146a001d1053ec5056e1afbc933e390de4410a68782ccada0ec1066ac9",

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
@@ -65,6 +65,7 @@ describe("Lambda@Edge origin response", () => {
         host: "mydistribution.cloudfront.net",
         config: { eventType: "origin-response" } as any,
         response: {
+          headers: {},
           status: "403"
         } as any
       });
@@ -79,7 +80,7 @@ describe("Lambda@Edge origin response", () => {
       });
 
       expect(response).toEqual({
-        status: "200",
+        status: 200,
         statusDescription: "OK",
         headers: {
           "cache-control": [
@@ -95,7 +96,8 @@ describe("Lambda@Edge origin response", () => {
             }
           ]
         },
-        body: "S3Body"
+        body: "UzNCb2R5",
+        bodyEncoding: "base64"
       });
     });
 
@@ -105,6 +107,7 @@ describe("Lambda@Edge origin response", () => {
         host: "mydistribution.cloudfront.net",
         config: { eventType: "origin-response" } as any,
         response: {
+          headers: {},
           status: "403"
         } as any
       });
@@ -119,7 +122,7 @@ describe("Lambda@Edge origin response", () => {
       });
 
       expect(response).toEqual({
-        status: "404",
+        status: 404,
         statusDescription: "Not Found",
         headers: {
           "cache-control": [
@@ -135,7 +138,8 @@ describe("Lambda@Edge origin response", () => {
             }
           ]
         },
-        body: "S3Body"
+        body: "UzNCb2R5",
+        bodyEncoding: "base64"
       });
     });
 

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath-origin-response.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath-origin-response.test.ts
@@ -65,6 +65,7 @@ describe("Lambda@Edge origin response", () => {
         host: "mydistribution.cloudfront.net",
         config: { eventType: "origin-response" } as any,
         response: {
+          headers: {},
           status: "403"
         } as any
       });
@@ -79,7 +80,7 @@ describe("Lambda@Edge origin response", () => {
       });
 
       expect(response).toEqual({
-        status: "200",
+        status: 200,
         statusDescription: "OK",
         headers: {
           "cache-control": [
@@ -95,7 +96,8 @@ describe("Lambda@Edge origin response", () => {
             }
           ]
         },
-        body: "S3Body"
+        body: "UzNCb2R5",
+        bodyEncoding: "base64"
       });
     });
 
@@ -105,6 +107,7 @@ describe("Lambda@Edge origin response", () => {
         host: "mydistribution.cloudfront.net",
         config: { eventType: "origin-response" } as any,
         response: {
+          headers: {},
           status: "403"
         } as any
       });
@@ -119,7 +122,7 @@ describe("Lambda@Edge origin response", () => {
       });
 
       expect(response).toEqual({
-        status: "404",
+        status: 404,
         statusDescription: "Not Found",
         headers: {
           "cache-control": [
@@ -135,7 +138,8 @@ describe("Lambda@Edge origin response", () => {
             }
           ]
         },
-        body: "S3Body"
+        body: "UzNCb2R5",
+        bodyEncoding: "base64"
       });
     });
 


### PR DESCRIPTION
Fixes #1286 and adds support for prerendered notFoundRoutes.

Does not cache notFound: true results in S3. It seems that next.js server does not cache them either.