### PR TITLE
refactor(core): create rough platform-agnostic page handler in core p…

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,9 @@
       "jest.config.js",
       "<rootDir>/packages/serverless-components/aws-s3",
       "<rootDir>/packages/libs/serverless-patched",
-      "<rootDir>/packages/libs/lambda-at-edge/src/render/renderStaticPage.ts"
+      "<rootDir>/packages/libs/lambda-at-edge/src/render/renderStaticPage.ts",
+      "<rootDir>/packages/libs/core/src/pageHandler.ts",
+      "<rootDir>/packages/libs/core/src/platform/platformClient.ts"
     ],
     "watchPathIgnorePatterns": [
       "/fixture/",

--- a/packages/libs/core/package.json
+++ b/packages/libs/core/package.json
@@ -36,12 +36,14 @@
     "cookie": "^0.4.1",
     "jsonwebtoken": "^8.5.1",
     "next": "^11.1.2",
+    "node-fetch": "2.6.5",
     "path-to-regexp": "^6.1.0",
     "regex-parser": "^2.2.10"
   },
   "devDependencies": {
     "@types/cookie": "^0.4.0",
     "@types/jsonwebtoken": "^8.5.5",
+    "@types/node-fetch": "3.0.3",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
     "@types/zen-observable": "^0.8.3",

--- a/packages/libs/core/src/pageHandler.ts
+++ b/packages/libs/core/src/pageHandler.ts
@@ -1,0 +1,382 @@
+import {
+  PerfLogger,
+  PreRenderedManifest as PrerenderManifestType
+} from "./types";
+import {
+  ExternalRoute,
+  handleDefault,
+  PublicFileRoute,
+  RoutesManifest,
+  StaticRoute,
+  getCustomHeaders,
+  getStaticRegenerationResponse,
+  getThrottledStaticRegenerationCachePolicy,
+  handleFallback,
+  Route
+} from "./index";
+import { PageManifest } from "./types";
+import { IncomingMessage, OutgoingHttpHeaders, ServerResponse } from "http";
+import { performance } from "perf_hooks";
+import { PlatformClient } from "./platform/platformClient";
+
+const createExternalRewriteResponse = async (
+  customRewrite: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+  platformClient: PlatformClient,
+  body?: string
+): Promise<void> => {
+  const { default: fetch } = await import("node-fetch");
+
+  // Set request headers
+  const reqHeaders: any = {};
+  Object.assign(reqHeaders, req.headers);
+
+  // Delete host header otherwise request may fail due to host mismatch
+  if (reqHeaders.hasOwnProperty("host")) {
+    delete reqHeaders.host;
+  }
+
+  let fetchResponse;
+  if (body) {
+    const decodedBody = Buffer.from(body, "base64").toString("utf8");
+
+    fetchResponse = await fetch(customRewrite, {
+      headers: reqHeaders,
+      method: req.method,
+      body: decodedBody, // Must pass body as a string,
+      compress: false,
+      redirect: "manual"
+    });
+  } else {
+    fetchResponse = await fetch(customRewrite, {
+      headers: reqHeaders,
+      method: req.method,
+      compress: false,
+      redirect: "manual"
+    });
+  }
+
+  for (const [name, val] of fetchResponse.headers.entries()) {
+    if (!platformClient.isIgnoredHeader(name)) {
+      res.setHeader(name, val);
+    }
+  }
+  res.statusCode = fetchResponse.status;
+  res.end(await fetchResponse.buffer());
+};
+
+const externalRewrite = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+  rewrite: string,
+  platformClient: PlatformClient
+): Promise<void> => {
+  const querystring = req.url?.includes("?") ? req.url?.split("?") : "";
+  let body = "";
+
+  req.on("data", (chunk) => {
+    body += chunk.toString();
+  });
+  await createExternalRewriteResponse(
+    rewrite + (querystring ? "?" : "") + querystring,
+    req,
+    res,
+    platformClient,
+    body
+  );
+};
+
+const staticRequest = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+  responsePromise: Promise<any>,
+  file: string,
+  path: string,
+  route: Route,
+  manifest: PageManifest,
+  routesManifest: RoutesManifest,
+  platformClient: PlatformClient
+) => {
+  const basePath = routesManifest.basePath;
+  const pageKey = (path + file).slice(1); // need to remove leading slash from path for page key
+
+  const staticRoute = route.isStatic ? (route as StaticRoute) : undefined;
+  const statusCode = route?.statusCode ?? 200;
+
+  // For PUT, DELETE, PATCH, POST, OPTIONS just return a 405 response as these should not be supported for a page fetch.
+  // TODO: OPTIONS should be able to be supported now.
+  if (
+    req.method === "PUT" ||
+    req.method === "DELETE" ||
+    req.method === "PATCH" ||
+    req.method === "POST" ||
+    req.method === "OPTIONS"
+  ) {
+    res.writeHead(405);
+    res.end();
+    return await responsePromise;
+  }
+
+  // Get page response using platform client
+  const pageResponse = platformClient.getObject(pageKey);
+
+  const s3BasePath = basePath ? `${basePath.replace(/^\//, "")}/` : "";
+
+  // These statuses are returned when S3 does not have access to the page.
+  // 404 will also be returned if CloudFront has permissions to list objects.
+  if (pageResponse.statusCode !== 403 && pageResponse.statusCode !== 404) {
+    let cacheControl = pageResponse.headers.cacheControl;
+
+    // If these are error pages, then just return them
+    if (statusCode === 404 || statusCode === 500) {
+      cacheControl =
+        statusCode === 500
+          ? "public, max-age=0, s-maxage=0, must-revalidate"
+          : cacheControl;
+    } else {
+      // Otherwise we may need to do static regeneration
+      const staticRegenerationResponse = getStaticRegenerationResponse({
+        expiresHeader: pageResponse.headers.expires?.toString() ?? "",
+        lastModifiedHeader: pageResponse.headers.lastModified?.toString() ?? "",
+        initialRevalidateSeconds: staticRoute?.revalidate
+      });
+
+      if (staticRegenerationResponse) {
+        cacheControl = staticRegenerationResponse.cacheControl;
+
+        if (
+          staticRoute?.page &&
+          staticRegenerationResponse.secondsRemainingUntilRevalidation === 0
+        ) {
+          const { throttle } = await platformClient.triggerStaticRegeneration({
+            basePath,
+            pageKey: pageKey,
+            eTag: pageResponse.headers.eTag,
+            lastModified: pageResponse.headers.lastModified
+              ?.getTime()
+              .toString(),
+            pagePath: staticRoute.page
+          });
+
+          // Occasionally we will get rate-limited by the Queue (in the event we
+          // send it too many messages) and so we we use the cache to reduce
+          // requests to the queue for a short period.
+          if (throttle) {
+            cacheControl =
+              getThrottledStaticRegenerationCachePolicy(1).cacheControl;
+          }
+        }
+      }
+    }
+
+    // Get custom headers and convert it into a plain object
+    const customHeaders = getCustomHeaders(req.url ?? "", routesManifest);
+    const convertedCustomHeaders: { [key: string]: string } = {};
+    for (const key in customHeaders) {
+      convertedCustomHeaders[key] = customHeaders[key][0].value;
+    }
+
+    const headers: OutgoingHttpHeaders = {
+      ...pageResponse.headers,
+      "Cache-Control": cacheControl,
+      ...convertedCustomHeaders
+    };
+
+    res.writeHead(statusCode, headers);
+    res.end(pageResponse.body);
+    return await responsePromise;
+  }
+
+  const getPage = (pagePath: string) => {
+    return require(`./${pagePath}`);
+  };
+
+  const fallbackRoute = await handleFallback(
+    { req, res, responsePromise },
+    route,
+    manifest,
+    routesManifest,
+    getPage
+  );
+
+  // Already handled dynamic error path
+  if (!fallbackRoute) {
+    return await responsePromise;
+  }
+
+  // Either a fallback: true page or a static error page
+  if (fallbackRoute.isStatic) {
+    const file = fallbackRoute.file.slice("pages".length);
+    const pageKey = `${s3BasePath}static-pages/${manifest.buildId}${file}`;
+
+    const pageResponse = platformClient.getObject(pageKey);
+
+    const statusCode = fallbackRoute.statusCode || 200;
+    const is500 = statusCode === 500;
+
+    const cacheControl = is500
+      ? "public, max-age=0, s-maxage=0, must-revalidate" // static 500 page should never be cached
+      : pageResponse.headers.CacheControl ??
+        (fallbackRoute.fallback // Use cache-control from S3 response if possible, otherwise use defaults
+          ? "public, max-age=0, s-maxage=0, must-revalidate" // fallback should never be cached
+          : "public, max-age=0, s-maxage=2678400, must-revalidate");
+
+    res.writeHead(statusCode, {
+      "Cache-Control": cacheControl,
+      "Content-Type": "text/html"
+    });
+    res.end(pageResponse.body);
+    return await responsePromise;
+  }
+
+  // This is a fallback route that should be stored in S3 before returning it
+  const { renderOpts, html } = fallbackRoute;
+  const { expires } = await platformClient.storePage({
+    html,
+    uri: file,
+    basePath,
+    buildId: manifest.buildId,
+    pageData: renderOpts.pageData,
+    revalidate: renderOpts.revalidate
+  });
+
+  const isrResponse = expires
+    ? getStaticRegenerationResponse({
+        expiresHeader: expires.toJSON(),
+        lastModifiedHeader: undefined,
+        initialRevalidateSeconds: staticRoute?.revalidate
+      })
+    : null;
+
+  const cacheControl =
+    (isrResponse && isrResponse.cacheControl) ||
+    "public, max-age=0, s-maxage=2678400, must-revalidate";
+
+  res.setHeader("Cache-Control", cacheControl);
+
+  if (fallbackRoute.route.isData) {
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(renderOpts.pageData));
+  } else {
+    res.setHeader("Content-Type", "text/html");
+    res.end(html);
+  }
+
+  return await responsePromise;
+};
+
+const perfLogger = (logLambdaExecutionTimes?: boolean): PerfLogger => {
+  if (logLambdaExecutionTimes) {
+    return {
+      now: () => performance.now(),
+      log: (metricDescription: string, t1?: number, t2?: number): void => {
+        if (!t1 || !t2) return;
+        console.log(`${metricDescription}: ${t2 - t1} (ms)`);
+      }
+    };
+  }
+  return {
+    now: () => 0,
+    log: () => {
+      // intentionally empty
+    }
+  };
+};
+
+/**
+ * Platform-agnostic page handler that handles all pages (SSR, SSG, and API).
+ * It requires passing a platform client which will implement methods for retrieving/storing pages, and triggering static regeneration.
+ * @param req
+ * @param res
+ * @param responsePromise
+ * @param manifest
+ * @param prerenderManifest
+ * @param routesManifest
+ * @param options
+ * @param platformClient
+ */
+export const pageHandler = async ({
+  req,
+  res,
+  responsePromise,
+  manifest,
+  prerenderManifest,
+  routesManifest,
+  options,
+  platformClient
+}: {
+  req: IncomingMessage;
+  res: ServerResponse;
+  responsePromise: Promise<any>;
+  manifest: PageManifest;
+  prerenderManifest: PrerenderManifestType;
+  routesManifest: RoutesManifest;
+  options: { logExecutionTimes: boolean };
+  platformClient: PlatformClient;
+}) => {
+  const { now, log } = perfLogger(options.logExecutionTimes);
+
+  let tBeforeSSR = null;
+  const getPage = (pagePath: string) => {
+    const tBeforePageRequire = now();
+    const page = require(`./${pagePath}`); // eslint-disable-line
+    const tAfterPageRequire = (tBeforeSSR = now());
+    log("Require JS execution time", tBeforePageRequire, tAfterPageRequire);
+    return page;
+  };
+
+  const route = await handleDefault(
+    { req, res, responsePromise },
+    manifest,
+    prerenderManifest,
+    routesManifest,
+    getPage
+  );
+  if (tBeforeSSR) {
+    const tAfterSSR = now();
+    log("SSR execution time", tBeforeSSR, tAfterSSR);
+  }
+
+  if (!route) {
+    return await responsePromise;
+  }
+
+  if (route.isPublicFile) {
+    const { file } = route as PublicFileRoute;
+    return await staticRequest(
+      req,
+      res,
+      responsePromise,
+      file,
+      `${routesManifest.basePath}/public`,
+      route,
+      manifest,
+      routesManifest,
+      platformClient
+    );
+  }
+  if (route.isStatic) {
+    const { file, isData } = route as StaticRoute;
+    const path = isData
+      ? `${routesManifest.basePath}`
+      : `${routesManifest.basePath}/static-pages/${manifest.buildId}`;
+
+    const relativeFile = isData ? file : file.slice("pages".length);
+    return await staticRequest(
+      req,
+      res,
+      responsePromise,
+      relativeFile,
+      path,
+      route,
+      manifest,
+      routesManifest,
+      platformClient
+    );
+  }
+
+  const external: ExternalRoute = route;
+  const { path } = external;
+  return externalRewrite(req, res, path, platformClient);
+};

