### PR TITLE
Fix Preview Mode when a dynamic route is used

### DIFF
--- a/packages/libs/core/src/route/data.ts
+++ b/packages/libs/core/src/route/data.ts
@@ -67,7 +67,7 @@ export const handleDataReq = (
   const dynamic = matchDynamicRoute(localeUri, pages.dynamic);
 
   const dynamicSSG = dynamic && pages.ssg.dynamic[dynamic];
-  if (dynamicSSG) {
+  if (dynamicSSG && !isPreview) {
     return {
       isData: true,
       isStatic: true,

--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -93,7 +93,7 @@ export const handlePageReq = (
   const dynamic = matchDynamicRoute(localeUri, pages.dynamic);
 
   const dynamicSSG = dynamic && pages.ssg.dynamic[dynamic];
-  if (dynamicSSG) {
+  if (dynamicSSG && !isPreview) {
     return {
       isData: false,
       isStatic: true,


### PR DESCRIPTION
When route was dynamic e.g. `/[[...slug]]` data and page routes would return the SSG content, rather than the SSR.

Added `&& !isPreview` to ensure it matches the same logic as non dynamic routes.

Fixes #1527