### PR TITLE
Fix ISR issue with `index.ts`

### DIFF
--- a/packages/libs/lambda-at-edge/src/s3/s3StorePage.ts
+++ b/packages/libs/lambda-at-edge/src/s3/s3StorePage.ts
@@ -30,6 +30,7 @@ export const s3StorePage = async (
     ? `${options.basePath.replace(/^\//, "")}/`
     : "";
   const baseKey = options.uri
+    .replace(/^\/$/, "index")
     .replace(/^\//, "")
     .replace(/\.(json|html)$/, "")
     .replace(/^_next\/data\/[^\/]*\//, "");


### PR DESCRIPTION
For the root path `/` the `s3StorePage` was not correctly storing to the `index.html` file and instead was storing as `.html`

Added an extra regex `replace()` to deal with the root path. 

#1098 