--- a/packages/libs/core/src/platform/platformClient.ts
+++ b/packages/libs/core/src/platform/platformClient.ts
@@ -1,0 +1,58 @@
+export type ObjectResponse = {
+  body: string;
+  headers: any;
+  statusCode: number;
+};
+
+export type StorePageOptions = {
+  basePath: string;
+  revalidate: any;
+  html: any;
+  buildId: string;
+  pageData: any;
+  uri: string;
+};
+
+export type TriggerStaticRegenerationOptions = {
+  basePath: string;
+  pageKey: string;
+  eTag: any;
+  lastModified: string | undefined;
+  pagePath: any;
+};
+
+/**
+ * Platforms should implement this interface which has all methods for retrieving from an object store,
+ * storing a page or triggering static regeneration.
+ */
+export interface PlatformClient {
+  /**
+   * Whether this header should be ignored.
+   * For example, some platforms such as AWS CloudFront may not allow certain headers to be added to the response.
+   * @param name
+   */
+  isIgnoredHeader(name: string): boolean;
+
+  /**
+   * Get an object from this platform's object store.
+   * This can be a page or other file.
+   * @param pageKey
+   */
+  getObject(pageKey: string): ObjectResponse;
+
+  /**
+   * Trigger static regeneration for this page.
+   * @param options
+   */
+  triggerStaticRegeneration(
+    options: TriggerStaticRegenerationOptions
+  ): Promise<{ throttle: boolean }>;
+
+  /**
+   * Store a page into the object store - both HTML and JSON data.
+   * @param options
+   */
+  storePage(
+    options: StorePageOptions
+  ): Promise<{ cacheControl: string | undefined; expires: Date | undefined }>;
+}

