### PR TITLE
fix(aws-cloudfront): handle bucket names with dots correctly

### DIFF
--- a/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/s3-origin.test.ts.snap
+++ b/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/s3-origin.test.ts.snap
@@ -447,6 +447,360 @@ Object {
 }
 `;
 
+exports[`S3 origins when origin is outside of us-east-1 and contains dots should use the origin's host at the DomainName 1`] = `
+Object {
+  "DistributionConfigWithTags": Object {
+    "DistributionConfig": Object {
+      "Aliases": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "CacheBehaviors": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "CallerReference": "1566599541192",
+      "Comment": "",
+      "CustomErrorResponses": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "DefaultCacheBehavior": Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": false,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "none",
+          },
+          "Headers": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "QueryString": false,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "SmoothStreaming": false,
+        "TargetOriginId": "mybucket.with.dots",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      "Enabled": true,
+      "HttpVersion": "http2",
+      "Origins": Object {
+        "Items": Array [
+          Object {
+            "CustomHeaders": Object {
+              "Items": Array [],
+              "Quantity": 0,
+            },
+            "DomainName": "mybucket.with.dots.s3.eu-west-1.amazonaws.com",
+            "Id": "mybucket.with.dots",
+            "OriginPath": "",
+            "S3OriginConfig": Object {
+              "OriginAccessIdentity": "",
+            },
+          },
+        ],
+        "Quantity": 1,
+      },
+      "PriceClass": "PriceClass_All",
+    },
+    "Tags": Object {
+      "Items": Array [],
+    },
+  },
+}
+`;
+
+exports[`S3 origins when origin is outside of us-east-1 and contains dots updates distribution 1`] = `
+Object {
+  "DistributionConfig": Object {
+    "CacheBehaviors": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "Comment": "",
+    "CustomErrorResponses": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "DefaultCacheBehavior": Object {
+      "AllowedMethods": Object {
+        "CachedMethods": Object {
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Items": Array [
+          "HEAD",
+          "GET",
+        ],
+        "Quantity": 2,
+      },
+      "Compress": false,
+      "DefaultTTL": 86400,
+      "FieldLevelEncryptionId": "",
+      "ForwardedValues": Object {
+        "Cookies": Object {
+          "Forward": "none",
+        },
+        "Headers": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "QueryString": false,
+        "QueryStringCacheKeys": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+      },
+      "LambdaFunctionAssociations": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "MaxTTL": 31536000,
+      "MinTTL": 0,
+      "SmoothStreaming": false,
+      "TargetOriginId": "anotherbucket",
+      "TrustedSigners": Object {
+        "Enabled": false,
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "ViewerProtocolPolicy": "redirect-to-https",
+    },
+    "Enabled": true,
+    "Origins": Object {
+      "Items": Array [
+        Object {
+          "CustomHeaders": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "DomainName": "anotherbucket.s3.eu-west-1.amazonaws.com",
+          "Id": "anotherbucket",
+          "OriginPath": "",
+          "S3OriginConfig": Object {
+            "OriginAccessIdentity": "",
+          },
+        },
+      ],
+      "Quantity": 1,
+    },
+    "PriceClass": "PriceClass_All",
+  },
+  "Id": "distributionwithS3origin",
+  "IfMatch": "etag",
+}
+`;
+
+exports[`S3 origins when origin is outside of us-east-1 and contains s3 and dots should use the origin's host at the DomainName 1`] = `
+Object {
+  "DistributionConfigWithTags": Object {
+    "DistributionConfig": Object {
+      "Aliases": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "CacheBehaviors": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "CallerReference": "1566599541192",
+      "Comment": "",
+      "CustomErrorResponses": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "DefaultCacheBehavior": Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": false,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "none",
+          },
+          "Headers": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "QueryString": false,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "SmoothStreaming": false,
+        "TargetOriginId": "mybucket.s3.s3",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      "Enabled": true,
+      "HttpVersion": "http2",
+      "Origins": Object {
+        "Items": Array [
+          Object {
+            "CustomHeaders": Object {
+              "Items": Array [],
+              "Quantity": 0,
+            },
+            "DomainName": "mybucket.s3.s3.s3.eu-west-1.amazonaws.com",
+            "Id": "mybucket.s3.s3",
+            "OriginPath": "",
+            "S3OriginConfig": Object {
+              "OriginAccessIdentity": "",
+            },
+          },
+        ],
+        "Quantity": 1,
+      },
+      "PriceClass": "PriceClass_All",
+    },
+    "Tags": Object {
+      "Items": Array [],
+    },
+  },
+}
+`;
+
+exports[`S3 origins when origin is outside of us-east-1 and contains s3 and dots updates distribution 1`] = `
+Object {
+  "DistributionConfig": Object {
+    "CacheBehaviors": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "Comment": "",
+    "CustomErrorResponses": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "DefaultCacheBehavior": Object {
+      "AllowedMethods": Object {
+        "CachedMethods": Object {
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Items": Array [
+          "HEAD",
+          "GET",
+        ],
+        "Quantity": 2,
+      },
+      "Compress": false,
+      "DefaultTTL": 86400,
+      "FieldLevelEncryptionId": "",
+      "ForwardedValues": Object {
+        "Cookies": Object {
+          "Forward": "none",
+        },
+        "Headers": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "QueryString": false,
+        "QueryStringCacheKeys": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+      },
+      "LambdaFunctionAssociations": Object {
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "MaxTTL": 31536000,
+      "MinTTL": 0,
+      "SmoothStreaming": false,
+      "TargetOriginId": "anotherbucket",
+      "TrustedSigners": Object {
+        "Enabled": false,
+        "Items": Array [],
+        "Quantity": 0,
+      },
+      "ViewerProtocolPolicy": "redirect-to-https",
+    },
+    "Enabled": true,
+    "Origins": Object {
+      "Items": Array [
+        Object {
+          "CustomHeaders": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "DomainName": "anotherbucket.s3.eu-west-1.amazonaws.com",
+          "Id": "anotherbucket",
+          "OriginPath": "",
+          "S3OriginConfig": Object {
+            "OriginAccessIdentity": "",
+          },
+        },
+      ],
+      "Quantity": 1,
+    },
+    "PriceClass": "PriceClass_All",
+  },
+  "Id": "distributionwithS3origin",
+  "IfMatch": "etag",
+}
+`;
+
 exports[`S3 origins when origin is outside of us-east-1 should use the origin's host at the DomainName 1`] = `
 Object {
   "DistributionConfigWithTags": Object {

--- a/packages/serverless-components/aws-cloudfront/__tests__/s3-origin.test.ts
+++ b/packages/serverless-components/aws-cloudfront/__tests__/s3-origin.test.ts
@@ -300,4 +300,114 @@ describe("S3 origins", () => {
       expect(mockUpdateDistribution.mock.calls[0][0]).toMatchSnapshot();
     });
   });
+
+  describe("when origin is outside of us-east-1 and contains dots", () => {
+    it("should use the origin's host at the DomainName", async () => {
+      await component.default({
+        origins: ["https://mybucket.with.dots.s3.eu-west-1.amazonaws.com"]
+      });
+
+      assertCDWTHasOrigin(mockCreateDistributionWithTags, {
+        Id: "mybucket.with.dots",
+        DomainName: "mybucket.with.dots.s3.eu-west-1.amazonaws.com",
+        S3OriginConfig: {
+          OriginAccessIdentity: ""
+        },
+        CustomHeaders: {
+          Quantity: 0,
+          Items: []
+        },
+        OriginPath: ""
+      });
+
+      expect(mockCreateDistributionWithTags.mock.calls[0][0]).toMatchSnapshot();
+    });
+
+    it("updates distribution", async () => {
+      mockGetDistributionConfigPromise.mockResolvedValueOnce({
+        ETag: "etag",
+        DistributionConfig: {
+          Origins: {
+            Quantity: 0,
+            Items: []
+          }
+        }
+      });
+      mockUpdateDistributionPromise.mockResolvedValueOnce({
+        Distribution: {
+          Id: "distributionwithS3originupdated"
+        }
+      });
+
+      await component.default({
+        origins: ["https://mybucket.with.dots.s3.eu-west-1.amazonaws.com"]
+      });
+
+      await component.default({
+        origins: ["https://anotherbucket.s3.eu-west-1.amazonaws.com"]
+      });
+
+      assertHasOrigin(mockUpdateDistribution, {
+        Id: "anotherbucket",
+        DomainName: "anotherbucket.s3.eu-west-1.amazonaws.com"
+      });
+
+      expect(mockUpdateDistribution.mock.calls[0][0]).toMatchSnapshot();
+    });
+  });
+
+  describe("when origin is outside of us-east-1 and contains s3 and dots", () => {
+    it("should use the origin's host at the DomainName", async () => {
+      await component.default({
+        origins: ["https://mybucket.s3.s3.s3.eu-west-1.amazonaws.com"]
+      });
+
+      assertCDWTHasOrigin(mockCreateDistributionWithTags, {
+        Id: "mybucket.s3.s3",
+        DomainName: "mybucket.s3.s3.s3.eu-west-1.amazonaws.com",
+        S3OriginConfig: {
+          OriginAccessIdentity: ""
+        },
+        CustomHeaders: {
+          Quantity: 0,
+          Items: []
+        },
+        OriginPath: ""
+      });
+
+      expect(mockCreateDistributionWithTags.mock.calls[0][0]).toMatchSnapshot();
+    });
+
+    it("updates distribution", async () => {
+      mockGetDistributionConfigPromise.mockResolvedValueOnce({
+        ETag: "etag",
+        DistributionConfig: {
+          Origins: {
+            Quantity: 0,
+            Items: []
+          }
+        }
+      });
+      mockUpdateDistributionPromise.mockResolvedValueOnce({
+        Distribution: {
+          Id: "distributionwithS3originupdated"
+        }
+      });
+
+      await component.default({
+        origins: ["https://mybucket.s3.s3.s3.eu-west-1.amazonaws.com"]
+      });
+
+      await component.default({
+        origins: ["https://anotherbucket.s3.eu-west-1.amazonaws.com"]
+      });
+
+      assertHasOrigin(mockUpdateDistribution, {
+        Id: "anotherbucket",
+        DomainName: "anotherbucket.s3.eu-west-1.amazonaws.com"
+      });
+
+      expect(mockUpdateDistribution.mock.calls[0][0]).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/serverless-components/aws-cloudfront/src/getBucketNameFromUrl.ts
+++ b/packages/serverless-components/aws-cloudfront/src/getBucketNameFromUrl.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns a bucket name for given S3 bucket url
+ *
+ * @param url S3 website URL
+ *
+ * @returns Bucket name
+ */
+export const getBucketNameFromUrl = (url: string): string => {
+  return url.substring(0, url.lastIndexOf(".s3"));
+};

--- a/packages/serverless-components/aws-cloudfront/src/getOriginConfig.ts
+++ b/packages/serverless-components/aws-cloudfront/src/getOriginConfig.ts
@@ -1,3 +1,5 @@
+import { getBucketNameFromUrl } from "./getBucketNameFromUrl";
+
 export type OriginConfig = {
   Id: string;
   DomainName: string;
@@ -47,7 +49,7 @@ export const getOriginConfig = (
   };
 
   if (originUrl.includes("s3")) {
-    const bucketName = hostname.split(".")[0];
+    const bucketName = getBucketNameFromUrl(hostname);
     originConfig.Id = bucketName;
     originConfig.DomainName = hostname;
     originConfig.S3OriginConfig = {


### PR DESCRIPTION
As per [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html), bucket names can contain dots. This was addressed in [this PR](https://github.com/serverless-nextjs/serverless-next.js/pull/596), but it was never merged. Hopefully this can be merged.
