### PR TITLE
fix(lambda-at-edge): sqs messageGroupId should be a hash to allow for…

### DIFF
--- a/packages/libs/lambda-at-edge/tests/utils/triggerStaticRegeneration.test.ts
+++ b/packages/libs/lambda-at-edge/tests/utils/triggerStaticRegeneration.test.ts
@@ -118,7 +118,7 @@ describe("triggerStaticRegeneration()", () => {
           pagePath: "/"
         }),
         MessageDeduplicationId: expected,
-        MessageGroupId: "index.html"
+        MessageGroupId: "eacf331f0ffc35d4b482f1d15a887d3b" // md5 hash of "index.html"
       });
     }
   );


### PR DESCRIPTION
… long URIs

Fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/1616