--- a/packages/libs/core/src/types.ts
+++ b/packages/libs/core/src/types.ts
@@ -220,3 +220,32 @@ export type Route =
   | StaticRoute
   | ApiRoute
   | UnauthorizedRoute;
+
+export type PreRenderedManifest = {
+  version: 2;
+  routes: {
+    [route: string]: {
+      initialRevalidateSeconds: number | false;
+      srcRoute: string | null;
+      dataRoute: string;
+    };
+  };
+  dynamicRoutes: {
+    [route: string]: {
+      routeRegex: string;
+      fallback: string | false;
+      dataRoute: string;
+      dataRouteRegex: string;
+    };
+  };
+  preview: {
+    previewModeId: string;
+    previewModeSigningKey: string;
+    previewModeEncryptionKey: string;
+  };
+};
+
+export type PerfLogger = {
+  now: () => number | undefined;
+  log: (metricDescription: string, t1?: number, t2?: number) => void;
+};

--- a/packages/libs/core/yarn.lock
+++ b/packages/libs/core/yarn.lock
@@ -146,6 +146,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz#9d969c9a748e841554a40ee435d26e53fa3ee899"
+  integrity sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==
+  dependencies:
+    node-fetch "*"
+
 "@types/node@*":
   version "16.7.2"
   resolved "https://registry.npmjs.org/@types/node/-/node-16.7.2.tgz#0465a39b5456b61a04d98bd5545f8b34be340cb7"
