### PR TITLE
chore(core, lambda-at-edge): make default handler handle _next/static routes

### DIFF
--- a/packages/libs/core/src/defaultHandler.ts
+++ b/packages/libs/core/src/defaultHandler.ts
@@ -1,4 +1,5 @@
 import {
+  NextStaticFileRoute,
   PerfLogger,
   PreRenderedManifest as PrerenderManifestType
 } from "./types";
@@ -374,6 +375,20 @@ export const defaultHandler = async ({
       responsePromise,
       file,
       `${routesManifest.basePath}/public`,
+      route,
+      manifest,
+      routesManifest,
+      platformClient
+    );
+  }
+  if (route.isNextStaticFile) {
+    const { file } = route as NextStaticFileRoute;
+    return await staticRequest(
+      req,
+      res,
+      responsePromise,
+      file,
+      `${routesManifest.basePath}/_next/static`,
       route,
       manifest,
       routesManifest,

--- a/packages/libs/core/src/handle/default.ts
+++ b/packages/libs/core/src/handle/default.ts
@@ -8,6 +8,7 @@ import {
   ApiRoute,
   Event,
   ExternalRoute,
+  NextStaticFileRoute,
   PageManifest,
   PrerenderManifest,
   PublicFileRoute,
@@ -85,7 +86,9 @@ export const handleDefault = async (
   prerenderManifest: PrerenderManifest,
   routesManifest: RoutesManifest,
   getPage: (page: string) => any
-): Promise<ExternalRoute | PublicFileRoute | StaticRoute | void> => {
+): Promise<
+  ExternalRoute | PublicFileRoute | NextStaticFileRoute | StaticRoute | void
+> => {
   const request = toRequest(event);
   const route = await routeDefault(
     request,

--- a/packages/libs/core/src/route/index.ts
+++ b/packages/libs/core/src/route/index.ts
@@ -73,6 +73,15 @@ const handleLanguageRedirect = async (
   }
 };
 
+export const handleNextStaticFiles = (uri: string): Route | undefined => {
+  if (uri.startsWith("/_next/static")) {
+    return {
+      isNextStaticFile: true,
+      file: uri
+    };
+  }
+};
+
 export const handlePublicFiles = (
   uri: string,
   manifest: Manifest
@@ -158,18 +167,29 @@ export const routeDefault = async (
   const isDataReq = uri.startsWith("/_next/data");
   const publicFile = handlePublicFiles(uri, manifest);
   const isPublicFile = !!publicFile;
+  const nextStaticFile = handleNextStaticFiles(uri);
+  const isNextStaticFile = !!nextStaticFile;
 
   // Only try to handle trailing slash redirects or public files if the URI isn't missing a base path.
   // This allows us to handle redirects without base paths.
   if (!missingExpectedBasePath) {
     const trailingSlash =
-      !is404 && handleTrailingSlash(req, manifest, isDataReq || isPublicFile);
+      !is404 &&
+      handleTrailingSlash(
+        req,
+        manifest,
+        isDataReq || isPublicFile || isNextStaticFile
+      );
     if (trailingSlash) {
       return trailingSlash;
     }
 
     if (publicFile) {
       return publicFile;
+    }
+
+    if (nextStaticFile) {
+      return nextStaticFile;
     }
   }
 

--- a/packages/libs/core/src/types.ts
+++ b/packages/libs/core/src/types.ts
@@ -153,6 +153,7 @@ export interface AnyRoute {
   isApi?: boolean;
   isExternal?: boolean;
   isPublicFile?: boolean;
+  isNextStaticFile?: boolean;
   isRedirect?: boolean;
   isRender?: boolean;
   isStatic?: boolean;
@@ -171,6 +172,11 @@ export interface ExternalRoute extends AnyRoute {
 
 export interface PublicFileRoute extends AnyRoute {
   isPublicFile: true;
+  file: string;
+}
+
+export interface NextStaticFileRoute extends AnyRoute {
+  isNextStaticFile: true;
   file: string;
 }
 
@@ -215,6 +221,7 @@ export type PageRoute = (RenderRoute | StaticRoute) & {
 export type Route =
   | ExternalRoute
   | PublicFileRoute
+  | NextStaticFileRoute
   | RedirectRoute
   | RenderRoute
   | StaticRoute

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -24,7 +24,8 @@ import {
   ExternalRoute,
   PublicFileRoute,
   Route,
-  StaticRoute
+  StaticRoute,
+  NextStaticFileRoute
 } from "@sls-next/core/dist/module/types";
 
 import {
@@ -255,6 +256,17 @@ const handleOriginRequest = async ({
       event,
       file,
       `${routesManifest.basePath}/public`,
+      route,
+      manifest,
+      routesManifest
+    );
+  }
+  if (route.isNextStaticFile) {
+    const { file } = route as NextStaticFileRoute;
+    return await staticRequest(
+      event,
+      file,
+      `${routesManifest.basePath}/_next/static`,
       route,
       manifest,
       routesManifest


### PR DESCRIPTION
* although not used for lambda-at-edge since CloudFront behavior handles those, only for lambda and other platforms where the function needs to serve next static files