### PR TITLE
fix redirect in getStaticProps

### DIFF
--- a/packages/libs/core/src/handle/redirect.ts
+++ b/packages/libs/core/src/handle/redirect.ts
@@ -8,20 +8,20 @@ export const redirect = (event: Event, route: RedirectRoute) => {
   event.res.end();
 };
 
-export const redirectSsg = (event: Event, route: RedirectRoute) => {
+export const redirectByPageProps = (event: Event, route: RedirectRoute) => {
   event.res.setHeader(
     "cache-control",
     route.headers?.cacheControl?.join(":") ?? ""
   );
   event.res.statusCode = 200;
-  event.res.write(
-    JSON.stringify({
-      pageProps: {
-        __N_REDIRECT: route.headers?.location[0].value ?? "",
-        __N_REDIRECT_STATUS: route.status
-      },
-      __N_SSG: true
-    })
-  );
+
+  const body = {
+    pageProps: {
+      __N_REDIRECT: route.headers?.location[0].value ?? "",
+      __N_REDIRECT_STATUS: route.status
+    },
+    __N_SSG: true
+  };
+  event.res.write(JSON.stringify(body));
   event.res.end();
 };

--- a/packages/libs/core/src/handle/redirect.ts
+++ b/packages/libs/core/src/handle/redirect.ts
@@ -7,3 +7,21 @@ export const redirect = (event: Event, route: RedirectRoute) => {
   event.res.statusMessage = route.statusDescription;
   event.res.end();
 };
+
+export const redirectSsg = (event: Event, route: RedirectRoute) => {
+  event.res.setHeader(
+    "cache-control",
+    route.headers?.cacheControl?.join(":") ?? ""
+  );
+  event.res.statusCode = 200;
+  event.res.write(
+    JSON.stringify({
+      pageProps: {
+        __N_REDIRECT: route.headers?.location[0].value ?? "",
+        __N_REDIRECT_STATUS: route.status
+      },
+      __N_SSG: true
+    })
+  );
+  event.res.end();
+};

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -51,7 +51,7 @@ import { s3BucketNameFromEventRequest } from "./s3/s3BucketNameFromEventRequest"
 import { triggerStaticRegeneration } from "./lib/triggerStaticRegeneration";
 import { s3StorePage } from "./s3/s3StorePage";
 import { createRedirectResponse } from "@sls-next/core/dist/module/route/redirect";
-import { redirectSsg } from "@sls-next/core/dist/module/handle/redirect";
+import { redirectByPageProps } from "@sls-next/core/dist/module/handle/redirect";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import getStream from "get-stream";
 
@@ -492,7 +492,7 @@ const handleOriginResponse = async ({
       statusCode
     );
 
-    redirectSsg({ req, res, responsePromise }, redirectResponse);
+    redirectByPageProps({ req, res, responsePromise }, redirectResponse);
 
     return await responsePromise;
   }

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -51,7 +51,7 @@ import { s3BucketNameFromEventRequest } from "./s3/s3BucketNameFromEventRequest"
 import { triggerStaticRegeneration } from "./lib/triggerStaticRegeneration";
 import { s3StorePage } from "./s3/s3StorePage";
 import { createRedirectResponse } from "@sls-next/core/dist/module/route/redirect";
-import { redirect } from "@sls-next/core/dist/module/handle/redirect";
+import { redirectSsg } from "@sls-next/core/dist/module/handle/redirect";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import getStream from "get-stream";
 
@@ -492,7 +492,7 @@ const handleOriginResponse = async ({
       statusCode
     );
 
-    redirect({ req, res, responsePromise }, redirectResponse);
+    redirectSsg({ req, res, responsePromise }, redirectResponse);
 
     return await responsePromise;
   }


### PR DESCRIPTION
This fixes #2346.

Added redirect to getStaticProps as shown in the code below.

```tsx
import type { NextPage, GetStaticProps } from "next";
import { useRouter } from "next/router";

export const getStaticProps: GetStaticProps = async () => {
  const data = await fetch("https://github.com/serverless-nextjs/serverless-next.js").then((res) =>
    res.text()
  );

  if (data.length > 0) {
    return {
      redirect: {
        permanent: false,
        destination: "/bar",
      },
    };
  }

  return {
    props: {},
  };
};

export async function getStaticPaths() {
  return {
    paths: [],
    fallback: true,
  };
}

const Foo: NextPage = () => {
  const router = useRouter();
  const { id } = router.query;

  return <p>Post: {id}</p>;
};

export default Foo;

```

And I deployed it to vercel, and the following response was returned.
```
Request URL: https://xxx.vercel.app/_next/data/xxx/foo/1.json
Request Method: GET
Status Code: 200 OK
{
  "pageProps": {
    "__N_REDIRECT": "/bar",
    "__N_REDIRECT_STATUS": 307
  },
  "__N_SSG": true
}
```

Therefore, I stopped returning 307 and return 200 & json body.