@@ -607,7 +614,7 @@ csstype@^3.0.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
-data-uri-to-buffer@3.0.1:
+data-uri-to-buffer@3.0.1, data-uri-to-buffer@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
@@ -759,6 +766,13 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+fetch-blob@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz#6bc438675f3851ecea51758ac91f6a1cd1bacabd"
+  integrity sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==
+  dependencies:
+    web-streams-polyfill "^3.0.3"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -1356,10 +1370,25 @@ next@^11.1.2:
     "@next/swc-linux-x64-gnu" "11.1.2"
     "@next/swc-win32-x64-msvc" "11.1.2"
 
+node-fetch@*:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz#79da7146a520036f2c5f644e4a26095f17e411ea"
+  integrity sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==
+  dependencies:
+    data-uri-to-buffer "^3.0.1"
+    fetch-blob "^3.1.2"
+
 node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@2.6.5:
+  version "2.6.5"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
+  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-html-parser@1.4.9:
   version "1.4.9"
@@ -1964,6 +1993,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -2063,10 +2097,28 @@ watchpack@2.1.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+web-streams-polyfill@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz#1516f2d4ea8f1bdbfed15eb65cb2df87098c8364"
+  integrity sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^7.0.0:
   version "7.1.0"

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -30,10 +30,12 @@ import {
   OriginRequestDefaultHandlerManifest,
   OriginRequestEvent,
   OriginResponseEvent,
-  PerfLogger,
-  PreRenderedManifest as PrerenderManifestType,
   RoutesManifest
 } from "./types";
