### PR TITLE
fix(lambda-at-edge, nextjs-component): fix triggering regeneration when sqs queue has custom name

### DIFF
--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -48,6 +48,7 @@ type BuildOptions = {
   baseDir?: string;
   cleanupDotNext?: boolean;
   assetIgnorePatterns?: string[];
+  regenerationQueueName?: string;
 };
 
 const defaultBuildOptions = {
@@ -64,7 +65,8 @@ const defaultBuildOptions = {
   resolve: undefined,
   baseDir: process.cwd(),
   cleanupDotNext: true,
-  assetIgnorePatterns: []
+  assetIgnorePatterns: [],
+  regenerationQueueName: undefined
 };
 
 class Builder {
@@ -754,8 +756,11 @@ class Builder {
         await this.readPublicFiles(assetIgnorePatterns)
       );
 
-    const { enableHTTPCompression, logLambdaExecutionTimes } =
-      this.buildOptions;
+    const {
+      enableHTTPCompression,
+      logLambdaExecutionTimes,
+      regenerationQueueName
+    } = this.buildOptions;
 
     const apiBuildManifest = {
       ...apiManifest,
@@ -764,7 +769,8 @@ class Builder {
     const defaultBuildManifest = {
       ...pageManifest,
       enableHTTPCompression,
-      logLambdaExecutionTimes
+      logLambdaExecutionTimes,
+      regenerationQueueName
     };
     const imageBuildManifest = {
       ...imageManifest,

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -299,11 +299,19 @@ const handleOriginResponse = async ({
         staticRoute?.page &&
         staticRegenerationResponse.secondsRemainingUntilRevalidation === 0
       ) {
+        const regenerationQueueName =
+          manifest.regenerationQueueName ?? `${bucketName}.fifo`; // if queue name not specified, we used [bucketName].fifo as used in deployment
+
+        if (!regenerationQueueName) {
+          throw new Error("Regeneration queue name is undefined.");
+        }
+
         const { throttle } = await triggerStaticRegeneration({
           basePath,
           request,
           response,
-          pagePath: staticRoute.page
+          pagePath: staticRoute.page,
+          queueName: regenerationQueueName
         });
 
         // Occasionally we will get rate-limited by the Queue (in the event we

--- a/packages/libs/lambda-at-edge/src/lib/triggerStaticRegeneration.ts
+++ b/packages/libs/lambda-at-edge/src/lib/triggerStaticRegeneration.ts
@@ -6,6 +6,7 @@ interface TriggerStaticRegenerationOptions {
   response: AWSLambda.CloudFrontResponse;
   basePath: string | undefined;
   pagePath: string;
+  queueName: string;
 }
 
 export const triggerStaticRegeneration = async (
@@ -13,6 +14,7 @@ export const triggerStaticRegeneration = async (
 ): Promise<{ throttle: boolean }> => {
   const { region } = options.request.origin?.s3 || {};
   const bucketName = s3BucketNameFromEventRequest(options.request);
+  const queueName = options.queueName;
 
   if (!bucketName) {
     throw new Error("Expected bucket name to be defined");
@@ -39,7 +41,7 @@ export const triggerStaticRegeneration = async (
   try {
     await sqs.send(
       new SendMessageCommand({
-        QueueUrl: `https://sqs.${region}.amazonaws.com/${bucketName}.fifo`,
+        QueueUrl: `https://sqs.${region}.amazonaws.com/${queueName}`,
         MessageBody: JSON.stringify(regenerationEvent), // This is not used, however it is a required property
         // We only want to trigger the regeneration once for every previous
         // update. This will prevent the case where this page is being

--- a/packages/libs/lambda-at-edge/src/types.ts
+++ b/packages/libs/lambda-at-edge/src/types.ts
@@ -13,6 +13,7 @@ export type OriginRequestApiHandlerManifest = ApiManifest & {
 export type OriginRequestDefaultHandlerManifest = PageManifest & {
   logLambdaExecutionTimes?: boolean;
   enableHTTPCompression?: boolean;
+  regenerationQueueName?: string;
 };
 
 export type OriginRequestImageHandlerManifest = {

--- a/packages/libs/lambda-at-edge/tests/utils/triggerStaticRegeneration.test.ts
+++ b/packages/libs/lambda-at-edge/tests/utils/triggerStaticRegeneration.test.ts
@@ -27,7 +27,9 @@ describe("triggerStaticRegeneration()", () => {
       headers: { etag: [{ key: "Etag", value: "123" }] },
       status: "200",
       statusDescription: "ok"
-    } as AWSLambda.CloudFrontResponse
+    } as AWSLambda.CloudFrontResponse,
+    queueName: "my-bucket.fifo",
+    pagePath: "/"
   };
 
   class RequestThrottledException extends Error {
@@ -112,7 +114,8 @@ describe("triggerStaticRegeneration()", () => {
           region: "us-east-1",
           bucketName: "my-bucket",
           cloudFrontEventRequest: options.request,
-          basePath: ""
+          basePath: "",
+          pagePath: "/"
         }),
         MessageDeduplicationId: expected,
         MessageGroupId: "index.html"

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -255,7 +255,8 @@ class NextjsComponent extends Component {
           authentication: inputs.authentication ?? undefined,
           baseDir: buildConfig.baseDir,
           cleanupDotNext: buildConfig.cleanupDotNext,
-          assetIgnorePatterns: buildConfig.assetIgnorePatterns
+          assetIgnorePatterns: buildConfig.assetIgnorePatterns,
+          regenerationQueueName: inputs.sqs?.name
         },
         nextStaticPath
       );


### PR DESCRIPTION
Fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/1593