### PR TITLE
Allow opt-in for AVIF optimization

### DIFF
--- a/packages/libs/core/src/build/types.ts
+++ b/packages/libs/core/src/build/types.ts
@@ -29,6 +29,7 @@ export type ImageConfig = {
   imageSizes: number[];
   loader: "default" | "imgix" | "cloudinary" | "akamai";
   path: string;
+  formats: string[];
   domains?: string[];
 };
 

--- a/packages/libs/core/src/images/imageConfig.ts
+++ b/packages/libs/core/src/images/imageConfig.ts
@@ -5,5 +5,6 @@ export const imageConfigDefault: ImageConfig = {
   imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   path: "/_next/image",
   loader: "default",
-  domains: []
+  domains: [],
+  formats: ["image/webp"]
 };

--- a/packages/libs/core/src/images/imageOptimizer.ts
+++ b/packages/libs/core/src/images/imageOptimizer.ts
@@ -11,21 +11,21 @@
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { UrlWithParsedQuery } from "url";
-import { IncomingMessage, ServerResponse } from "http";
-import { join } from "path";
 import { mediaType } from "@hapi/accept";
-import { createReadStream, promises } from "fs";
 import { createHash } from "crypto";
-import { getContentType, getExtension } from "./serveStatic";
+import * as fs from "fs";
+import { createReadStream, promises } from "fs";
+import { IncomingMessage, ServerResponse } from "http";
 // @ts-ignore no types for is-animated
 import isAnimated from "is-animated";
-import { sendEtagResponse } from "./sendEtagResponse";
-import { ImageConfig, ImagesManifest } from "../build/types";
-import { imageConfigDefault } from "./imageConfig";
-import * as fs from "fs";
 import fetch from "node-fetch";
+import { join } from "path";
+import { UrlWithParsedQuery } from "url";
+import { ImageConfig, ImagesManifest } from "../build/types";
 import { PlatformClient } from "../platform";
+import { imageConfigDefault } from "./imageConfig";
+import { sendEtagResponse } from "./sendEtagResponse";
+import { getContentType, getExtension } from "./serveStatic";
 
 let sharp: typeof import("sharp");
 const AVIF = "image/avif";
@@ -35,7 +35,6 @@ const JPEG = "image/jpeg";
 const GIF = "image/gif";
 const SVG = "image/svg+xml";
 const CACHE_VERSION = 2;
-const MODERN_TYPES = [AVIF, WEBP];
 const ANIMATABLE_TYPES = [WEBP, PNG, GIF];
 const VECTOR_TYPES = [SVG];
 
@@ -105,6 +104,7 @@ export async function imageOptimizer(
     deviceSizes = [],
     imageSizes = [],
     domains = [],
+    formats = ["image/webp"],
     loader
   } = imageConfig;
   const sizes = [...deviceSizes, ...imageSizes];
@@ -117,7 +117,7 @@ export async function imageOptimizer(
 
   const { headers } = req;
   const { url, w, q } = parsedUrl.query;
-  const mimeType = getSupportedMimeType(MODERN_TYPES, headers.accept);
+  const mimeType = getSupportedMimeType(formats, headers.accept);
   let href: string;
 
   if (!url) {

--- a/packages/libs/core/tests/images/image-images-manifest.json
+++ b/packages/libs/core/tests/images/image-images-manifest.json
@@ -23,6 +23,7 @@
       128,
       256,
       384
-    ]
+    ],
+    "formats": ["image/avif","image/webp"]
   }
 }

--- a/packages/serverless-components/nextjs-cdk-construct/src/utils/toLambdaOption.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/utils/toLambdaOption.ts
@@ -1,8 +1,6 @@
-// @ts-nocheck
-// TODO: fix line 12-14 TS errors: TS2361: The right-hand side of an 'in' expression must not be a primitive.
 import { LambdaOption } from "../props";
 
-export const toLambdaOption = <T extends unknown>(
+export const toLambdaOption = <T>(
   key: "defaultLambda" | "apiLambda" | "imageLambda" | "regenerationLambda",
   option?: LambdaOption<T>
 ): T | undefined => {


### PR DESCRIPTION
Thanks so much for this awesome package! This request aims to make the new formats setting from next.config in next 12 (https://nextjs.org/docs/api-reference/next/image#acceptable-formats) work as expected and allow opt-in or out for avif optimization (the default being, as next's is, webp).

closes #2235 