### PR TITLE
fix(core, lambda-at-edge): do not replace .html for public files in r…

### DIFF
--- a/packages/e2e-tests/next-app-with-base-path/cypress/integration/static-files.test.ts
+++ b/packages/e2e-tests/next-app-with-base-path/cypress/integration/static-files.test.ts
@@ -18,12 +18,15 @@ describe("Static Files Tests", () => {
   });
 
   describe("public files", () => {
-    [{ path: "/basepath/app-store-badge.png" }].forEach(({ path }) => {
+    [
+      { path: "/basepath/app-store-badge.png", contentType: "image/png" },
+      { path: "/basepath/example.html", contentType: "text/html" }
+    ].forEach(({ path, contentType }) => {
       it(`serves and caches file ${path}`, () => {
         // Request once to ensure cached
         cy.request(path);
         cy.request(path).then((response) => {
-          expect(response.headers["content-type"]).to.equal("image/png");
+          expect(response.headers["content-type"]).to.equal(contentType);
           expect(response.status).to.equal(200);
           cy.verifyResponseCacheStatus(response, true);
         });

--- a/packages/e2e-tests/next-app-with-base-path/public/example.html
+++ b/packages/e2e-tests/next-app-with-base-path/public/example.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<h1>Serverless-next.js</h1>
+</body>
+</html>

--- a/packages/e2e-tests/next-app/cypress/integration/static-files.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/static-files.test.ts
@@ -18,12 +18,15 @@ describe("Static Files Tests", () => {
   });
 
   describe("public files", () => {
-    [{ path: "/app-store-badge.png" }].forEach(({ path }) => {
+    [
+      { path: "/app-store-badge.png", contentType: "image/png" },
+      { path: "/example.html", contentType: "text/html" }
+    ].forEach(({ path, contentType }) => {
       it(`serves and caches file ${path}`, () => {
         // Request once to ensure cached
         cy.request(path);
         cy.request(path).then((response) => {
-          expect(response.headers["content-type"]).to.equal("image/png");
+          expect(response.headers["content-type"]).to.equal(contentType);
           expect(response.status).to.equal(200);
           cy.verifyResponseCacheStatus(response, true);
         });

--- a/packages/e2e-tests/next-app/public/example.html
+++ b/packages/e2e-tests/next-app/public/example.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<h1>Serverless-next.js</h1>
+</body>
+</html>

--- a/packages/libs/core/src/route/index.ts
+++ b/packages/libs/core/src/route/index.ts
@@ -73,7 +73,7 @@ const handleLanguageRedirect = async (
   }
 };
 
-const handlePublicFiles = (
+export const handlePublicFiles = (
   uri: string,
   manifest: Manifest
 ): Route | undefined => {

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -14,7 +14,8 @@ import {
   getCustomHeaders,
   StaticRoute,
   getStaticRegenerationResponse,
-  getThrottledStaticRegenerationCachePolicy
+  getThrottledStaticRegenerationCachePolicy,
+  handlePublicFiles
 } from "@sls-next/core";
 
 import {
@@ -138,6 +139,12 @@ const reconstructOriginalRequestUri = (
   s3Uri: string,
   manifest: OriginRequestDefaultHandlerManifest
 ) => {
+  // For public files we do not replace .html as it can cause public HTML files to be classified with wrong status code
+  const publicFile = handlePublicFiles(s3Uri, manifest);
+  if (publicFile) {
+    return `${basePath}${s3Uri}`;
+  }
+
   let originalUri = `${basePath}${s3Uri.replace(
     /(\.html)?$/,
     manifest.trailingSlash ? "/" : ""

--- a/packages/libs/s3-static-assets/src/lib/constants.ts
+++ b/packages/libs/s3-static-assets/src/lib/constants.ts
@@ -11,4 +11,4 @@ export const SERVER_NO_CACHE_CACHE_CONTROL_HEADER =
   "public, max-age=0, s-maxage=0, must-revalidate";
 
 export const DEFAULT_PUBLIC_DIR_CACHE_REGEX =
-  /\.(gif|jpe?g|jp2|tiff|png|webp|bmp|svg|ico)$/i;
+  /\.(gif|jpe?g|jp2|tiff|png|webp|bmp|svg|ico|html)$/i;


### PR DESCRIPTION
…econstruction of uri in origin response handler

* Otherwise if there is a public file like "example.html", it will be changed to "example" and misclassified as 404 status code, although the content renders fine
* Also ensures HTML public files are cached

Fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/1466