### PR TITLE
Add cache to CI workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
 
       - run: yarn --frozen-lockfile
 

--- a/.github/workflows/cleanup-e2e-tests.yml
+++ b/.github/workflows/cleanup-e2e-tests.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "14.x"
+          cache: "yarn"
 
       - name: Cleanup any old Lambda versions in AWS account
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "12.x"
+          cache: "yarn"
 
       - name: Build
         run: yarn --frozen-lockfile
@@ -145,6 +146,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
 
       - name: "Download build"
         uses: actions/download-artifact@v2


### PR DESCRIPTION
- resolve #1239 
- Setup-node officially supports dependency caching the other day.  
(https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/)
It will improve CI workflow speed.