### PR TITLE
fix(core): render static pages for all http methods, for options meth…

### DIFF
--- a/packages/e2e-tests/next-app-experimental/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-experimental/cypress/integration/pages.test.ts
@@ -95,14 +95,13 @@ describe("Pages Tests", () => {
       });
 
       ["DELETE", "POST", "OPTIONS", "PUT", "PATCH"].forEach((method) => {
-        it(`disallows HTTP method for path ${path} with 4xx error: ${method}`, () => {
+        it(`allows HTTP method for path ${path} with 2xx status: ${method}`, () => {
           cy.request({
             url: path,
-            method: method,
-            failOnStatusCode: false
+            method: method
           }).then((response) => {
-            expect(response.status).to.be.at.least(400);
-            expect(response.status).to.be.lessThan(500);
+            expect(response.status).to.be.at.least(200);
+            expect(response.status).to.be.lessThan(300);
           });
         });
       });

--- a/packages/e2e-tests/next-app-experimental/cypress/integration/static-files.test.ts
+++ b/packages/e2e-tests/next-app-experimental/cypress/integration/static-files.test.ts
@@ -50,14 +50,13 @@ describe("Static Files Tests", () => {
       });
 
       ["DELETE", "POST", "OPTIONS", "PUT", "PATCH"].forEach((method) => {
-        it(`disallows HTTP method for path ${path} with 4xx error: ${method}`, () => {
+        it(`allows HTTP method for path ${path} with 2xx status: ${method}`, () => {
           cy.request({
             url: path,
-            method: method,
-            failOnStatusCode: false
+            method: method
           }).then((response) => {
-            expect(response.status).to.be.at.least(400);
-            expect(response.status).to.be.lessThan(500);
+            expect(response.status).to.be.at.least(200);
+            expect(response.status).to.be.lessThan(300);
           });
         });
       });

--- a/packages/libs/core/src/defaultHandler.ts
+++ b/packages/libs/core/src/defaultHandler.ts
@@ -124,16 +124,12 @@ const staticRequest = async (
   const staticRoute = route.isStatic ? (route as StaticRoute) : undefined;
   const statusCode = route?.statusCode ?? 200;
 
-  // For PUT, DELETE, PATCH, POST, OPTIONS just return a 405 response as these should not be supported for a page fetch.
-  // TODO: OPTIONS should be able to be supported now.
-  if (
-    req.method === "PUT" ||
-    req.method === "DELETE" ||
-    req.method === "PATCH" ||
-    req.method === "POST" ||
-    req.method === "OPTIONS"
-  ) {
-    res.writeHead(405);
+  // For PUT, DELETE, PATCH, POST just return the page as this is a static page, so HTTP method doesn't really do anything.
+  // For OPTIONS, we should not return the content but instead return allowed methods.
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      Allow: "OPTIONS, GET, HEAD, POST, PUT, PATCH, DELETE"
+    });
     res.end();
     return await responsePromise;
   }

--- a/packages/libs/lambda-at-edge/src/render/renderStaticPage.ts
+++ b/packages/libs/lambda-at-edge/src/render/renderStaticPage.ts
@@ -48,18 +48,12 @@ export const renderStaticPage = async ({
   const staticRoute = route.isStatic ? (route as StaticRoute) : undefined;
   const statusCode = route?.statusCode ?? 200;
 
-  // For PUT, DELETE, PATCH, POST, OPTIONS just return a 405 response as these are unsupported S3 methods
-  // when using CloudFront S3 origin to return the page, so we keep it in parity.
-  // TODO: now that we are directly calling S3 in the origin request handler,
-  //  we could implement OPTIONS method as well.
-  if (
-    request.method === "PUT" ||
-    request.method === "DELETE" ||
-    request.method === "PATCH" ||
-    request.method === "POST" ||
-    request.method === "OPTIONS"
-  ) {
-    res.writeHead(405);
+  // For PUT, DELETE, PATCH, POST just return the page as this is a static page, so HTTP method doesn't really do anything.
+  // For OPTIONS, we should not return the content but instead return allowed methods.
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      Allow: "OPTIONS, GET, HEAD, POST, PUT, PATCH, DELETE"
+    });
     res.end();
     return await responsePromise;
   }


### PR DESCRIPTION
…ods return allowed methods. This will be in parity with Next.js server as it also renders static pages no matter the request method. Note: only applies if S3 pages are rendered through the Lambda, as for CloudFront -> s3 origin, http method cannot be modified (and we don't want to do it in origin response handler as it will just be inefficient).