### PR TITLE
CDK: Allow to whitelist headers

### DIFF
--- a/documentation/docs/cdkconstruct.md
+++ b/documentation/docs/cdkconstruct.md
@@ -92,6 +92,8 @@ new NextJSLambdaEdge(this, "NextJsApp", {
 - `s3Props?: Partial<BucketProps>` - pass custom s3 props
 - `whiteListedCookies?: string[]` - provide a list of cookies to forward to the
   CloudFront origin.
+- `whiteListedHeaders?: string[]` - provide a list of headers to forward to the
+  CloudFront origin.
 - `defaultBehavior?: Partial<cloudfront.Behaviour>` - provide overrides for the
   default behavior
 - `behaviours?: Array<cloudfront.Behaviour>` - an array of Cloudfront

--- a/packages/serverless-components/nextjs-cdk-construct/__tests__/construct.test.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/__tests__/construct.test.ts
@@ -67,6 +67,33 @@ describe("CDK Construct", () => {
     });
   });
 
+  it("lambda cache policy passes correct headers to origin when specified", () => {
+    const stack = new Stack();
+    new NextJSLambdaEdge(stack, "Stack", {
+      serverlessBuildOutDir: path.join(__dirname, "fixtures/app"),
+      whiteListedHeaders: ["my-header"],
+      cachePolicyName: {
+        lambdaCache: "NextLambdaCache"
+      }
+    });
+
+    const synthesizedStack = SynthUtils.toCloudFormation(stack);
+    expect(synthesizedStack).toHaveResourceLike(
+      "AWS::CloudFront::CachePolicy",
+      {
+        CachePolicyConfig: {
+          Name: "NextLambdaCache",
+          ParametersInCacheKeyAndForwardedToOrigin: {
+            HeadersConfig: {
+              HeaderBehavior: "whitelist",
+              Headers: ["my-header"]
+            }
+          }
+        }
+      }
+    );
+  });
+
   it("lambda cache policy passes correct cookies to origin when specified", () => {
     const stack = new Stack();
     new NextJSLambdaEdge(stack, "Stack", {

--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -271,7 +271,11 @@ export class NextJSLambdaEdge extends Construct {
       {
         cachePolicyName: props.cachePolicyName?.lambdaCache,
         queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
-        headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+        headerBehavior: props.whiteListedHeaders
+          ? cloudfront.CacheHeaderBehavior.allowList(
+              ...props.whiteListedHeaders
+            )
+          : cloudfront.CacheHeaderBehavior.none(),
         cookieBehavior: {
           behavior: props.whiteListedCookies?.length ? "whitelist" : "all",
           cookies: props.whiteListedCookies

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -76,6 +76,13 @@ export interface Props extends StackProps {
    * .e.g ['my-apps-auth-token-cookie-key']
    */
   whiteListedCookies?: string[];
+
+  /**
+   * Provide a list of headers to forward to the CloudFront origin.
+   * This is useful if your SSR page is depending on headers from the request.
+   */
+  whiteListedHeaders?: string[];
+
   /**
    * Provide a subset (or all) of the props to override the CloudFront
    * distributions default props.


### PR DESCRIPTION
Hello, first of all thanks for this great library, and thanks for porting it to CDK.

Currently, I'm working on a Cloudfront app that has the domain as `*.mypage.com`

Where `*` is a brand selected by our customers, identifying it has become difficult for a couple of reasons:
- I don't know how to access the original event sent to the lambda (I also don't know how I can implement this one) so I went to the 2nd option which is reading the `Host` header.
- When reading the `Host` header on SSR, it works quite well, except when the request is to `_next/data`, in that case, the `Host` header is from CloudFront because it's not being forwarded, this PR adds the ability to forward headers.

I've tried to keep it up with what was needed, it was being tested by my end and I added a unit test, please let me know if I'm missing something, also, if you have some clues on how to read the original event on nextjs `getServerSideProps`. I would love to implement that on another PR.

Again, thank you!

