### PR TITLE
Fix: wrong replace causing "on" files on S3

### DIFF
--- a/packages/libs/lambda-at-edge/src/regeneration-handler.ts
+++ b/packages/libs/lambda-at-edge/src/regeneration-handler.ts
@@ -31,7 +31,7 @@ export const handler = async (event: AWSLambda.SQSEvent): Promise<void> => {
 
       const normalizedUri = decodeURI(regenerationEvent.pageS3Path)
         .replace(`static-pages/${manifest.buildId}`, "")
-        .replace(".js", "");
+        .replace(/.js$/, "");
 
       await s3StorePage({
         html,


### PR DESCRIPTION
Fix the regex to only replace `.js` at the end of the string

Fixes #2349