+import {
+  PreRenderedManifest as PrerenderManifestType,
+  PerfLogger
+} from "@sls-next/core";
 import { performance } from "perf_hooks";
 import type { Readable } from "stream";
 import { externalRewrite } from "./routing/rewriter";

--- a/packages/libs/lambda-at-edge/src/types.ts
+++ b/packages/libs/lambda-at-edge/src/types.ts
@@ -50,32 +50,3 @@ export interface RegenerationEvent {
   pageS3Path: string;
   cloudFrontEventRequest: AWSLambda.CloudFrontRequest;
 }
-
-export type PreRenderedManifest = {
-  version: 2;
-  routes: {
-    [route: string]: {
-      initialRevalidateSeconds: number | false;
-      srcRoute: string | null;
-      dataRoute: string;
-    };
-  };
-  dynamicRoutes: {
-    [route: string]: {
-      routeRegex: string;
-      fallback: string | false;
-      dataRoute: string;
-      dataRouteRegex: string;
-    };
-  };
-  preview: {
-    previewModeId: string;
-    previewModeSigningKey: string;
-    previewModeEncryptionKey: string;
-  };
-};
-
-export type PerfLogger = {
-  now: () => number | undefined;
-  log: (metricDescription: string, t1?: number, t2?: number) => void;
-};

--- a/packages/libs/lambda-at-edge/yarn.lock
+++ b/packages/libs/lambda-at-edge/yarn.lock
@@ -1390,14 +1390,8 @@
     picomatch "^2.2.2"
 
 "@sls-next/core@link:../core":
-  version "3.4.0-alpha.9"
-  dependencies:
-    "@hapi/accept" "^5.0.1"
-    cookie "^0.4.1"
-    jsonwebtoken "^8.5.1"
-    next "^11.1.2"
-    path-to-regexp "^6.1.0"
-    regex-parser "^2.2.10"
+  version "0.0.0"
+  uid ""
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
@@ -3597,6 +3591,13 @@ node-fetch@2.6.1, node-fetch@^2.6.1:
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@2.6.5:
+  version "2.6.5"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
+  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-gyp-build@^4.2.2:
   version "4.2.3"
   resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
@@ -4685,6 +4686,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 ts-loader@^9.2.6:
   version "9.2.6"
   resolved "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz#9937c4dd0a1e3dbbb5e433f8102a6601c6615d74"
@@ -4849,10 +4855,23 @@ watchpack@2.1.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^6.5.0:
   version "6.5.0"

--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -12,9 +12,9 @@ import {
   OriginRequestImageHandlerManifest,
   OriginRequestApiHandlerManifest,
   OriginRequestDefaultHandlerManifest,
-  RoutesManifest,
-  PreRenderedManifest
+  RoutesManifest
 } from "@sls-next/lambda-at-edge";
+import { PreRenderedManifest } from "@sls-next/core";
 import * as fs from "fs-extra";
 import * as path from "path";
 import {


### PR DESCRIPTION
…ackage

* First step in making the handlers actually platform-agnostic so that we can easily wire it up for other platforms (Lambda, etc.)
* TODO: still need to implement the AWS PlatformClient and actually wire things up