### PR TITLE
Allow to set custom handler

### DIFF
--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -151,7 +151,7 @@ export class NextJSLambdaEdge extends Construct {
     this.defaultNextLambda = new lambda.Function(this, "NextLambda", {
       functionName: toLambdaOption("defaultLambda", props.name),
       description: `Default Lambda@Edge for Next CloudFront distribution`,
-      handler: "index.handler",
+      handler: props.handler || "index.handler",
       currentVersionOptions: {
         removalPolicy: RemovalPolicy.DESTROY // destroy old versions
       },

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -64,6 +64,11 @@ export interface Props extends StackProps {
     lambdaCache?: string;
   };
   /**
+   * If you use a custom handler with `.build()`, you can set the handler here.
+   */
+  handler?: string;
+
+  /**
    * Enable logging on the cloudfront distribution
    */
   withLogging?: boolean;


### PR DESCRIPTION
When using `Builder` from `@sls-next/lambda-at-edge` there's a really useful functionality to add an extra handler (in case you want to call `callbackWaitsForEmptyEventLoop = false`, set any tracer or establish a DB connection, really useful!).

But unfortunately it's kinda useless on CDK because the default handler is stuck at `index.handler`, this PR solves that, so you can do the following:

```ts
export function MyStack(scope: Construct, id: string, props?: cdk.StackProps) {
  /** other things */

  new NextJSLambdaEdge(stack, `${id}-next`, {
    memory: 1536,
    runtime: Runtime.NODEJS_14_X,
    handler: 'handler.handler' // <------ We could replace the default handler and make use of the one we provided to "build"
  })
}

const builder = new Builder('.', './build', {
  args: ['build'], 
  handler: 'handler.js', // <------ We told builder we want this handler, but we should tell the lambda too ☝🏻
})

builder
  .build()
  .then(() => {
    const app = new cdk.App()
    MyStack(app, `example-stack`)
  })
  .catch((e) => {
    console.log(e)
    process.exit(1)
  })

```