### PR TITLE
Update faq.md with fixed examples link

### DIFF
--- a/documentation/docs/faq.md
+++ b/documentation/docs/faq.md
@@ -48,7 +48,7 @@ Users are encouraged to use this component instead of the `serverless-plugin`. T
 
 ### How do I interact with other AWS Services within my app?
 
-See `examples/dynamodb-crud` for an example Todo application that interacts with DynamoDB. You can find a full list of examples [here](https://github.com/serverless-nextjs/serverless-next.js/tree/master/packages/serverless-component/examples)
+See `examples/dynamodb-crud` for an example Todo application that interacts with DynamoDB. You can find a full list of examples [here](https://github.com/serverless-nextjs/serverless-next.js/tree/master/packages/serverless-components/nextjs-component/examples)
 
 ### [CI/CD] A new CloudFront distribution is created on every CI build. I wasn't expecting that
 


### PR DESCRIPTION
The examples link was corrected in `README.md` in 468da0daf6c120e9888048bad0f3dc8e991f0a7c. This fixes it in `faq.md`.