### PR TITLE
feat(nextjs-cdk-construct): add runtime options to regeneration

### DIFF
--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -136,7 +136,7 @@ export class NextJSLambdaEdge extends cdk.Construct {
           role: this.edgeLambdaRole,
           runtime:
             toLambdaOption("regenerationLambda", props.runtime) ??
-            lambda.Runtime.NODEJS_12_X,
+            lambda.Runtime.NODEJS_14_X,
           memorySize: toLambdaOption("regenerationLambda", props.memory) ?? 512,
           timeout:
             toLambdaOption("regenerationLambda", props.timeout) ?? Duration.seconds(30)

--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -133,11 +133,10 @@ export class NextJSLambdaEdge extends cdk.Construct {
           code: lambda.Code.fromAsset(
             path.join(this.props.serverlessBuildOutDir, "regeneration-lambda")
           ),
-          role: this.edgeLambdaRole,
           runtime:
             toLambdaOption("regenerationLambda", props.runtime) ??
             lambda.Runtime.NODEJS_14_X,
-          memorySize: toLambdaOption("regenerationLambda", props.memory) ?? 512,
+          memorySize: toLambdaOption("regenerationLambda", props.memory) ?? undefined,
           timeout:
             toLambdaOption("regenerationLambda", props.timeout) ?? Duration.seconds(30)
         }

--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -89,6 +89,20 @@ export class NextJSLambdaEdge extends cdk.Construct {
       ...(props.s3Props || {})
     });
 
+    this.edgeLambdaRole = new Role(this, "NextEdgeLambdaRole", {
+      assumedBy: new CompositePrincipal(
+        new ServicePrincipal("lambda.amazonaws.com"),
+        new ServicePrincipal("edgelambda.amazonaws.com")
+      ),
+      managedPolicies: [
+        ManagedPolicy.fromManagedPolicyArn(
+          this,
+          "NextApiLambdaPolicy",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        )
+      ]
+    });
+
     const hasISRPages = Object.keys(this.prerenderManifest.routes).some(
       (key) =>
         typeof this.prerenderManifest.routes[key].initialRevalidateSeconds ===
@@ -116,11 +130,16 @@ export class NextJSLambdaEdge extends cdk.Construct {
         "RegenerationFunction",
         {
           handler: "index.handler",
-          runtime: lambda.Runtime.NODEJS_14_X,
-          timeout: Duration.seconds(30),
           code: lambda.Code.fromAsset(
             path.join(this.props.serverlessBuildOutDir, "regeneration-lambda")
-          )
+          ),
+          role: this.edgeLambdaRole,
+          runtime:
+            toLambdaOption("regenerationLambda", props.runtime) ??
+            lambda.Runtime.NODEJS_12_X,
+          memorySize: toLambdaOption("regenerationLambda", props.memory) ?? 512,
+          timeout:
+            toLambdaOption("regenerationLambda", props.timeout) ?? Duration.seconds(30)
         }
       );
 
@@ -128,20 +147,6 @@ export class NextJSLambdaEdge extends cdk.Construct {
         new lambdaEventSources.SqsEventSource(this.regenerationQueue)
       );
     }
-
-    this.edgeLambdaRole = new Role(this, "NextEdgeLambdaRole", {
-      assumedBy: new CompositePrincipal(
-        new ServicePrincipal("lambda.amazonaws.com"),
-        new ServicePrincipal("edgelambda.amazonaws.com")
-      ),
-      managedPolicies: [
-        ManagedPolicy.fromManagedPolicyArn(
-          this,
-          "NextApiLambdaPolicy",
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        )
-      ]
-    });
 
     this.defaultNextLambda = new lambda.Function(this, "NextLambda", {
       functionName: toLambdaOption("defaultLambda", props.name),

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -7,7 +7,12 @@ import { Duration, StackProps } from "@aws-cdk/core";
 
 export type LambdaOption<T> =
   | T
-  | { defaultLambda?: T; apiLambda?: T; imageLambda?: T };
+  | {
+      defaultLambda?: T;
+      apiLambda?: T;
+      imageLambda?: T;
+      regenerationLambda?: T;
+    };
 
 export interface Props extends StackProps {
   /**

--- a/packages/serverless-components/nextjs-cdk-construct/src/utils/toLambdaOption.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/utils/toLambdaOption.ts
@@ -3,7 +3,7 @@
 import { LambdaOption } from "../props";
 
 export const toLambdaOption = <T extends unknown>(
-  key: "defaultLambda" | "apiLambda" | "imageLambda",
+  key: "defaultLambda" | "apiLambda" | "imageLambda" | "regenerationLambda",
   option?: LambdaOption<T>
 ): T | undefined => {
   if (
@@ -11,7 +11,8 @@ export const toLambdaOption = <T extends unknown>(
     !(
       "defaultLambda" in option ||
       "apiLambda" in option ||
-      "imageLambda" in option
+      "imageLambda" in option ||
+      "regenerationLambda" in option
     )
   ) {
     return option as T | undefined;


### PR DESCRIPTION
fixes issue #2048  
The regeneration function was the only function where the runtime could not be modified through setttings prop
This can cause the regeneration lambda function to time out an fail
The pull request adds the option to configure the regeneration runtime (memory, timeout, role, and node version)

as a note I have not modified the nomenclature for this function but it is the only lambda handler that is named as Function instead of Lambda for the others (nextApiLambda, nextDefaultLambda, nextImageLambda) but the regeneration lambda is named RegenerationFunction. I can modify that also if needed.