### PR TITLE
Use existing upstream `Cache-Control` if present on upstream response

### DIFF
--- a/packages/libs/core/src/images/imageOptimizer.ts
+++ b/packages/libs/core/src/images/imageOptimizer.ts
@@ -257,6 +257,12 @@ export async function imageOptimizer(
     upstreamBuffer = Buffer.from(await upstreamRes.arrayBuffer());
     upstreamType = upstreamRes.headers.get("Content-Type") ?? undefined;
     maxAge = getMaxAge(upstreamRes.headers.get("Cache-Control") ?? undefined);
+    if (upstreamRes.headers.get("Cache-Control")) {
+      res.setHeader(
+          "Cache-Control",
+          upstreamRes.headers.get("Cache-Control") as string
+      );
+    }
   } else {
     let objectKey;
     try {


### PR DESCRIPTION
Fixes #2272 

Change maintains the upstream `Cache-Control` if present in the upstream response. rather than overiding it with the default.