### PR TITLE
Add URL normalise to image optimiser URL

### DIFF
--- a/packages/libs/core/src/images/imageOptimizer.ts
+++ b/packages/libs/core/src/images/imageOptimizer.ts
@@ -130,6 +130,7 @@ export async function imageOptimizer(
   if (url.startsWith(basePath)) {
     url = url.slice(basePath.length);
   }
+  
   if (url.startsWith("/")) {
     href = url;
     isAbsolute = false;

--- a/packages/libs/core/src/images/imageOptimizer.ts
+++ b/packages/libs/core/src/images/imageOptimizer.ts
@@ -116,7 +116,7 @@ export async function imageOptimizer(
 
   let isAbsolute: boolean;
 
-  // Ensure if Basepath is in the URL, otherwise, a 400 is triggered (same behaviour as Nextjs)
+  // Ensure that Basepath is in the URL, otherwise, a 400 is triggered (same behaviour as Nextjs)
   if (basePath !== "/" && !url.startsWith(basePath)) {
     res.statusCode = 400;
     res.end('"basepath" set but not added to the URL');
@@ -127,10 +127,10 @@ export async function imageOptimizer(
    * If Basepath set, it needs to be removed from the query
    *
    * Not normalised -> error 403
-   * /<base-path>/_next/image?url=%2F<base-path>%2Fassets%2Fimages%2Flogo.svg&w=256&q=75
+   * /<base-path>/_next/image?url=/<base-path>/assets/images/logo.svg&w=256&q=75
    *
    * Normalised -> 200
-   * /<base-path>/_next/image?url=%2Fassets%2Fimages%2Flogo.svg&w=256&q=75
+   * /<base-path>/_next/image?url=/assets/images/logo.svg&w=256&q=75
    */
   if (url.startsWith(basePath)) {
     url = url.slice(basePath.length);

--- a/packages/libs/core/src/images/imageOptimizer.ts
+++ b/packages/libs/core/src/images/imageOptimizer.ts
@@ -75,6 +75,23 @@ export function getMaxAge(str: string | undefined): number {
   return minimum;
 }
 
+/**
+ * If Basepath set, it needs to be removed from URL
+ *
+ * Not normalised -> error 403
+ * url: '<base-path>/assets/images/logo.svg',
+ *
+ * Normalised -> 200
+ * url: '/assets/images/logo.svg',
+ */
+export function normaliseUri(uri: string, basePath: string): string {
+  if (uri.startsWith(basePath)) {
+    uri = uri.slice(basePath.length);
+  }
+
+  return uri;
+}
+
 export async function imageOptimizer(
   basePath: string,
   imagesManifest: ImagesManifest | undefined,
@@ -99,8 +116,7 @@ export async function imageOptimizer(
   }
 
   const { headers } = req;
-  const { w, q } = parsedUrl.query;
-  let url = parsedUrl.query.url;
+  const { url, w, q } = parsedUrl.query;
   const mimeType = getSupportedMimeType(MODERN_TYPES, headers.accept);
   let href: string;
 
@@ -116,27 +132,15 @@ export async function imageOptimizer(
 
   let isAbsolute: boolean;
 
-  // Ensure that Basepath is in the URL, otherwise, a 400 is triggered (same behaviour as Nextjs)
-  if (basePath !== "/" && !url.startsWith(basePath)) {
-    res.statusCode = 400;
-    res.end('"basepath" set but not added to the URL');
-    return { finished: true };
-  }
-
-  /**
-   * If Basepath set, it needs to be removed from the query
-   *
-   * Not normalised -> error 403
-   * /<base-path>/_next/image?url=/<base-path>/assets/images/logo.svg&w=256&q=75
-   *
-   * Normalised -> 200
-   * /<base-path>/_next/image?url=/assets/images/logo.svg&w=256&q=75
-   */
-  if (url.startsWith(basePath)) {
-    url = url.slice(basePath.length);
-  }
   if (url.startsWith("/")) {
-    href = url;
+    // Ensure that Basepath is in the URL, otherwise, a 400 is triggered (same behaviour as Nextjs)
+    if (basePath !== "/" && !url.startsWith(basePath)) {
+      res.statusCode = 400;
+      res.end('"Basepath" set but not added to the URL');
+      return { finished: true };
+    }
+
+    href = normaliseUri(url, basePath);
     isAbsolute = false;
   } else {
     let hrefParsed: URL;

--- a/packages/libs/core/src/images/imageOptimizer.ts
+++ b/packages/libs/core/src/images/imageOptimizer.ts
@@ -99,7 +99,8 @@ export async function imageOptimizer(
   }
 
   const { headers } = req;
-  const { url, w, q } = parsedUrl.query;
+  const { w, q } = parsedUrl.query;
+  let url = parsedUrl.query.url;
   const mimeType = getSupportedMimeType(MODERN_TYPES, headers.accept);
   let href: string;
 
@@ -115,6 +116,9 @@ export async function imageOptimizer(
 
   let isAbsolute: boolean;
 
+  if (url.startsWith(basePath)) {
+    url = url.slice(basePath.length);
+  }
   if (url.startsWith("/")) {
     href = url;
     isAbsolute = false;

--- a/packages/libs/core/src/images/imageOptimizer.ts
+++ b/packages/libs/core/src/images/imageOptimizer.ts
@@ -116,21 +116,24 @@ export async function imageOptimizer(
 
   let isAbsolute: boolean;
 
+  // Ensure if Basepath is in the URL, otherwise, a 400 is triggered (same behaviour as Nextjs)
+  if (basePath !== "/" && !url.startsWith(basePath)) {
+    res.statusCode = 400;
+    res.end('"basepath" set but not added to the URL');
+    return { finished: true };
+  }
+
   /**
-   * Basepath, needs to be removed from the query
-   * 
+   * If Basepath set, it needs to be removed from the query
+   *
    * Not normalised -> error 403
    * /<base-path>/_next/image?url=%2F<base-path>%2Fassets%2Fimages%2Flogo.svg&w=256&q=75
-   * 
+   *
    * Normalised -> 200
    * /<base-path>/_next/image?url=%2Fassets%2Fimages%2Flogo.svg&w=256&q=75
-   * 
-   * 
    */
-  if (url.startsWith(basePath)) {
-    url = url.slice(basePath.length);
-  }
-  
+  url = url.slice(basePath.length);
+
   if (url.startsWith("/")) {
     href = url;
     isAbsolute = false;

--- a/packages/libs/core/src/images/imageOptimizer.ts
+++ b/packages/libs/core/src/images/imageOptimizer.ts
@@ -116,6 +116,17 @@ export async function imageOptimizer(
 
   let isAbsolute: boolean;
 
+  /**
+   * Basepath, needs to be removed from the query
+   * 
+   * Not normalised -> error 403
+   * /<base-path>/_next/image?url=%2F<base-path>%2Fassets%2Fimages%2Flogo.svg&w=256&q=75
+   * 
+   * Normalised -> 200
+   * /<base-path>/_next/image?url=%2Fassets%2Fimages%2Flogo.svg&w=256&q=75
+   * 
+   * 
+   */
   if (url.startsWith(basePath)) {
     url = url.slice(basePath.length);
   }

--- a/packages/libs/core/src/images/imageOptimizer.ts
+++ b/packages/libs/core/src/images/imageOptimizer.ts
@@ -132,8 +132,9 @@ export async function imageOptimizer(
    * Normalised -> 200
    * /<base-path>/_next/image?url=%2Fassets%2Fimages%2Flogo.svg&w=256&q=75
    */
-  url = url.slice(basePath.length);
-
+  if (url.startsWith(basePath)) {
+    url = url.slice(basePath.length);
+  }
   if (url.startsWith("/")) {
     href = url;
     isAbsolute = false;

--- a/packages/libs/core/src/images/index.ts
+++ b/packages/libs/core/src/images/index.ts
@@ -1,1 +1,1 @@
-export { imageOptimizer } from "./imageOptimizer";
+export { imageOptimizer, normaliseUri } from "./imageOptimizer";

--- a/packages/libs/lambda-at-edge/src/image-handler.ts
+++ b/packages/libs/lambda-at-edge/src/image-handler.ts
@@ -15,7 +15,10 @@ import {
   handleDomainRedirects,
   setCustomHeaders
 } from "@sls-next/core/dist/module";
-import { imageOptimizer } from "@sls-next/core/dist/module/images";
+import {
+  imageOptimizer,
+  normaliseUri
+} from "@sls-next/core/dist/module/images";
 import { UrlWithParsedQuery } from "url";
 import url from "url";
 import { removeBlacklistedHeaders } from "./headers/removeBlacklistedHeaders";
@@ -23,15 +26,6 @@ import { s3BucketNameFromEventRequest } from "./s3/s3BucketNameFromEventRequest"
 import { AwsPlatformClient } from "@sls-next/aws-common";
 
 const basePath = RoutesManifestJson.basePath;
-
-const normaliseUri = (uri: string): string => {
-  if (uri.startsWith(basePath)) {
-    uri = uri.slice(basePath.length);
-  }
-
-  return uri;
-};
-
 const isImageOptimizerRequest = (uri: string): boolean =>
   uri.startsWith("/_next/image");
 
@@ -59,7 +53,7 @@ export const handler = async (
   // No other redirects or rewrites supported for now as it's assumed one is accessing this directly.
   // But it can be added later.
 
-  const uri = normaliseUri(request.uri);
+  const uri = normaliseUri(request.uri, basePath);
 
   // Handle image optimizer requests
   const isImageRequest = isImageOptimizerRequest(uri);

--- a/packages/libs/lambda/src/handlers/image-handler.ts
+++ b/packages/libs/lambda/src/handlers/image-handler.ts
@@ -11,17 +11,12 @@ import {
 import { ImagesManifest, setCustomHeaders } from "@sls-next/core/dist/module";
 import url, { UrlWithParsedQuery } from "url";
 import { LambdaManifest, RoutesManifest } from "src/types";
-import { imageOptimizer } from "@sls-next/core/dist/module/images";
+import {
+  imageOptimizer,
+  normaliseUri
+} from "@sls-next/core/dist/module/images";
 
 const basePath = RoutesManifestJson.basePath;
-
-const normaliseUri = (uri: string): string => {
-  if (uri.startsWith(basePath)) {
-    uri = uri.slice(basePath.length);
-  }
-
-  return uri;
-};
 
 const isImageOptimizerRequest = (uri: string): boolean =>
   uri.startsWith("/_next/image");
@@ -36,7 +31,7 @@ export const handler = async (
   // Compatibility layer required to convert from Node.js req/res <-> API Gateway
   const { req, res, responsePromise } = httpCompat(event);
 
-  const uri = normaliseUri(req.url ?? "");
+  const uri = normaliseUri(req.url ?? "", basePath);
 
   // Handle image optimizer requests
   // TODO: probably can move these to core package


### PR DESCRIPTION
If Basepath is set, it needs to be removed from the query

 Not normalised -> error 403
 `url: '<base-path>/assets/images/logo.svg'`
 
Normalised -> 200
url: `'/assets/images/logo.svg'`