### PR TITLE
chore(e2e-tests): enable lambda function cleanup

### DIFF
--- a/packages/e2e-tests/next-app-dynamic-routes/serverless.yml
+++ b/packages/e2e-tests/next-app-dynamic-routes/serverless.yml
@@ -1,2 +1,4 @@
 next-app-dynamic-routes:
   component: "../../serverless-components/nextjs-component"
+  inputs:
+    removeOldLambdaVersions: true

--- a/packages/e2e-tests/next-app-experimental/serverless.yml
+++ b/packages/e2e-tests/next-app-experimental/serverless.yml
@@ -1,6 +1,7 @@
 next-app-experimental:
   component: "../../serverless-components/nextjs-component"
   inputs:
+    removeOldLambdaVersions: true
     sqs:
       tags:
         foo: bar

--- a/packages/e2e-tests/next-app-using-serverless-trace/serverless.yml
+++ b/packages/e2e-tests/next-app-using-serverless-trace/serverless.yml
@@ -1,6 +1,7 @@
 next-app-using-serverless-trace:
   component: "../../serverless-components/nextjs-component"
   inputs:
+    removeOldLambdaVersions: true
     useServerlessTraceTarget: true
     build:
       postBuildCommands: ["node scripts/post-build-test.js"]

--- a/packages/e2e-tests/next-app-windows/serverless.yml
+++ b/packages/e2e-tests/next-app-windows/serverless.yml
@@ -1,6 +1,7 @@
 next-app-windows:
   component: "../../serverless-components/nextjs-component"
   inputs:
+    removeOldLambdaVersions: true
     build:
       postBuildCommands: ["node scripts/post-build-test.js"]
     cloudfront:

--- a/packages/e2e-tests/next-app-with-base-path/serverless.yml
+++ b/packages/e2e-tests/next-app-with-base-path/serverless.yml
@@ -1,2 +1,4 @@
 next-app-with-base-path:
   component: "../../serverless-components/nextjs-component"
+  inputs:
+    removeOldLambdaVersions: true

--- a/packages/e2e-tests/next-app-with-locales-using-serverless-trace/serverless.yml
+++ b/packages/e2e-tests/next-app-with-locales-using-serverless-trace/serverless.yml
@@ -1,6 +1,7 @@
 next-app-with-locales-using-serverless-trace:
   component: "../../serverless-components/nextjs-component"
   inputs:
+    removeOldLambdaVersions: true
     useServerlessTraceTarget: true
     build:
       postBuildCommands: ["node scripts/post-build-test.js"]

--- a/packages/e2e-tests/next-app-with-locales/serverless.yml
+++ b/packages/e2e-tests/next-app-with-locales/serverless.yml
@@ -1,6 +1,7 @@
 next-app-with-locales:
   component: "../../serverless-components/nextjs-component"
   inputs:
+    removeOldLambdaVersions: true
     build:
       postBuildCommands: ["node scripts/post-build-test.js"]
     cloudfront:

--- a/packages/e2e-tests/next-app-with-trailing-slash/serverless.yml
+++ b/packages/e2e-tests/next-app-with-trailing-slash/serverless.yml
@@ -1,2 +1,4 @@
 next-app-with-trailing-slash:
   component: "../../serverless-components/nextjs-component"
+  inputs:
+    removeOldLambdaVersions: true

--- a/packages/e2e-tests/prev-next-app-dynamic-routes/serverless.yml
+++ b/packages/e2e-tests/prev-next-app-dynamic-routes/serverless.yml
@@ -1,2 +1,4 @@
 prev-next-app-dynamic-routes:
   component: "../../serverless-components/nextjs-component"
+  inputs:
+    removeOldLambdaVersions: true

--- a/packages/e2e-tests/prev-next-app-with-base-path/serverless.yml
+++ b/packages/e2e-tests/prev-next-app-with-base-path/serverless.yml
@@ -1,2 +1,4 @@
 prev-next-app-with-base-path:
   component: "../../serverless-components/nextjs-component"
+  inputs:
+    removeOldLambdaVersions: true

--- a/packages/e2e-tests/prev-next-app-with-trailing-slash/serverless.yml
+++ b/packages/e2e-tests/prev-next-app-with-trailing-slash/serverless.yml
@@ -1,2 +1,4 @@
 prev-next-app-with-trailing-slash:
   component: "../../serverless-components/nextjs-component"
+  inputs:
+    removeOldLambdaVersions: true

--- a/packages/e2e-tests/prev-next-app/serverless.yml
+++ b/packages/e2e-tests/prev-next-app/serverless.yml
@@ -1,6 +1,7 @@
 prev-next-app:
   component: "../../serverless-components/nextjs-component"
   inputs:
+    removeOldLambdaVersions: true
     build:
       postBuildCommands: ["node scripts/post-build-test.js"]
     cloudfront:


### PR DESCRIPTION
So the Lambda versions can be cleaned up as part of e2e tests instead of a daily scheduled task