### PR TITLE
fix(libs): resolve invalid syntax on etag

### DIFF
--- a/packages/libs/core/src/images/sendEtagResponse.ts
+++ b/packages/libs/core/src/images/sendEtagResponse.ts
@@ -13,10 +13,10 @@ export function sendEtagResponse(
      * response to the same request: Cache-Control, Content-Location, Date,
      * ETag, Expires, and Vary. https://tools.ietf.org/html/rfc7232#section-4.1
      */
-    res.setHeader("ETag", etag);
+    res.setHeader("ETag", `"${etag}"`);
   }
 
-  if (fresh(req.headers, { etag })) {
+  if (fresh(req.headers, { etag: `"${etag}"` })) {
     res.statusCode = 304;
     res.end();
     return true;

--- a/packages/libs/core/tests/images/imageOptimizer.test.ts
+++ b/packages/libs/core/tests/images/imageOptimizer.test.ts
@@ -288,7 +288,7 @@ describe("Image optimizer", () => {
 
       expect(res.getHeaders()).toEqual({
         "cache-control": "public, max-age=60",
-        etag: "-MEos7nPVi9RjCQMnHdAmrGDydYWJ1GJUF1IEQkQ1Sw=",
+        etag: '"-MEos7nPVi9RjCQMnHdAmrGDydYWJ1GJUF1IEQkQ1Sw="',
         "content-type": "image/webp"
       });
 


### PR DESCRIPTION
This PR fixed about invalid ETag value.
ETag header value should begins double quote character (`"`)  or `W/`, referring to MDN docs.

PR also fixed that CloudFront will remove the ETag header when compressing files; because CloudFront also converts ETag header value, but it is missing double quote character.


References:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#directives
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html#compressed-content-cloudfront-etag-header