### PR TITLE
getter function for http base class in api handler

### DIFF
--- a/packages/libs/core/src/handle/api.ts
+++ b/packages/libs/core/src/handle/api.ts
@@ -41,6 +41,16 @@ export const handleApi = async (
   if (route.isApi) {
     const { page } = route as ApiRoute;
     setCustomHeaders(event, routesManifest);
+    if (!event.req.hasOwnProperty("originalRequest")) {
+      Object.defineProperty(event.req, "originalRequest", {
+        get: () => event.req
+      });
+    }
+    if (!event.res.hasOwnProperty("originalResponse")) {
+      Object.defineProperty(event.res, "originalResponse", {
+        get: () => event.res
+      });
+    }
     getPage(page).default(event.req, event.res);
     return;
   }

--- a/packages/libs/core/tests/handle/api.test.ts
+++ b/packages/libs/core/tests/handle/api.test.ts
@@ -118,16 +118,41 @@ describe("Api handler", () => {
       ${"/rewrite/2"}       | ${"pages/api/dynamic/[id].js"}
       ${"/rewrite-query/3"} | ${"pages/api/static.js"}
     `("Routes api request $uri to page $page", async ({ uri, page }) => {
-      const route = await handleApi(
-        mockEvent(uri),
-        manifest,
-        routesManifest,
-        getPage
-      );
+      const event = mockEvent(uri);
+      const route = await handleApi(event, manifest, routesManifest, getPage);
 
       expect(route).toBeFalsy();
       expect(getPage).toHaveBeenCalledWith(page);
+      expect((event.req as any).originalRequest).toBe(event.req);
+      expect((event.res as any).originalResponse).toBe(event.res);
     });
+
+    it.each`
+      uri                   | page
+      ${"/api"}             | ${"pages/api/index.js"}
+      ${"/api/static"}      | ${"pages/api/static.js"}
+      ${"/api/dynamic/1"}   | ${"pages/api/dynamic/[id].js"}
+      ${"/rewrite"}         | ${"pages/api/static.js"}
+      ${"/rewrite/2"}       | ${"pages/api/dynamic/[id].js"}
+      ${"/rewrite-query/3"} | ${"pages/api/static.js"}
+    `(
+      "Routes api request $uri to page $page with NodeNextRequest & NodeNextResponse",
+      async ({ uri, page }) => {
+        const event: any = mockEvent(uri);
+        event.req["originalRequest"] = {};
+        event.res["originalResponse"] = {};
+        const route = await handleApi(event, manifest, routesManifest, getPage);
+
+        expect(route).toBeFalsy();
+        expect(getPage).toHaveBeenCalledWith(page);
+        expect((event.req as any).originalRequest).toBe(
+          (event.req as any).originalRequest
+        );
+        expect((event.res as any).originalResponse).toBe(
+          (event.res as any).originalResponse
+        );
+      }
+    );
 
     it.each`
       uri

--- a/packages/libs/core/tests/handle/api.test.ts
+++ b/packages/libs/core/tests/handle/api.test.ts
@@ -139,8 +139,8 @@ describe("Api handler", () => {
       "Routes api request $uri to page $page with NodeNextRequest & NodeNextResponse",
       async ({ uri, page }) => {
         const event: any = mockEvent(uri);
-        event.req["originalRequest"] = {};
-        event.res["originalResponse"] = {};
+        event.req.originalRequest = {};
+        event.res.originalResponse = {};
         const route = await handleApi(event, manifest, routesManifest, getPage);
 
         expect(route).toBeFalsy();


### PR DESCRIPTION
this fixies #2327.

This bug is caused by [next.js PR #32999](https://github.com/vercel/next.js/pull/32999/files#diff-527588a4dadf6d2d9111766e571eec95cd658fea219da01bb7f259a6c0a70d6aR17-R25) (included in next v12.0.9).
I implemented the getter function of event.req & event.res.

Or should I update next.js v11.1.2 to v12 in packages/libs/core/package.json?