### PR TITLE
fix(lambda-at-edge): handle trailing slash index.html page in reconst…

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -193,8 +193,11 @@ const reconstructOriginalRequestUri = (
     manifest.trailingSlash ? "/" : ""
   )}`;
 
-  // For index.html page, it will become "/index", which is not a route so normalize it to "/"
-  originalUri = originalUri.replace(/\/index$/, "/");
+  // For index.html page, it will become "/index" or "/index/", which is not a route so normalize it to "/"
+  originalUri = originalUri.replace(
+    manifest.trailingSlash ? /\/index\/$/ : /\/index$/,
+    "/"
+  );
 
   return originalUri;
 };


### PR DESCRIPTION
…ructOriginalRequestUri

Fixes: https://github.com/serverless-nextjs/serverless-next.js/issues/1823