### PR TITLE
Use basepath in s3 assets

### DIFF
--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -406,7 +406,9 @@ export class NextJSLambdaEdge extends Construct {
     );
 
     const assetsDirectory = path.join(props.serverlessBuildOutDir, "assets");
-    const assets = readAssetsDirectory({ assetsDirectory });
+    const { basePath } = this.routesManifest || {};
+    const normalizedBasePath = basePath && basePath.length > 0 ? basePath.slice(1) : "";
+    const assets = readAssetsDirectory({ assetsDirectory: path.join(assetsDirectory, normalizedBasePath) });
 
     // This `BucketDeployment` deploys just the BUILD_ID file. We don't actually
     // use the BUILD_ID file at runtime, however in this case we use it as a


### PR DESCRIPTION
I ran into the problem described in #1620: when using a `basePath` in the Next.js application, the S3 asset bucket remains empty. There was a fix mentioned in the issue, but no PR yet, so I've taken the liberty to make that change and open this PR. I tried the change locally and it worked.

@dphang or any other maintainer: I'm of course willing to add tests, but I couldn't figure out how to integrate such a basePath test with the existing CDK tests.