### PR TITLE
fix(core): fix lookup for _next/static files (used in lambda only rig…

### DIFF
--- a/packages/libs/core/src/defaultHandler.ts
+++ b/packages/libs/core/src/defaultHandler.ts
@@ -382,11 +382,12 @@ export const defaultHandler = async ({
   }
   if (route.isNextStaticFile) {
     const { file } = route as NextStaticFileRoute;
+    const relativeFile = file.slice("/_next/static".length);
     return await staticRequest(
       req,
       res,
       responsePromise,
-      file,
+      relativeFile,
       `${routesManifest.basePath}/_next/static`,
       route,
       manifest,


### PR DESCRIPTION
…ht now)

* In case the handler is being used to proxy e.g to S3 even for `_next/static` files, fix the lookup path. Currently Lambda@Edge uses the CloudFront distribution to route `_next/static/*` paths to the S3 bucket directly, so although this was broken it wasn't affecting it.