### PR TITLE
fix(aws-cloudfront, nextjs-component): specify s3 client's region in …

### DIFF
--- a/packages/serverless-components/aws-cloudfront/src/component.ts
+++ b/packages/serverless-components/aws-cloudfront/src/component.ts
@@ -23,7 +23,8 @@ class CloudFront extends Component {
   async default(inputs: any = {}) {
     this.context.status("Deploying");
 
-    inputs.region = inputs.region || "us-east-1";
+    inputs.region = inputs.region ?? "us-east-1";
+    inputs.bucketRegion = inputs.bucketRegion ?? "us-east-1"; // S3 client needs to be specific to the bucket region
     inputs.enabled = inputs.enabled !== false;
     inputs.comment =
       inputs.comment === null || inputs.comment === undefined
@@ -57,7 +58,7 @@ class CloudFront extends Component {
 
     const s3 = new AWS.S3({
       credentials: this.context.credentials.aws,
-      region: inputs.region
+      region: inputs.bucketRegion
     });
 
     this.state.id = inputs.distributionId || this.state.id;

--- a/packages/serverless-components/nextjs-component/__tests__/deploy.test.ts
+++ b/packages/serverless-components/nextjs-component/__tests__/deploy.test.ts
@@ -310,6 +310,7 @@ describe.each`
 
     it("creates distribution", () => {
       expect(mockCloudFront).toBeCalledWith({
+        bucketRegion: "us-east-1",
         defaults: {
           allowedHttpMethods: [
             "HEAD",

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -911,6 +911,7 @@ class NextjsComponent extends Component {
     delete defaultLambdaAtEdgeConfig["origin-response"];
 
     const cloudFrontOutputs = await cloudFront({
+      bucketRegion: bucketRegion,
       distributionId: cloudFrontDistributionId,
       defaults: {
         minTTL: 0,


### PR DESCRIPTION
…aws-cloudfront the same as the bucket region

Should fix: https://github.com/serverless-nextjs/serverless-next.js/issues/2041