### PR TITLE
fix(lambda-at-edge): fix reconstruction of basepath index uri

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -144,7 +144,7 @@ const reconstructOriginalRequestUri = (
   )}`;
 
   // For index.html page, it will become "/index", which is not a route so normalize it to "/"
-  originalUri = originalUri.replace(/^(\/index)?$/, "/");
+  originalUri = originalUri.replace(/\/index$/, "/");
 
   return originalUri;
 };

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-origin-response.json
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-build-manifest-origin-response.json
@@ -1,0 +1,113 @@
+{
+  "buildId": "build-id",
+  "pages": {
+    "dynamic": [
+      {
+        "route": "/blog/[id]",
+        "regex": "^\\/blog(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
+      },
+      {
+        "route": "/customers/[customer]",
+        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
+      },
+      {
+        "route": "/customers/[customer]/profile",
+        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))\\/profile[\\/#\\?]?$"
+      },
+      {
+        "route": "/customers/[customer]/[post]",
+        "regex": "^\\/customers(?:\\/([^\\/#\\?]+?))(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
+      },
+      {
+        "route": "/customers/[...catchAll]",
+        "regex": "^\\/customers(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
+      },
+      {
+        "route": "/fallback/[slug]",
+        "regex": "^\\/fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
+      },
+      {
+        "route": "/fallback-blocking/[slug]",
+        "regex": "^\\/fallback-blocking(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
+      },
+      {
+        "route": "/no-fallback/[slug]",
+        "regex": "^\\/no-fallback(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
+      },
+      {
+        "route": "/users/[...user]",
+        "regex": "^\\/users(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?[\\/#\\?]?$"
+      }
+    ],
+    "ssr": {
+      "dynamic": {
+        "/blog/[id]": "pages/blog/[id].js",
+        "/customers/[...catchAll]": "pages/customers/[...catchAll].js",
+        "/customers/[customer]": "pages/customers/[customer].js",
+        "/customers/[customer]/[post]": "pages/customers/[customer]/[post].js",
+        "/customers/[customer]/profile": "pages/customers/[customer]/profile.js",
+        "/fallback-blocking/[slug]": "pages/fallback-blocking/[slug].js",
+        "/fallback/[slug]": "pages/fallback/[slug].js",
+        "/no-fallback/[slug]": "pages/no-fallback/[slug].js"
+      },
+      "nonDynamic": {
+        "/async-page": "pages/async-page.js",
+        "/customers": "pages/customers.js",
+        "/customers/new": "pages/customers/new.js",
+        "/erroredPage": "pages/erroredPage.js",
+        "/": "pages/index.js",
+        "/preview": "pages/preview.js",
+        "/_error": "pages/_error.js"
+      }
+    },
+    "html": {
+      "dynamic": {
+        "/users/[...user]": "pages/users/[...user].html"
+      },
+      "nonDynamic": {
+        "/terms": "pages/terms.html",
+        "/404": "pages/404.html"
+      }
+    },
+    "ssg": {
+      "dynamic": {
+        "/fallback/[slug]": {
+          "fallback": "/fallback/[slug].html"
+        },
+        "/fallback-blocking/[slug]": {
+          "fallback": null
+        },
+        "/no-fallback/[slug]": {
+          "fallback": false
+        }
+      },
+      "nonDynamic": {
+        "/preview": {
+          "initialRevalidateSeconds": 5,
+          "srcRoute": null
+        },
+        "/fallback/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/fallback/[slug]"
+        },
+        "/": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": null
+        },
+        "/no-fallback/example-static-page": {
+          "initialRevalidateSeconds": false,
+          "srcRoute": "/no-fallback/[slug]"
+        }
+      }
+    }
+  },
+  "publicFiles": {
+    "/favicon.ico": "favicon.ico",
+    "/file with spaces.json": "file with spaces.json",
+    "/manifest.json": "manifest.json"
+  },
+  "trailingSlash": false,
+  "domainRedirects": {
+    "example.com": "https://www.example.com"
+  }
+}

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-origin-response.test.ts
@@ -21,7 +21,7 @@ jest.mock("@aws-sdk/client-s3/commands/PutObjectCommand", () =>
 
 jest.mock(
   "../../src/manifest.json",
-  () => require("./default-build-manifest.json"),
+  () => require("./default-build-manifest-origin-response.json"),
   {
     virtual: true
   }
@@ -260,7 +260,7 @@ describe("Lambda@Edge origin response", () => {
   });
 
   describe("SSG page requests", () => {
-    it("index page is routed properly", async () => {
+    it("index page has correct status code", async () => {
       const event = createCloudFrontEvent({
         uri: "/index.html",
         host: "mydistribution.cloudfront.net",

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath-origin-response.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath-origin-response.test.ts
@@ -21,7 +21,7 @@ jest.mock("@aws-sdk/client-s3/commands/PutObjectCommand", () =>
 
 jest.mock(
   "../../src/manifest.json",
-  () => require("./default-build-manifest.json"),
+  () => require("./default-build-manifest-origin-response.json"),
   {
     virtual: true
   }
@@ -245,6 +245,24 @@ describe("Lambda@Edge origin response", () => {
         ContentType: "text/html",
         CacheControl: "public, max-age=0, s-maxage=2678400, must-revalidate"
       });
+    });
+  });
+
+  describe("SSG page requests", () => {
+    it("index page has correct status code", async () => {
+      const event = createCloudFrontEvent({
+        uri: "/index.html",
+        host: "mydistribution.cloudfront.net",
+        config: { eventType: "origin-response" } as any,
+        response: {
+          headers: {},
+          status: "200"
+        } as any
+      });
+
+      const response = await handler(event);
+      const cfResponse = response as CloudFrontResultResponse;
+      expect(cfResponse.status).toBe("200");
     });
   });
 


### PR DESCRIPTION
Related: https://github.com/serverless-nextjs/serverless-next.js/issues/1277

Also removed the root catch-all in build manifest for all origin response tests so we can do a proper index page test that status code remains 200 (not 404).