### PR TITLE
add getter to event req & res object in default handler.

### DIFF
--- a/packages/libs/core/src/handle/default.ts
+++ b/packages/libs/core/src/handle/default.ts
@@ -118,6 +118,16 @@ export const handleDefault = async (
   if (route.isApi) {
     const { page } = route as ApiRoute;
     setCustomHeaders(event, routesManifest);
+    if (!event.req.hasOwnProperty("originalRequest")) {
+      Object.defineProperty(event.req, "originalRequest", {
+        get: () => event.req
+      });
+    }
+    if (!event.res.hasOwnProperty("originalResponse")) {
+      Object.defineProperty(event.res, "originalResponse", {
+        get: () => event.res
+      });
+    }
     getPage(page).default(event.req, event.res);
     return;
   }


### PR DESCRIPTION
This fixies #2327.

The reason for this bug is the same as for #2344.
When `useV2Handler: true` set in `serverless.yml`, this problem was not solved.

I Implemented getter function in default handler.
