### PR TITLE
feat(cloudfront): add ability to set ResponseHeadersPolicyId

### DIFF
--- a/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/cache-behavior-options.test.ts.snap
+++ b/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/cache-behavior-options.test.ts.snap
@@ -57,6 +57,7 @@ Object {
             "MaxTTL": 0,
             "MinTTL": 0,
             "PathPattern": "/sample/path",
+            "ResponseHeadersPolicyId": "",
             "SmoothStreaming": false,
             "TargetOriginId": "mycustomorigin.com",
             "TrustedSigners": Object {
@@ -112,6 +113,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "mycustomorigin.com",
         "TrustedSigners": Object {
@@ -225,6 +227,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "uuid",
         "SmoothStreaming": true,
         "TargetOriginId": "mycustomorigin.com",
         "TrustedSigners": Object {

--- a/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/custom-url-origin.test.ts.snap
+++ b/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/custom-url-origin.test.ts.snap
@@ -67,6 +67,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "mycustomorigin.com",
         "TrustedSigners": Object {
@@ -164,6 +165,7 @@ Object {
       },
       "MaxTTL": 31536000,
       "MinTTL": 0,
+      "ResponseHeadersPolicyId": "",
       "SmoothStreaming": false,
       "TargetOriginId": "mycustomoriginupdated.com",
       "TrustedSigners": Object {

--- a/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/lambda-at-edge.test.ts.snap
+++ b/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/lambda-at-edge.test.ts.snap
@@ -70,6 +70,7 @@ Object {
             "MaxTTL": 10,
             "MinTTL": 10,
             "PathPattern": "/some/path",
+            "ResponseHeadersPolicyId": "",
             "SmoothStreaming": false,
             "TargetOriginId": "exampleorigin.com",
             "TrustedSigners": Object {
@@ -125,6 +126,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "exampleorigin.com",
         "TrustedSigners": Object {

--- a/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/origin-with-custom-headers.test.ts.snap
+++ b/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/origin-with-custom-headers.test.ts.snap
@@ -50,6 +50,7 @@ Object {
             "MaxTTL": 10,
             "MinTTL": 10,
             "PathPattern": "/some/path",
+            "ResponseHeadersPolicyId": "",
             "SmoothStreaming": false,
             "TargetOriginId": "exampleorigin.com",
             "TrustedSigners": Object {
@@ -105,6 +106,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "exampleorigin.com",
         "TrustedSigners": Object {

--- a/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/origin-with-custom-origin-config.ts.snap
+++ b/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/origin-with-custom-origin-config.ts.snap
@@ -56,6 +56,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "exampleorigin.com",
         "TrustedSigners": Object {
@@ -153,6 +154,7 @@ Object {
       },
       "MaxTTL": 31536000,
       "MinTTL": 0,
+      "ResponseHeadersPolicyId": "",
       "SmoothStreaming": false,
       "TargetOriginId": "exampleorigin.com",
       "TrustedSigners": Object {

--- a/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/origin-with-path-pattern.test.ts.snap
+++ b/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/origin-with-path-pattern.test.ts.snap
@@ -50,6 +50,7 @@ Object {
             "MaxTTL": 10,
             "MinTTL": 10,
             "PathPattern": "/some/path",
+            "ResponseHeadersPolicyId": "",
             "SmoothStreaming": false,
             "TargetOriginId": "exampleorigin.com",
             "TrustedSigners": Object {
@@ -105,6 +106,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "exampleorigin.com",
         "TrustedSigners": Object {
@@ -196,6 +198,7 @@ Object {
           "MaxTTL": 10,
           "MinTTL": 10,
           "PathPattern": "/some/other/path",
+          "ResponseHeadersPolicyId": "",
           "SmoothStreaming": false,
           "TargetOriginId": "exampleorigin.com",
           "TrustedSigners": Object {
@@ -250,6 +253,7 @@ Object {
       },
       "MaxTTL": 31536000,
       "MinTTL": 0,
+      "ResponseHeadersPolicyId": "",
       "SmoothStreaming": false,
       "TargetOriginId": "exampleorigin.com",
       "TrustedSigners": Object {

--- a/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/s3-origin.test.ts.snap
+++ b/packages/serverless-components/aws-cloudfront/__tests__/__snapshots__/s3-origin.test.ts.snap
@@ -56,6 +56,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "mybucket",
         "TrustedSigners": Object {
@@ -149,6 +150,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "mybucket",
         "TrustedSigners": Object {
@@ -236,6 +238,7 @@ Object {
       },
       "MaxTTL": 31536000,
       "MinTTL": 0,
+      "ResponseHeadersPolicyId": "",
       "SmoothStreaming": false,
       "TargetOriginId": "anotherbucket",
       "TrustedSigners": Object {
@@ -326,6 +329,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "mybucket",
         "TrustedSigners": Object {
@@ -413,6 +417,7 @@ Object {
       },
       "MaxTTL": 31536000,
       "MinTTL": 0,
+      "ResponseHeadersPolicyId": "",
       "SmoothStreaming": false,
       "TargetOriginId": "anotherbucket",
       "TrustedSigners": Object {
@@ -503,6 +508,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "mybucket.with.dots",
         "TrustedSigners": Object {
@@ -590,6 +596,7 @@ Object {
       },
       "MaxTTL": 31536000,
       "MinTTL": 0,
+      "ResponseHeadersPolicyId": "",
       "SmoothStreaming": false,
       "TargetOriginId": "anotherbucket",
       "TrustedSigners": Object {
@@ -680,6 +687,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "mybucket.s3.s3",
         "TrustedSigners": Object {
@@ -767,6 +775,7 @@ Object {
       },
       "MaxTTL": 31536000,
       "MinTTL": 0,
+      "ResponseHeadersPolicyId": "",
       "SmoothStreaming": false,
       "TargetOriginId": "anotherbucket",
       "TrustedSigners": Object {
@@ -857,6 +866,7 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
+        "ResponseHeadersPolicyId": "",
         "SmoothStreaming": false,
         "TargetOriginId": "mybucket",
         "TrustedSigners": Object {
@@ -944,6 +954,7 @@ Object {
       },
       "MaxTTL": 31536000,
       "MinTTL": 0,
+      "ResponseHeadersPolicyId": "",
       "SmoothStreaming": false,
       "TargetOriginId": "anotherbucket",
       "TrustedSigners": Object {

--- a/packages/serverless-components/aws-cloudfront/__tests__/cache-behavior-options.test.ts
+++ b/packages/serverless-components/aws-cloudfront/__tests__/cache-behavior-options.test.ts
@@ -44,7 +44,8 @@ describe("Input origin as a custom url", () => {
         viewerProtocolPolicy: "https-only",
         smoothStreaming: true,
         compress: true,
-        fieldLevelEncryptionId: "123"
+        fieldLevelEncryptionId: "123",
+        responseHeadersPolicyId: "uuid"
       },
       origins: ["https://mycustomorigin.com"]
     });

--- a/packages/serverless-components/aws-cloudfront/src/getCacheBehavior.ts
+++ b/packages/serverless-components/aws-cloudfront/src/getCacheBehavior.ts
@@ -14,6 +14,7 @@ export default (
     smoothStreaming = false,
     viewerProtocolPolicy = "https-only",
     fieldLevelEncryptionId = "",
+    responseHeadersPolicyId = "",
     trustedSigners = {
       Enabled: false,
       Quantity: 0
@@ -43,6 +44,7 @@ export default (
     DefaultTTL: defaultTTL,
     MaxTTL: maxTTL,
     FieldLevelEncryptionId: fieldLevelEncryptionId,
+    ResponseHeadersPolicyId: responseHeadersPolicyId,
     LambdaFunctionAssociations: {
       Quantity: 0,
       Items: []

--- a/packages/serverless-components/aws-cloudfront/src/getDefaultCacheBehavior.ts
+++ b/packages/serverless-components/aws-cloudfront/src/getDefaultCacheBehavior.ts
@@ -11,6 +11,7 @@ type DefaultCacheBehavior = {
   smoothStreaming?: boolean;
   viewerProtocolPolicy?: string;
   fieldLevelEncryptionId?: string;
+  responseHeadersPolicyId?: string;
 };
 
 export default (originId, defaults: DefaultCacheBehavior = {}) => {
@@ -23,7 +24,8 @@ export default (originId, defaults: DefaultCacheBehavior = {}) => {
     compress = false,
     smoothStreaming = false,
     viewerProtocolPolicy = "redirect-to-https",
-    fieldLevelEncryptionId = ""
+    fieldLevelEncryptionId = "",
+    responseHeadersPolicyId = ""
   } = defaults;
 
   const defaultCacheBehavior = {
@@ -52,7 +54,8 @@ export default (originId, defaults: DefaultCacheBehavior = {}) => {
       Quantity: 0,
       Items: []
     },
-    FieldLevelEncryptionId: fieldLevelEncryptionId
+    FieldLevelEncryptionId: fieldLevelEncryptionId,
+    ResponseHeadersPolicyId: responseHeadersPolicyId
   };
 
   addLambdaAtEdgeToCacheBehavior(defaultCacheBehavior, defaults["lambda@edge"]);


### PR DESCRIPTION
I have added the ability to set the ResponseHeadersPolicyId on the Cloudfront behaviours.

I had to update some snapshots to get the tests to pass, though I get failures when Jest gets to the `Running coverage on untested files...` section.

I haven't had a chance to run an end-to-end test with it yet though.