### PR TITLE
fix(core, lambda-at-edge): properly decode URIs so they can map to th…

### DIFF
--- a/packages/e2e-tests/next-app/cypress/integration/static-regeneration.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/static-regeneration.test.ts
@@ -6,7 +6,8 @@ describe("ISR Tests", () => {
   describe("SSG page", () => {
     [
       { path: "/revalidated-ssg-page", initialWaitSeconds: 0 },
-      { path: "/revalidated-ssg-page%20with-space", initialWaitSeconds: 0 },
+      // Page with spaces in it (generally not recommended since this is not URL-safe character, but Next.js handles this)
+      { path: "/revalidated-ssg-pages-2/with%20space", initialWaitSeconds: 0 },
       // Pre-rendered ISR page
       { path: "/revalidated-ssg-pages/101", initialWaitSeconds: 0 },
       // Blocking dynamic generated page. As the page will be created and cached

--- a/packages/e2e-tests/next-app/cypress/integration/static-regeneration.test.ts
+++ b/packages/e2e-tests/next-app/cypress/integration/static-regeneration.test.ts
@@ -6,6 +6,7 @@ describe("ISR Tests", () => {
   describe("SSG page", () => {
     [
       { path: "/revalidated-ssg-page", initialWaitSeconds: 0 },
+      { path: "/revalidated-ssg-page%20with-space", initialWaitSeconds: 0 },
       // Pre-rendered ISR page
       { path: "/revalidated-ssg-pages/101", initialWaitSeconds: 0 },
       // Blocking dynamic generated page. As the page will be created and cached

--- a/packages/e2e-tests/next-app/pages/revalidated-ssg-page with-space.tsx
+++ b/packages/e2e-tests/next-app/pages/revalidated-ssg-page with-space.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { GetStaticPropsResult } from "next";
+
+type SSGPageProps = {
+  date: string;
+};
+
+export default function RevalidatedSSGPageWithSpace(
+  props: SSGPageProps
+): JSX.Element {
+  return (
+    <React.Fragment>
+      <div>
+        <p data-cy="date-text">{props.date}</p>
+      </div>
+    </React.Fragment>
+  );
+}
+
+export function getStaticProps(): GetStaticPropsResult<SSGPageProps> {
+  return {
+    revalidate: 10,
+    props: {
+      date: new Date().toJSON()
+    }
+  };
+}

--- a/packages/e2e-tests/next-app/pages/revalidated-ssg-pages-2/[title].tsx
+++ b/packages/e2e-tests/next-app/pages/revalidated-ssg-pages-2/[title].tsx
@@ -1,13 +1,11 @@
 import React from "react";
-import { GetStaticPropsResult } from "next";
+import { GetStaticPaths, GetStaticPropsResult } from "next";
 
 type SSGPageProps = {
   date: string;
 };
 
-export default function RevalidatedSSGPageWithSpace(
-  props: SSGPageProps
-): JSX.Element {
+export default function RevalidatedSSGPage(props: SSGPageProps): JSX.Element {
   return (
     <React.Fragment>
       <div>
@@ -15,6 +13,11 @@ export default function RevalidatedSSGPageWithSpace(
       </div>
     </React.Fragment>
   );
+}
+
+export function getStaticPaths() {
+  const paths = [{ params: { title: "with space" } }];
+  return { paths, fallback: true };
 }
 
 export function getStaticProps(): GetStaticPropsResult<SSGPageProps> {

--- a/packages/libs/core/src/defaultHandler.ts
+++ b/packages/libs/core/src/defaultHandler.ts
@@ -119,7 +119,9 @@ const staticRequest = async (
   platformClient: PlatformClient
 ) => {
   const basePath = routesManifest.basePath;
-  const fileKey = (path + file).slice(1); // need to remove leading slash from path for page/file key
+  const fileKey = (path + decodeURI(file)).slice(1); // need to remove leading slash from path for page/file key
+  // also decode file parameter as it's encoded
+  // (legacy reasons since previously Cloudfront request is used to request S3, and CF requires an encoded request.uri)
 
   const staticRoute = route.isStatic ? (route as StaticRoute) : undefined;
   const statusCode = route?.statusCode ?? 200;

--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -40,12 +40,11 @@ export const handlePageReq = (
     ),
     routesManifest
   );
-  const decodedLocaleUri = decodeURI(localeUri); // Need to decode URI since manifest is decoded
 
   // This allows matching against rewrites even without basepath
   if (!missingExpectedBasePath) {
-    if (pages.html.nonDynamic[decodedLocaleUri]) {
-      const nonLocaleUri = dropLocaleFromPath(decodedLocaleUri, routesManifest);
+    if (pages.html.nonDynamic[localeUri]) {
+      const nonLocaleUri = dropLocaleFromPath(localeUri, routesManifest);
       const statusCode =
         nonLocaleUri === "/404"
           ? 404
@@ -55,14 +54,14 @@ export const handlePageReq = (
       return {
         isData: false,
         isStatic: true,
-        file: pages.html.nonDynamic[decodedLocaleUri],
+        file: pages.html.nonDynamic[localeUri],
         statusCode
       };
     }
-    if (pages.ssg.nonDynamic[decodedLocaleUri] && !isPreview) {
-      const ssg = pages.ssg.nonDynamic[decodedLocaleUri];
-      const route = ssg.srcRoute ?? decodedLocaleUri;
-      const nonLocaleUri = dropLocaleFromPath(decodedLocaleUri, routesManifest);
+    if (pages.ssg.nonDynamic[localeUri] && !isPreview) {
+      const ssg = pages.ssg.nonDynamic[localeUri];
+      const route = ssg.srcRoute ?? localeUri;
+      const nonLocaleUri = dropLocaleFromPath(localeUri, routesManifest);
       const statusCode =
         nonLocaleUri === "/404"
           ? 404
@@ -78,6 +77,34 @@ export const handlePageReq = (
         revalidate: ssg.initialRevalidateSeconds,
         statusCode
       };
+    }
+    // Handle ISR pages with encoded URL
+    // This only applies to ISR, other pages should not be resolved if sent with encoded characters (same as local Next.js server behavior)
+    const decodedLocaleUri = decodeURI(localeUri);
+    if (pages.ssg.nonDynamic[decodedLocaleUri] && !isPreview) {
+      const ssg = pages.ssg.nonDynamic[decodedLocaleUri];
+      if (ssg.initialRevalidateSeconds) {
+        const route = ssg.srcRoute ?? decodedLocaleUri;
+        const nonLocaleUri = dropLocaleFromPath(
+          decodedLocaleUri,
+          routesManifest
+        );
+        const statusCode =
+          nonLocaleUri === "/404"
+            ? 404
+            : nonLocaleUri === "/500"
+            ? 500
+            : undefined;
+        return {
+          isData: false,
+          isStatic: true,
+          file: pageHtml(localeUri), // Use encoded localeUri instead of decodedLocaleUri as this is used by CloudFront request that needs an encoded URL
+          // page JS path is from SSR entries in manifest
+          page: pages.ssr.nonDynamic[route] || pages.ssr.dynamic[route],
+          revalidate: ssg.initialRevalidateSeconds,
+          statusCode
+        };
+      }
     }
     if ((pages.ssg.notFound ?? {})[decodedLocaleUri] && !isPreview) {
       return notFoundPage(uri, manifest, routesManifest);

--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -106,20 +106,20 @@ export const handlePageReq = (
         };
       }
     }
-    if ((pages.ssg.notFound ?? {})[decodedLocaleUri] && !isPreview) {
+    if ((pages.ssg.notFound ?? {})[localeUri] && !isPreview) {
       return notFoundPage(uri, manifest, routesManifest);
     }
-    if (pages.ssr.nonDynamic[decodedLocaleUri]) {
+    if (pages.ssr.nonDynamic[localeUri]) {
       if (localeUri.startsWith("/api/")) {
         return {
           isApi: true,
-          page: pages.ssr.nonDynamic[decodedLocaleUri]
+          page: pages.ssr.nonDynamic[localeUri]
         };
       } else {
         return {
           isData: false,
           isRender: true,
-          page: pages.ssr.nonDynamic[decodedLocaleUri]
+          page: pages.ssr.nonDynamic[localeUri]
         };
       }
     }
@@ -152,7 +152,7 @@ export const handlePageReq = (
 
   // We don't want to match URIs with missing basepath against dynamic routes if it wasn't already covered by rewrite.
   if (!missingExpectedBasePath) {
-    const dynamic = matchDynamicRoute(decodedLocaleUri, pages.dynamic);
+    const dynamic = matchDynamicRoute(localeUri, pages.dynamic);
 
     const dynamicSSG = dynamic && pages.ssg.dynamic[dynamic];
     if (dynamicSSG && !isPreview) {

--- a/packages/libs/core/src/route/page.ts
+++ b/packages/libs/core/src/route/page.ts
@@ -40,11 +40,12 @@ export const handlePageReq = (
     ),
     routesManifest
   );
+  const decodedLocaleUri = decodeURI(localeUri); // Need to decode URI since manifest is decoded
 
   // This allows matching against rewrites even without basepath
   if (!missingExpectedBasePath) {
-    if (pages.html.nonDynamic[localeUri]) {
-      const nonLocaleUri = dropLocaleFromPath(localeUri, routesManifest);
+    if (pages.html.nonDynamic[decodedLocaleUri]) {
+      const nonLocaleUri = dropLocaleFromPath(decodedLocaleUri, routesManifest);
       const statusCode =
         nonLocaleUri === "/404"
           ? 404
@@ -54,14 +55,14 @@ export const handlePageReq = (
       return {
         isData: false,
         isStatic: true,
-        file: pages.html.nonDynamic[localeUri],
+        file: pages.html.nonDynamic[decodedLocaleUri],
         statusCode
       };
     }
-    if (pages.ssg.nonDynamic[localeUri] && !isPreview) {
-      const ssg = pages.ssg.nonDynamic[localeUri];
-      const route = ssg.srcRoute ?? localeUri;
-      const nonLocaleUri = dropLocaleFromPath(localeUri, routesManifest);
+    if (pages.ssg.nonDynamic[decodedLocaleUri] && !isPreview) {
+      const ssg = pages.ssg.nonDynamic[decodedLocaleUri];
+      const route = ssg.srcRoute ?? decodedLocaleUri;
+      const nonLocaleUri = dropLocaleFromPath(decodedLocaleUri, routesManifest);
       const statusCode =
         nonLocaleUri === "/404"
           ? 404
@@ -78,20 +79,20 @@ export const handlePageReq = (
         statusCode
       };
     }
-    if ((pages.ssg.notFound ?? {})[localeUri] && !isPreview) {
+    if ((pages.ssg.notFound ?? {})[decodedLocaleUri] && !isPreview) {
       return notFoundPage(uri, manifest, routesManifest);
     }
-    if (pages.ssr.nonDynamic[localeUri]) {
+    if (pages.ssr.nonDynamic[decodedLocaleUri]) {
       if (localeUri.startsWith("/api/")) {
         return {
           isApi: true,
-          page: pages.ssr.nonDynamic[localeUri]
+          page: pages.ssr.nonDynamic[decodedLocaleUri]
         };
       } else {
         return {
           isData: false,
           isRender: true,
-          page: pages.ssr.nonDynamic[localeUri]
+          page: pages.ssr.nonDynamic[decodedLocaleUri]
         };
       }
     }
@@ -124,7 +125,7 @@ export const handlePageReq = (
 
   // We don't want to match URIs with missing basepath against dynamic routes if it wasn't already covered by rewrite.
   if (!missingExpectedBasePath) {
-    const dynamic = matchDynamicRoute(localeUri, pages.dynamic);
+    const dynamic = matchDynamicRoute(decodedLocaleUri, pages.dynamic);
 
     const dynamicSSG = dynamic && pages.ssg.dynamic[dynamic];
     if (dynamicSSG && !isPreview) {

--- a/packages/libs/lambda-at-edge/src/regeneration-handler.ts
+++ b/packages/libs/lambda-at-edge/src/regeneration-handler.ts
@@ -29,7 +29,7 @@ export const handler = async (event: AWSLambda.SQSEvent): Promise<void> => {
         "passthrough"
       );
 
-      const normalizedUri = regenerationEvent.pageS3Path
+      const normalizedUri = decodeURI(regenerationEvent.pageS3Path)
         .replace(`static-pages/${manifest.buildId}`, "")
         .replace(".js", "");
 


### PR DESCRIPTION
…e right paths for ISR encoded  parameters only (Next.js doesn't resolve other paths)