### PR TITLE
fix(nextjs-component, nextjs-cdk-construct): create AWS resources for dynamic SSG (#1476)

### DIFF
--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -452,6 +452,12 @@ class NextjsComponent extends Component {
           .initialRevalidateSeconds === "number"
     );
 
+    const hasDynamicISRPages = Object.keys(
+      defaultBuildManifest.pages.ssg.dynamic
+    ).some(
+      (key) => defaultBuildManifest.pages.ssg.dynamic[key].fallback !== false
+    );
+
     const readLambdaInputValue = (
       inputKey: "memory" | "timeout" | "name" | "runtime" | "roleArn" | "tags",
       lambdaType: LambdaType,
@@ -471,7 +477,7 @@ class NextjsComponent extends Component {
     };
 
     let queue;
-    if (hasISRPages) {
+    if (hasISRPages || hasDynamicISRPages) {
       queue = await sqs({
         name: `${bucketOutputs.name}.fifo`,
         deduplicationScope: "messageGroup",
@@ -521,7 +527,7 @@ class NextjsComponent extends Component {
       }
     }
 
-    if (hasISRPages) {
+    if (hasISRPages || hasDynamicISRPages) {
       const regenerationLambdaInput: LambdaInput = {
         region: bucketRegion, // make sure SQS region and regeneration lambda region are the same
         description: inputs.description


### PR DESCRIPTION
it adds the resource creation conditions that my suggestions for fix #1476. I think we need to create SQS and Regeneration Handler at deployment time, because it can 'fallback: true|blocking' with 'revaliate'.

I would like your review on whether that is an appropriate solution or not. thanks