### PR TITLE
feat(nextjs-cdk-construct): Allow cache policies to be provided as props

### DIFF
--- a/documentation/docs/cdkconstruct.md
+++ b/documentation/docs/cdkconstruct.md
@@ -101,3 +101,6 @@ new NextJSLambdaEdge(this, "NextJsApp", {
 - `invalidationPaths?: string[]` - an array of invalidation paths, by default we
   invalidate all pages found in manifest
 - `cachePolicyName?: Object`: configure the name given to the cache policies
+- `nextStaticsCachePolicy?: CachePolicy;`: configure the CloudFront cache policy used for static resources
+- `nextImageCachePolicy?: CachePolicy;`: configure the CloudFront cache policy used for image caching
+- `nextLambdaCachePolicy?: CachePolicy;`: configure the CloudFront cache policy used for Lambda functions

--- a/packages/serverless-components/nextjs-cdk-construct/__tests__/construct.test.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/__tests__/construct.test.ts
@@ -6,7 +6,7 @@ import { NextJSLambdaEdge } from "../src";
 import { Runtime, Function, Code } from "aws-cdk-lib/aws-lambda";
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import { HostedZone } from "aws-cdk-lib/aws-route53";
-import { LambdaEdgeEventType } from "aws-cdk-lib/aws-cloudfront";
+import { LambdaEdgeEventType, CachePolicy } from "aws-cdk-lib/aws-cloudfront";
 
 describe("CDK Construct", () => {
   it("passes correct lambda options to underlying lambdas when single value passed", () => {
@@ -141,6 +141,66 @@ describe("CDK Construct", () => {
               CookieBehavior: "all"
             }
           }
+        }
+      }
+    );
+  });
+
+  it("statics cache policy uses passed in policy if provided", () => {
+    const stack = new Stack();
+    new NextJSLambdaEdge(stack, "Stack", {
+      serverlessBuildOutDir: path.join(__dirname, "fixtures/app"),
+      nextStaticsCachePolicy: new CachePolicy(stack, "NextStaticsCache", {
+        cachePolicyName: "customNextStaticsCache"
+      })
+    });
+
+    const synthesizedStack = SynthUtils.toCloudFormation(stack);
+    expect(synthesizedStack).toHaveResourceLike(
+      "AWS::CloudFront::CachePolicy",
+      {
+        CachePolicyConfig: {
+          Name: "customNextStaticsCache"
+        }
+      }
+    );
+  });
+
+  it("image cache policy uses passed in policy if provided", () => {
+    const stack = new Stack();
+    new NextJSLambdaEdge(stack, "Stack", {
+      serverlessBuildOutDir: path.join(__dirname, "fixtures/app"),
+      nextImageCachePolicy: new CachePolicy(stack, "NextImageCache", {
+        cachePolicyName: "customNextImageCache"
+      })
+    });
+
+    const synthesizedStack = SynthUtils.toCloudFormation(stack);
+    expect(synthesizedStack).toHaveResourceLike(
+      "AWS::CloudFront::CachePolicy",
+      {
+        CachePolicyConfig: {
+          Name: "customNextImageCache"
+        }
+      }
+    );
+  });
+
+  it("lambda cache policy uses passed in policy if provided", () => {
+    const stack = new Stack();
+    new NextJSLambdaEdge(stack, "Stack", {
+      serverlessBuildOutDir: path.join(__dirname, "fixtures/app"),
+      nextLambdaCachePolicy: new CachePolicy(stack, "NextLambdaCache", {
+        cachePolicyName: "customNextLambdaCache"
+      })
+    });
+
+    const synthesizedStack = SynthUtils.toCloudFormation(stack);
+    expect(synthesizedStack).toHaveResourceLike(
+      "AWS::CloudFront::CachePolicy",
+      {
+        CachePolicyConfig: {
+          Name: "customNextLambdaCache"
         }
       }
     );

--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -233,10 +233,9 @@ export class NextJSLambdaEdge extends Construct {
       this.nextImageLambda.currentVersion.addAlias("live");
     }
 
-    this.nextStaticsCachePolicy = new cloudfront.CachePolicy(
-      this,
-      "NextStaticsCache",
-      {
+    this.nextStaticsCachePolicy =
+      props.nextStaticsCachePolicy ||
+      new cloudfront.CachePolicy(this, "NextStaticsCache", {
         cachePolicyName: props.cachePolicyName?.staticsCache,
         queryStringBehavior: cloudfront.CacheQueryStringBehavior.none(),
         headerBehavior: cloudfront.CacheHeaderBehavior.none(),
@@ -249,10 +248,9 @@ export class NextJSLambdaEdge extends Construct {
       }
     );
 
-    this.nextImageCachePolicy = new cloudfront.CachePolicy(
-      this,
-      "NextImageCache",
-      {
+    this.nextImageCachePolicy =
+      props.nextImageCachePolicy ||
+      new cloudfront.CachePolicy(this, "NextImageCache", {
         cachePolicyName: props.cachePolicyName?.imageCache,
         queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
         headerBehavior: cloudfront.CacheHeaderBehavior.allowList("Accept"),
@@ -265,10 +263,9 @@ export class NextJSLambdaEdge extends Construct {
       }
     );
 
-    this.nextLambdaCachePolicy = new cloudfront.CachePolicy(
-      this,
-      "NextLambdaCache",
-      {
+    this.nextLambdaCachePolicy =
+      props.nextLambdaCachePolicy ||
+      new cloudfront.CachePolicy(this, "NextLambdaCache", {
         cachePolicyName: props.cachePolicyName?.lambdaCache,
         queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
         headerBehavior: props.whiteListedHeaders

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -1,5 +1,5 @@
 import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
-import { BehaviorOptions, DistributionProps } from "aws-cdk-lib/aws-cloudfront";
+import { BehaviorOptions, DistributionProps, CachePolicy } from "aws-cdk-lib/aws-cloudfront";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { IHostedZone } from "aws-cdk-lib/aws-route53";
 import { BucketProps } from "aws-cdk-lib/aws-s3";
@@ -108,4 +108,20 @@ export interface Props extends StackProps {
    * Override props passed to the underlying s3 bucket
    */
   cloudfrontProps?: Partial<DistributionProps>;
+
+  /**
+   * Override cache policy used for statics
+   */
+  nextStaticsCachePolicy?: CachePolicy;
+
+  /**
+   * Override cache policy used for image caching
+   */
+
+  nextImageCachePolicy?: CachePolicy;
+
+  /**
+   * Override cache policy used for Lambda
+   */
+  nextLambdaCachePolicy?: CachePolicy;
 }


### PR DESCRIPTION
Our company has started to extensively use the CDK construct for next.js and it's been working great so far 🎉

However, since each app builds its own 3 unique cache policies, we have started to run into a limitation. AWS only allows you to have 20 cache policies per account. See `Cache policies per AWS account` in AWS docs here:
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html#limits-policies

Since all the next apps have the same 3 cache policies duplicated, we created 3 universal ones to share across all our apps. Then, we will simply import the shared 3 policies into our next apps.

EX:
```
nextStaticsCachePolicy: CachePolicy.fromCachePolicyId(
      scope,
      'NextImageCache',
      'unique-cache-policy-id-here'
    )
```

This PR allows you to pass those policies into the construct so it will not make another 3 unique ones so you should be able to have as many next.js apps as you want in one account using this method!