### PR TITLE
fix: Change defaultNextLambda removalPolicy from DESTROY to RETAIN

### DIFF
--- a/packages/serverless-components/nextjs-cdk-construct/__tests__/__snapshots__/snapshots.test.ts.snap
+++ b/packages/serverless-components/nextjs-cdk-construct/__tests__/__snapshots__/snapshots.test.ts.snap
@@ -1250,14 +1250,14 @@ Object {
       "Type": "AWS::CloudFront::CachePolicy",
     },
     "StackNextLambdaCurrentVersion21F01F879970bafa5c9141f6152d4057c3ab8184": Object {
-      "DeletionPolicy": "Delete",
+      "DeletionPolicy": "Retain",
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "StackNextLambdaF64DCE99",
         },
       },
       "Type": "AWS::Lambda::Version",
-      "UpdateReplacePolicy": "Delete",
+      "UpdateReplacePolicy": "Retain",
     },
     "StackNextLambdaCurrentVersionAliasliveB07D2AA0": Object {
       "Properties": Object {
@@ -2999,14 +2999,14 @@ Object {
       "Type": "AWS::CloudFront::CachePolicy",
     },
     "StackNextLambdaCurrentVersion21F01F87b5875487743b0e6b4f7058e417862406": Object {
-      "DeletionPolicy": "Delete",
+      "DeletionPolicy": "Retain",
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "StackNextLambdaF64DCE99",
         },
       },
       "Type": "AWS::Lambda::Version",
-      "UpdateReplacePolicy": "Delete",
+      "UpdateReplacePolicy": "Retain",
     },
     "StackNextLambdaCurrentVersionAliasliveB07D2AA0": Object {
       "Properties": Object {

--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -153,7 +153,7 @@ export class NextJSLambdaEdge extends Construct {
       description: `Default Lambda@Edge for Next CloudFront distribution`,
       handler: "index.handler",
       currentVersionOptions: {
-        removalPolicy: RemovalPolicy.DESTROY // destroy old versions
+        removalPolicy: RemovalPolicy.RETAIN // retain old versions to prevent premature removal, cleanup via trigger later on
       },
       logRetention: logs.RetentionDays.THREE_DAYS,
       code: lambda.Code.fromAsset(


### PR DESCRIPTION
#### Issues:
As per [this issue](https://github.com/serverless-nextjs/serverless-next.js/issues/2400), there are times during builds where the old `defaultNextLambda` gets destroyed before the build has completed and incoming traffic is served a 503 error for pages that have not yet finished static generation. 

#### Solution:
Change the `removalPolicy` of `DESTROY` on the `defaultNextLambda` to `RETAIN`, and in a separate PR, trigger a function to clean up old Lambda's after a build has completed successfully.