### PR TITLE
test(e2e-tests): fix external site used in e2e tests

### DIFF
--- a/packages/e2e-tests/next-app-using-serverless-trace/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/next-app-using-serverless-trace/cypress/integration/redirects.test.ts
@@ -145,7 +145,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/external-redirect-1",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/next-app-using-serverless-trace/next.config.js
+++ b/packages/e2e-tests/next-app-using-serverless-trace/next.config.js
@@ -46,7 +46,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {

--- a/packages/e2e-tests/next-app-windows/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/next-app-windows/cypress/integration/redirects.test.ts
@@ -164,7 +164,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/external-redirect-1",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/next-app-windows/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/next-app-windows/cypress/integration/rewrites.test.ts
@@ -100,19 +100,19 @@ describe("Rewrites Tests", () => {
     [
       {
         path: "/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
         expectedStatus: 404

--- a/packages/e2e-tests/next-app-windows/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/next-app-windows/cypress/integration/rewrites.test.ts
@@ -115,7 +115,7 @@ describe("Rewrites Tests", () => {
         expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
-        expectedStatus: 404
+        expectedStatus: 201
       },
       {
         path: "/external-rewrite-issues?page=1",

--- a/packages/e2e-tests/next-app-windows/next.config.js
+++ b/packages/e2e-tests/next-app-windows/next.config.js
@@ -49,7 +49,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {
@@ -121,7 +121,7 @@ module.exports = {
       },
       {
         source: "/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/external-rewrite-issues",
@@ -133,7 +133,7 @@ module.exports = {
       },
       {
         source: "/api/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/api/external-rewrite-issues",

--- a/packages/e2e-tests/next-app-with-base-path/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/next-app-with-base-path/cypress/integration/redirects.test.ts
@@ -145,7 +145,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/basepath/external-redirect-1",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/next-app-with-base-path/next.config.js
+++ b/packages/e2e-tests/next-app-with-base-path/next.config.js
@@ -47,7 +47,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/redirects.test.ts
@@ -189,7 +189,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/external-redirect-1",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/rewrites.test.ts
@@ -100,19 +100,19 @@ describe("Rewrites Tests", () => {
     [
       {
         path: "/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
         expectedStatus: 404

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/cypress/integration/rewrites.test.ts
@@ -115,7 +115,7 @@ describe("Rewrites Tests", () => {
         expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
-        expectedStatus: 404
+        expectedStatus: 201
       },
       {
         path: "/external-rewrite-issues?page=1",

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/next.config.js
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/next.config.js
@@ -49,7 +49,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {
@@ -121,7 +121,7 @@ module.exports = {
       },
       {
         source: "/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/external-rewrite-issues",
@@ -133,7 +133,7 @@ module.exports = {
       },
       {
         source: "/api/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/api/external-rewrite-issues",

--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/redirects.test.ts
@@ -189,7 +189,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/external-redirect-1",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/rewrites.test.ts
@@ -120,7 +120,7 @@ describe("Rewrites Tests", () => {
         expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
-        expectedStatus: 404
+        expectedStatus: 201
       },
       {
         path: "/external-rewrite-issues?page=1",

--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/rewrites.test.ts
@@ -105,19 +105,19 @@ describe("Rewrites Tests", () => {
     [
       {
         path: "/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
         expectedStatus: 404

--- a/packages/e2e-tests/next-app-with-locales/next.config.js
+++ b/packages/e2e-tests/next-app-with-locales/next.config.js
@@ -49,7 +49,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {
@@ -125,7 +125,7 @@ module.exports = {
       },
       {
         source: "/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/external-rewrite-issues",
@@ -137,7 +137,7 @@ module.exports = {
       },
       {
         source: "/api/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/api/external-rewrite-issues",

--- a/packages/e2e-tests/next-app-with-trailing-slash/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/next-app-with-trailing-slash/cypress/integration/redirects.test.ts
@@ -160,7 +160,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/external-redirect-1/",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/next-app-with-trailing-slash/next.config.js
+++ b/packages/e2e-tests/next-app-with-trailing-slash/next.config.js
@@ -48,7 +48,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1/",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {

--- a/packages/e2e-tests/next-app/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/redirects.test.ts
@@ -164,7 +164,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/external-redirect-1",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/next-app/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/rewrites.test.ts
@@ -120,7 +120,7 @@ describe("Rewrites Tests", () => {
         expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
-        expectedStatus: 404
+        expectedStatus: 201
       },
       {
         path: "/external-rewrite-issues?page=1",

--- a/packages/e2e-tests/next-app/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/rewrites.test.ts
@@ -105,19 +105,19 @@ describe("Rewrites Tests", () => {
     [
       {
         path: "/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
         expectedStatus: 404

--- a/packages/e2e-tests/next-app/next.config.js
+++ b/packages/e2e-tests/next-app/next.config.js
@@ -49,7 +49,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {
@@ -121,7 +121,7 @@ module.exports = {
       },
       {
         source: "/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/external-rewrite-issues",
@@ -133,7 +133,7 @@ module.exports = {
       },
       {
         source: "/api/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/api/external-rewrite-issues",

--- a/packages/e2e-tests/prev-next-app-with-base-path/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/prev-next-app-with-base-path/cypress/integration/redirects.test.ts
@@ -145,7 +145,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/basepath/external-redirect-1",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/prev-next-app-with-base-path/next.config.js
+++ b/packages/e2e-tests/prev-next-app-with-base-path/next.config.js
@@ -44,7 +44,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {

--- a/packages/e2e-tests/prev-next-app-with-trailing-slash/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/prev-next-app-with-trailing-slash/cypress/integration/redirects.test.ts
@@ -160,7 +160,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/external-redirect-1/",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/prev-next-app-with-trailing-slash/next.config.js
+++ b/packages/e2e-tests/prev-next-app-with-trailing-slash/next.config.js
@@ -45,7 +45,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1/",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {

--- a/packages/e2e-tests/prev-next-app/cypress/integration/redirects.test.ts
+++ b/packages/e2e-tests/prev-next-app/cypress/integration/redirects.test.ts
@@ -164,7 +164,7 @@ describe("Redirects Tests", () => {
       },
       {
         path: "/external-redirect-1",
-        expectedRedirect: "https://jsonplaceholder.typicode.com",
+        expectedRedirect: "https://jsonplaceholder.typicode.com/users",
         expectedStatus: 200,
         expectedRedirectStatus: 308
       },

--- a/packages/e2e-tests/prev-next-app/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/prev-next-app/cypress/integration/rewrites.test.ts
@@ -100,19 +100,19 @@ describe("Rewrites Tests", () => {
     [
       {
         path: "/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "GET",
         expectedStatus: 200
       },
       {
         path: "/api/external-rewrite",
-        expectedRewrite: "https://jsonplaceholder.typicode.com",
+        expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
         expectedStatus: 404

--- a/packages/e2e-tests/prev-next-app/cypress/integration/rewrites.test.ts
+++ b/packages/e2e-tests/prev-next-app/cypress/integration/rewrites.test.ts
@@ -115,7 +115,7 @@ describe("Rewrites Tests", () => {
         expectedRewrite: "https://jsonplaceholder.typicode.com/users",
         method: "POST",
         body: '{ "hello": "world" }', // Check that body can passed to external rewrite
-        expectedStatus: 404
+        expectedStatus: 201
       },
       {
         path: "/external-rewrite-issues?page=1",

--- a/packages/e2e-tests/prev-next-app/next.config.js
+++ b/packages/e2e-tests/prev-next-app/next.config.js
@@ -46,7 +46,7 @@ module.exports = {
       },
       {
         source: "/external-redirect-1",
-        destination: "https://jsonplaceholder.typicode.com",
+        destination: "https://jsonplaceholder.typicode.com/users",
         permanent: true
       },
       {
@@ -118,7 +118,7 @@ module.exports = {
       },
       {
         source: "/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/external-rewrite-issues",
@@ -130,7 +130,7 @@ module.exports = {
       },
       {
         source: "/api/external-rewrite",
-        destination: "https://jsonplaceholder.typicode.com"
+        destination: "https://jsonplaceholder.typicode.com/users"
       },
       {
         source: "/api/external-rewrite-issues",


### PR DESCRIPTION
jsonplaceholder.typicode.com started adding Cloudflare browsers insights: https://support.cloudflare.com/hc/en-us/articles/360033929991-Cloudflare-Browser-Insights to the main page, which has a unique ID in the HTML source each time, so we can't use it anymore 