### PR TITLE
fix(nextjs-component): allow setting custom regeneration lambda name

### DIFF
--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -580,7 +580,11 @@ class NextjsComponent extends Component {
           "regenerationLambda",
           "nodejs14.x"
         ) as string,
-        name: bucketOutputs.name,
+        name: readLambdaInputValue(
+          "name",
+          "regenerationLambda",
+          bucketOutputs.name
+        ) as string,
         tags: readLambdaInputValue(
           "tags",
           "regenerationLambda",


### PR DESCRIPTION
Fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/1486