### PR TITLE
CDK: Use same s3 origin across behaviors

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -1,0 +1,34 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: cd packages/serverless-components/nextjs-cdk-construct
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/junit.xml
+++ b/junit.xml
@@ -1,0 +1,2518 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="jest tests" tests="788" failures="2" errors="0" time="82.417">
+  <testsuite name="Serverless Trace" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:38:59" time="5.41" tests="3">
+    <testcase classname="Serverless Trace copies api page dependencies to api lambda artefact" name="Serverless Trace copies api page dependencies to api lambda artefact" time="0.074">
+    </testcase>
+    <testcase classname="Serverless Trace copies ssr page dependencies to lambda artefact" name="Serverless Trace copies ssr page dependencies to lambda artefact" time="0.033">
+    </testcase>
+    <testcase classname="Serverless Trace does not copy any .next/ files into lambda artefact" name="Serverless Trace does not copy any .next/ files into lambda artefact" time="0.029">
+    </testcase>
+  </testsuite>
+  <testsuite name="next-aws-lambda" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:04" time="0.15" tests="3">
+    <testcase classname="next-aws-lambda passes request and response to next page" name="next-aws-lambda passes request and response to next page" time="0.002">
+    </testcase>
+    <testcase classname="next-aws-lambda passes request and response to next api" name="next-aws-lambda passes request and response to next api" time="0">
+    </testcase>
+    <testcase classname="next-aws-lambda supports async signature" name="next-aws-lambda supports async signature" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="compatLayer.request" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:04" time="0.092" tests="20">
+    <testcase classname="compatLayer.request request url path" name="compatLayer.request request url path" time="0.002">
+    </testcase>
+    <testcase classname="compatLayer.request request url path fallback" name="compatLayer.request request url path fallback" time="0">
+    </testcase>
+    <testcase classname="compatLayer.request request url path with stage removed" name="compatLayer.request request url path with stage removed" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request request url path just stage name no trailing slash" name="compatLayer.request request url path just stage name no trailing slash" time="0">
+    </testcase>
+    <testcase classname="compatLayer.request querystring /?x=42" name="compatLayer.request querystring /?x=42" time="0.002">
+    </testcase>
+    <testcase classname="compatLayer.request querystring /?x=åäö" name="compatLayer.request querystring /?x=åäö" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request querystring /?x=õ" name="compatLayer.request querystring /?x=õ" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request querystring with multiple values for same name /?x=1&amp;x=2" name="compatLayer.request querystring with multiple values for same name /?x=1&amp;x=2" time="0">
+    </testcase>
+    <testcase classname="compatLayer.request complicated querystring" name="compatLayer.request complicated querystring" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request event pathParameters { foo: &quot;bar&quot;, bar: &quot;baz&quot; }" name="compatLayer.request event pathParameters { foo: &quot;bar&quot;, bar: &quot;baz&quot; }" time="0">
+    </testcase>
+    <testcase classname="compatLayer.request event pathParameters and queryString" name="compatLayer.request event pathParameters and queryString" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request request method" name="compatLayer.request request method" time="0">
+    </testcase>
+    <testcase classname="compatLayer.request request headers" name="compatLayer.request request headers" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request request headers with same name" name="compatLayer.request request headers with same name" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request text body" name="compatLayer.request text body" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request text base64 body" name="compatLayer.request text base64 body" time="0">
+    </testcase>
+    <testcase classname="compatLayer.request text body with encoding" name="compatLayer.request text body with encoding" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request connection" name="compatLayer.request connection" time="0">
+    </testcase>
+    <testcase classname="compatLayer.request request preserve http.IncomingMessage.prototype property" name="compatLayer.request request preserve http.IncomingMessage.prototype property" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.request request preserve http.IncomingMessage.prototype function" name="compatLayer.request request preserve http.IncomingMessage.prototype function" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="compatLayer.response" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:05" time="0.107" tests="25">
+    <testcase classname="compatLayer.response statusCode writeHead 404" name="compatLayer.response statusCode writeHead 404" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] statusCode writeHead 404" name="compatLayer.response [Promise] statusCode writeHead 404" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response statusCode statusCode=200" name="compatLayer.response statusCode statusCode=200" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] statusCode statusCode=200 by default" name="compatLayer.response [Promise] statusCode statusCode=200 by default" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] statusCode statusCode=200" name="compatLayer.response [Promise] statusCode statusCode=200" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response writeHead headers" name="compatLayer.response writeHead headers" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] writeHead headers" name="compatLayer.response [Promise] writeHead headers" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response setHeader" name="compatLayer.response setHeader" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] setHeader" name="compatLayer.response [Promise] setHeader" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response multi header support for api gateway" name="compatLayer.response multi header support for api gateway" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] multi header support for api gateway" name="compatLayer.response [Promise] multi header support for api gateway" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response setHeader + removeHeader" name="compatLayer.response setHeader + removeHeader" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] setHeader + removeHeader" name="compatLayer.response [Promise] setHeader + removeHeader" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response getHeader/s" name="compatLayer.response getHeader/s" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response hasHeader" name="compatLayer.response hasHeader" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response case insensitive headers" name="compatLayer.response case insensitive headers" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response res.write(&apos;ok&apos;)" name="compatLayer.response res.write(&apos;ok&apos;)" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] res.write(&apos;ok&apos;)" name="compatLayer.response [Promise] res.write(&apos;ok&apos;)" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response res.end(&apos;ok&apos;)" name="compatLayer.response res.end(&apos;ok&apos;)" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] res.end(&apos;ok&apos;)" name="compatLayer.response [Promise] res.end(&apos;ok&apos;)" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response req.pipe(res)" name="compatLayer.response req.pipe(res)" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] req.pipe(res)" name="compatLayer.response [Promise] req.pipe(res)" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response base64 support" name="compatLayer.response base64 support" time="0">
+    </testcase>
+    <testcase classname="compatLayer.response [Promise] base64 support" name="compatLayer.response [Promise] base64 support" time="0.001">
+    </testcase>
+    <testcase classname="compatLayer.response response does not have a body if only statusCode is set" name="compatLayer.response response does not have a body if only statusCode is set" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="Request Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:05" time="0.158" tests="11">
+    <testcase classname="Request Tests request url path" name="Request Tests request url path" time="0.001">
+    </testcase>
+    <testcase classname="Request Tests querystring /?x=42" name="Request Tests querystring /?x=42" time="0">
+    </testcase>
+    <testcase classname="Request Tests request method" name="Request Tests request method" time="0.001">
+    </testcase>
+    <testcase classname="Request Tests request headers" name="Request Tests request headers" time="0.001">
+    </testcase>
+    <testcase classname="Request Tests duplicates of special request headers are discarded" name="Request Tests duplicates of special request headers are discarded" time="0.009">
+    </testcase>
+    <testcase classname="Request Tests text body" name="Request Tests text body" time="0.001">
+    </testcase>
+    <testcase classname="Request Tests text base64 body" name="Request Tests text base64 body" time="0.001">
+    </testcase>
+    <testcase classname="Request Tests text body with encoding" name="Request Tests text body with encoding" time="0">
+    </testcase>
+    <testcase classname="Request Tests connection" name="Request Tests connection" time="0">
+    </testcase>
+    <testcase classname="Request Tests request preserve http.IncomingMessage.prototype property" name="Request Tests request preserve http.IncomingMessage.prototype property" time="0">
+    </testcase>
+    <testcase classname="Request Tests request preserve http.IncomingMessage.prototype function" name="Request Tests request preserve http.IncomingMessage.prototype function" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="Response Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:05" time="0.095" tests="21">
+    <testcase classname="Response Tests statusCode writeHead 404" name="Response Tests statusCode writeHead 404" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests statusCode statusCode=200" name="Response Tests statusCode statusCode=200" time="0">
+    </testcase>
+    <testcase classname="Response Tests statusCode statusCode=200 by default" name="Response Tests statusCode statusCode=200 by default" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests writeHead headers" name="Response Tests writeHead headers" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests writeHead ignores special CloudFront Headers" name="Response Tests writeHead ignores special CloudFront Headers" time="0">
+    </testcase>
+    <testcase classname="Response Tests writeHead preserves existing Headers" name="Response Tests writeHead preserves existing Headers" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests writeHead does not overwrite special CloudFront Headers" name="Response Tests writeHead does not overwrite special CloudFront Headers" time="0">
+    </testcase>
+    <testcase classname="Response Tests writeHead can be chained" name="Response Tests writeHead can be chained" time="0">
+    </testcase>
+    <testcase classname="Response Tests setHeader (multiple headers with same name)" name="Response Tests setHeader (multiple headers with same name)" time="0">
+    </testcase>
+    <testcase classname="Response Tests setHeader" name="Response Tests setHeader" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests setHeader ignores special CloudFront headers" name="Response Tests setHeader ignores special CloudFront headers" time="0">
+    </testcase>
+    <testcase classname="Response Tests setHeader + removeHeader" name="Response Tests setHeader + removeHeader" time="0">
+    </testcase>
+    <testcase classname="Response Tests getHeader/s" name="Response Tests getHeader/s" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests hasHeader" name="Response Tests hasHeader" time="0">
+    </testcase>
+    <testcase classname="Response Tests case insensitive headers" name="Response Tests case insensitive headers" time="0">
+    </testcase>
+    <testcase classname="Response Tests res.write(&apos;ok&apos;)" name="Response Tests res.write(&apos;ok&apos;)" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests res.end(&apos;ok&apos;)" name="Response Tests res.end(&apos;ok&apos;)" time="0">
+    </testcase>
+    <testcase classname="Response Tests res.end() ignores any calls after the first one" name="Response Tests res.end() ignores any calls after the first one" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests does not gzip by default" name="Response Tests does not gzip by default" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests gzips when compression is enabled" name="Response Tests gzips when compression is enabled" time="0.001">
+    </testcase>
+    <testcase classname="Response Tests response does not have a body if only statusCode is set" name="Response Tests response does not have a body if only statusCode is set" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Cache invalidation tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:05" time="0.121" tests="3">
+    <testcase classname="Cache invalidation tests passes credentials to CloudFront client" name="Cache invalidation tests passes credentials to CloudFront client" time="0.001">
+    </testcase>
+    <testcase classname="Cache invalidation tests invalidates CloudFront distribution" name="Cache invalidation tests invalidates CloudFront distribution" time="0.001">
+    </testcase>
+    <testcase classname="Cache invalidation tests invalidates specified paths" name="Cache invalidation tests invalidates specified paths" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="Check CloudFront distribution ready tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:05" time="1.062" tests="3">
+    <testcase classname="Check CloudFront distribution ready tests passes credentials to CloudFront client" name="Check CloudFront distribution ready tests passes credentials to CloudFront client" time="0.001">
+    </testcase>
+    <testcase classname="Check CloudFront distribution ready tests successfully waits for CloudFront distribution" name="Check CloudFront distribution ready tests successfully waits for CloudFront distribution" time="0">
+    </testcase>
+    <testcase classname="Check CloudFront distribution ready tests times out waiting for CloudFront distribution" name="Check CloudFront distribution ready tests times out waiting for CloudFront distribution" time="1.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Api handler" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:06" time="0.131" tests="23">
+    <testcase classname="Api handler Api pages Routes api request /api to page pages/api/index.js" name="Api handler Api pages Routes api request /api to page pages/api/index.js" time="0.002">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /api/static to page pages/api/static.js" name="Api handler Api pages Routes api request /api/static to page pages/api/static.js" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /api/dynamic/1 to page pages/api/dynamic/[id].js" name="Api handler Api pages Routes api request /api/dynamic/1 to page pages/api/dynamic/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /rewrite to page pages/api/static.js" name="Api handler Api pages Routes api request /rewrite to page pages/api/static.js" time="0.002">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /rewrite/2 to page pages/api/dynamic/[id].js" name="Api handler Api pages Routes api request /rewrite/2 to page pages/api/dynamic/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /rewrite-query/3 to page pages/api/static.js" name="Api handler Api pages Routes api request /rewrite-query/3 to page pages/api/static.js" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /api to page pages/api/index.js with NodeNextRequest &amp; NodeNextResponse" name="Api handler Api pages Routes api request /api to page pages/api/index.js with NodeNextRequest &amp; NodeNextResponse" time="0.002">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /api/static to page pages/api/static.js with NodeNextRequest &amp; NodeNextResponse" name="Api handler Api pages Routes api request /api/static to page pages/api/static.js with NodeNextRequest &amp; NodeNextResponse" time="0">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /api/dynamic/1 to page pages/api/dynamic/[id].js with NodeNextRequest &amp; NodeNextResponse" name="Api handler Api pages Routes api request /api/dynamic/1 to page pages/api/dynamic/[id].js with NodeNextRequest &amp; NodeNextResponse" time="0">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /rewrite to page pages/api/static.js with NodeNextRequest &amp; NodeNextResponse" name="Api handler Api pages Routes api request /rewrite to page pages/api/static.js with NodeNextRequest &amp; NodeNextResponse" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /rewrite/2 to page pages/api/dynamic/[id].js with NodeNextRequest &amp; NodeNextResponse" name="Api handler Api pages Routes api request /rewrite/2 to page pages/api/dynamic/[id].js with NodeNextRequest &amp; NodeNextResponse" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Api pages Routes api request /rewrite-query/3 to page pages/api/static.js with NodeNextRequest &amp; NodeNextResponse" name="Api handler Api pages Routes api request /rewrite-query/3 to page pages/api/static.js with NodeNextRequest &amp; NodeNextResponse" time="0">
+    </testcase>
+    <testcase classname="Api handler Api pages Returns 404 for /api/notfound" name="Api handler Api pages Returns 404 for /api/notfound" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Api pages Returns 404 for /api/dynamic/not/found" name="Api handler Api pages Returns 404 for /api/dynamic/not/found" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Api pages Returns 404 for /rewrite-not-found" name="Api handler Api pages Returns 404 for /rewrite-not-found" time="0">
+    </testcase>
+    <testcase classname="Api handler Headers Sets headers for /api/static" name="Api handler Headers Sets headers for /api/static" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Redirects Redirects /api/redirect-simple to /api/static with code 307" name="Api handler Redirects Redirects /api/redirect-simple to /api/static with code 307" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Redirects Redirects /redirect/test to /api/dynamic/test with code 308" name="Api handler Redirects Redirects /redirect/test to /api/dynamic/test with code 308" time="0.003">
+    </testcase>
+    <testcase classname="Api handler Redirects Redirects /api/redirect-query?key=val to /api/static?key=val&amp;foo=bar with code 307" name="Api handler Redirects Redirects /api/redirect-query?key=val to /api/static?key=val&amp;foo=bar with code 307" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Redirects Redirects www.example.com/api to https://example.com/api with code 308" name="Api handler Redirects Redirects www.example.com/api to https://example.com/api with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Api handler Redirects Redirects www.example.com/api/static to https://example.com/api/static with code 308" name="Api handler Redirects Redirects www.example.com/api/static to https://example.com/api/static with code 308" time="0">
+    </testcase>
+    <testcase classname="Api handler Redirects Redirects www.example.com/api?query to https://example.com/api?query with code 308" name="Api handler Redirects Redirects www.example.com/api?query to https://example.com/api?query with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Api handler External rewrite Returns external rewrite from /rewrite-external to https://ext.example.com" name="Api handler External rewrite Returns external rewrite from /rewrite-external to https://ext.example.com" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Basic authentication" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:06" time="0.086" tests="6">
+    <testcase classname="Basic authentication Api handler Handles api request /api when authorized" name="Basic authentication Api handler Handles api request /api when authorized" time="0.001">
+    </testcase>
+    <testcase classname="Basic authentication Api handler Returns 401 when not authorized" name="Basic authentication Api handler Returns 401 when not authorized" time="0.001">
+    </testcase>
+    <testcase classname="Basic authentication Api handler Returns 401 when password is wrong" name="Basic authentication Api handler Returns 401 when password is wrong" time="0">
+    </testcase>
+    <testcase classname="Basic authentication Default handler Handles page request / when authorized" name="Basic authentication Default handler Handles page request / when authorized" time="0.004">
+    </testcase>
+    <testcase classname="Basic authentication Default handler Returns 401 when not authorized" name="Basic authentication Default handler Returns 401 when not authorized" time="0">
+    </testcase>
+    <testcase classname="Basic authentication Default handler Returns 401 when password is wrong" name="Basic authentication Default handler Returns 401 when password is wrong" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Default handler (basepath + i18n)" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:06" time="0.139" tests="41">
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /base to file pages/en.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /base to file pages/en.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /base/ssg to file pages/en/ssg.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /base/ssg to file pages/en/ssg.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /base/not/found to file pages/en/404.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /base/not/found to file pages/en/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /not/found to file pages/en/404.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /not/found to file pages/en/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /base/en to file pages/en.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /base/en to file pages/en.html" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /base/en/ssg to file pages/en/ssg.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /base/en/ssg to file pages/en/ssg.html" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /base/en/not/found to file pages/en/404.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /base/en/not/found to file pages/en/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /base/fr to file pages/fr.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /base/fr to file pages/fr.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /base/fr/ssg to file pages/fr/ssg.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /base/fr/ssg to file pages/fr/ssg.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static page /base/fr/not/found to file pages/fr/404.html" name="Default handler (basepath + i18n) Non-dynamic Routes static page /base/fr/not/found to file pages/fr/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static data route /base/_next/data/test-build-id/ssg.json to file /_next/data/test-build-id/en/ssg.json" name="Default handler (basepath + i18n) Non-dynamic Routes static data route /base/_next/data/test-build-id/ssg.json to file /_next/data/test-build-id/en/ssg.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static data route /base/_next/data/test-build-id/en/ssg.json to file /_next/data/test-build-id/en/ssg.json" name="Default handler (basepath + i18n) Non-dynamic Routes static data route /base/_next/data/test-build-id/en/ssg.json to file /_next/data/test-build-id/en/ssg.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes static data route /base/_next/data/test-build-id/fr/ssg.json to file /_next/data/test-build-id/fr/ssg.json" name="Default handler (basepath + i18n) Non-dynamic Routes static data route /base/_next/data/test-build-id/fr/ssg.json to file /_next/data/test-build-id/fr/ssg.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes SSR request /base/ssr to pages/ssr.js" name="Default handler (basepath + i18n) Non-dynamic Routes SSR request /base/ssr to pages/ssr.js" time="0.016">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes SSR request /base/en/ssr to pages/ssr.js" name="Default handler (basepath + i18n) Non-dynamic Routes SSR request /base/en/ssr to pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes SSR request /base/fr/ssr to pages/ssr.js" name="Default handler (basepath + i18n) Non-dynamic Routes SSR request /base/fr/ssr to pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Non-dynamic Routes SSR request /base/_next/data/test-build-id/ssr.json to pages/ssr.js" name="Default handler (basepath + i18n) Non-dynamic Routes SSR request /base/_next/data/test-build-id/ssr.json to pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static page /base/foo to file pages/en/[root].html" name="Default handler (basepath + i18n) Dynamic Routes static page /base/foo to file pages/en/[root].html" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static page /base/html/bar to file pages/en/html/[page].html" name="Default handler (basepath + i18n) Dynamic Routes static page /base/html/bar to file pages/en/html/[page].html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static page /base/fallback/new to file pages/en/fallback/new.html" name="Default handler (basepath + i18n) Dynamic Routes static page /base/fallback/new to file pages/en/fallback/new.html" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static page /base/en/foo to file pages/en/[root].html" name="Default handler (basepath + i18n) Dynamic Routes static page /base/en/foo to file pages/en/[root].html" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static page /base/en/html/bar to file pages/en/html/[page].html" name="Default handler (basepath + i18n) Dynamic Routes static page /base/en/html/bar to file pages/en/html/[page].html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static page /base/en/fallback/new to file pages/en/fallback/new.html" name="Default handler (basepath + i18n) Dynamic Routes static page /base/en/fallback/new to file pages/en/fallback/new.html" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static page /base/fr/foo to file pages/fr/[root].html" name="Default handler (basepath + i18n) Dynamic Routes static page /base/fr/foo to file pages/fr/[root].html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static page /base/fr/html/bar to file pages/fr/html/[page].html" name="Default handler (basepath + i18n) Dynamic Routes static page /base/fr/html/bar to file pages/fr/html/[page].html" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static page /base/fr/fallback/new to file pages/fr/fallback/new.html" name="Default handler (basepath + i18n) Dynamic Routes static page /base/fr/fallback/new to file pages/fr/fallback/new.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static data route /base/_next/data/test-build-id/fallback/new.json to file /_next/data/test-build-id/en/fallback/new.json" name="Default handler (basepath + i18n) Dynamic Routes static data route /base/_next/data/test-build-id/fallback/new.json to file /_next/data/test-build-id/en/fallback/new.json" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static data route /base/_next/data/test-build-id/en/fallback/new.json to file /_next/data/test-build-id/en/fallback/new.json" name="Default handler (basepath + i18n) Dynamic Routes static data route /base/_next/data/test-build-id/en/fallback/new.json to file /_next/data/test-build-id/en/fallback/new.json" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes static data route /base/_next/data/test-build-id/fr/fallback/new.json to file /_next/data/test-build-id/fr/fallback/new.json" name="Default handler (basepath + i18n) Dynamic Routes static data route /base/_next/data/test-build-id/fr/fallback/new.json to file /_next/data/test-build-id/fr/fallback/new.json" time="0.004">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes SSR request /base/ssr/1 to pages/ssr/[id].js" name="Default handler (basepath + i18n) Dynamic Routes SSR request /base/ssr/1 to pages/ssr/[id].js" time="0.002">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes SSR request /base/en/ssr/1 to pages/ssr/[id].js" name="Default handler (basepath + i18n) Dynamic Routes SSR request /base/en/ssr/1 to pages/ssr/[id].js" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes SSR request /base/fr/ssr/1 to pages/ssr/[id].js" name="Default handler (basepath + i18n) Dynamic Routes SSR request /base/fr/ssr/1 to pages/ssr/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Dynamic Routes SSR request /base/_next/data/test-build-id/ssr/1.json to pages/ssr/[id].js" name="Default handler (basepath + i18n) Dynamic Routes SSR request /base/_next/data/test-build-id/ssr/1.json to pages/ssr/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Redirect Redirects /base/ssg/ to /base/ssg with code 308" name="Default handler (basepath + i18n) Redirect Redirects /base/ssg/ to /base/ssg with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Redirect Redirects /base/favicon.ico/ to /base/favicon.ico with code 308" name="Default handler (basepath + i18n) Redirect Redirects /base/favicon.ico/ to /base/favicon.ico with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Redirect Redirects /base/redirect-simple to /base/en/redirect-target with code 307" name="Default handler (basepath + i18n) Redirect Redirects /base/redirect-simple to /base/en/redirect-target with code 307" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Redirect Redirects /base/redirect/test to /base/en/redirect-target/test with code 308" name="Default handler (basepath + i18n) Redirect Redirects /base/redirect/test to /base/en/redirect-target/test with code 308" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Redirect Redirects /base/en/redirect-simple to /base/en/redirect-target with code 307" name="Default handler (basepath + i18n) Redirect Redirects /base/en/redirect-simple to /base/en/redirect-target with code 307" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Redirect Redirects /base/en/redirect/test to /base/en/redirect-target/test with code 308" name="Default handler (basepath + i18n) Redirect Redirects /base/en/redirect/test to /base/en/redirect-target/test with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Redirect Redirects /base/fr/redirect-simple to /base/fr/redirect-target with code 307" name="Default handler (basepath + i18n) Redirect Redirects /base/fr/redirect-simple to /base/fr/redirect-target with code 307" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath + i18n) Redirect Redirects /base/fr/redirect/test to /base/fr/redirect-target/test with code 308" name="Default handler (basepath + i18n) Redirect Redirects /base/fr/redirect/test to /base/fr/redirect-target/test with code 308" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Default handler (basepath)" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:07" time="0.1" tests="20">
+    <testcase classname="Default handler (basepath) Public file Routes /base/favicon.ico to public file" name="Default handler (basepath) Public file Routes /base/favicon.ico to public file" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath) Public file Routes /base/name%20with%20spaces.txt to public file" name="Default handler (basepath) Public file Routes /base/name%20with%20spaces.txt to public file" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath) Non-dynamic Routes static page /base to file pages/index.html" name="Default handler (basepath) Non-dynamic Routes static page /base to file pages/index.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath) Non-dynamic Routes static page /base/html to file pages/html.html" name="Default handler (basepath) Non-dynamic Routes static page /base/html to file pages/html.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath) Non-dynamic Routes static page /base/not/found to file pages/404.html" name="Default handler (basepath) Non-dynamic Routes static page /base/not/found to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath) Non-dynamic Routes static page /html to file pages/404.html" name="Default handler (basepath) Non-dynamic Routes static page /html to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath) Non-dynamic Routes static data route /base/_next/data/test-build-id.json to file /_next/data/test-build-id/index.json" name="Default handler (basepath) Non-dynamic Routes static data route /base/_next/data/test-build-id.json to file /_next/data/test-build-id/index.json" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath) Non-dynamic Routes static data route /base/_next/data/test-build-id/index.json to file /_next/data/test-build-id/index.json" name="Default handler (basepath) Non-dynamic Routes static data route /base/_next/data/test-build-id/index.json to file /_next/data/test-build-id/index.json" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath) Non-dynamic Routes SSR request /base/ssr to page pages/ssr.js" name="Default handler (basepath) Non-dynamic Routes SSR request /base/ssr to page pages/ssr.js" time="0.002">
+    </testcase>
+    <testcase classname="Default handler (basepath) Non-dynamic Routes SSR request /base/_next/data/test-build-id/ssr.json to page pages/ssr.js" name="Default handler (basepath) Non-dynamic Routes SSR request /base/_next/data/test-build-id/ssr.json to page pages/ssr.js" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath) Dynamic Routes static page /base/foo to file pages/[root].html" name="Default handler (basepath) Dynamic Routes static page /base/foo to file pages/[root].html" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath) Dynamic Routes static page /base/html/bar to file pages/html/[page].html" name="Default handler (basepath) Dynamic Routes static page /base/html/bar to file pages/html/[page].html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath) Dynamic Routes static page /base/fallback/new to file pages/fallback/new.html" name="Default handler (basepath) Dynamic Routes static page /base/fallback/new to file pages/fallback/new.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath) Dynamic Routes static data route /base/_next/data/test-build-id/fallback/new.json to file /_next/data/test-build-id/fallback/new.json" name="Default handler (basepath) Dynamic Routes static data route /base/_next/data/test-build-id/fallback/new.json to file /_next/data/test-build-id/fallback/new.json" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath) Dynamic Routes SSR request /base/ssr/1 to page pages/ssr/[id].js" name="Default handler (basepath) Dynamic Routes SSR request /base/ssr/1 to page pages/ssr/[id].js" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath) Dynamic Routes SSR request /base/_next/data/test-build-id/ssr/1.json to page pages/ssr/[id].js" name="Default handler (basepath) Dynamic Routes SSR request /base/_next/data/test-build-id/ssr/1.json to page pages/ssr/[id].js" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath) Redirect Redirects /base/ssg/ to /base/ssg with code 308" name="Default handler (basepath) Redirect Redirects /base/ssg/ to /base/ssg with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (basepath) Redirect Redirects /base/favicon.ico/ to /base/favicon.ico with code 308" name="Default handler (basepath) Redirect Redirects /base/favicon.ico/ to /base/favicon.ico with code 308" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath) Redirect Redirects /base/redirect-simple to /base/redirect-target with code 307" name="Default handler (basepath) Redirect Redirects /base/redirect-simple to /base/redirect-target with code 307" time="0">
+    </testcase>
+    <testcase classname="Default handler (basepath) Redirect Redirects /base/redirect/test to /base/redirect-target/test with code 308" name="Default handler (basepath) Redirect Redirects /base/redirect/test to /base/redirect-target/test with code 308" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Default handler (i18n)" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:07" time="0.16" tests="56">
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static page / to file pages/en.html" name="Default handler (i18n) Non-dynamic Routes static page / to file pages/en.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static page /ssg to file pages/en/ssg.html" name="Default handler (i18n) Non-dynamic Routes static page /ssg to file pages/en/ssg.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static page /not/found to file pages/en/404.html" name="Default handler (i18n) Non-dynamic Routes static page /not/found to file pages/en/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static page /en to file pages/en.html" name="Default handler (i18n) Non-dynamic Routes static page /en to file pages/en.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static page /en/ssg to file pages/en/ssg.html" name="Default handler (i18n) Non-dynamic Routes static page /en/ssg to file pages/en/ssg.html" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static page /en/not/found to file pages/en/404.html" name="Default handler (i18n) Non-dynamic Routes static page /en/not/found to file pages/en/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static page /fr to file pages/fr.html" name="Default handler (i18n) Non-dynamic Routes static page /fr to file pages/fr.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static page /fr/ssg to file pages/fr/ssg.html" name="Default handler (i18n) Non-dynamic Routes static page /fr/ssg to file pages/fr/ssg.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static page /fr/not/found to file pages/fr/404.html" name="Default handler (i18n) Non-dynamic Routes static page /fr/not/found to file pages/fr/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static data route /_next/data/test-build-id/ssg.json to file /_next/data/test-build-id/en/ssg.json" name="Default handler (i18n) Non-dynamic Routes static data route /_next/data/test-build-id/ssg.json to file /_next/data/test-build-id/en/ssg.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static data route /_next/data/test-build-id/en/ssg.json to file /_next/data/test-build-id/en/ssg.json" name="Default handler (i18n) Non-dynamic Routes static data route /_next/data/test-build-id/en/ssg.json to file /_next/data/test-build-id/en/ssg.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes static data route /_next/data/test-build-id/fr/ssg.json to file /_next/data/test-build-id/fr/ssg.json" name="Default handler (i18n) Non-dynamic Routes static data route /_next/data/test-build-id/fr/ssg.json to file /_next/data/test-build-id/fr/ssg.json" time="0.004">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes SSR request /ssr to pages/ssr.js" name="Default handler (i18n) Non-dynamic Routes SSR request /ssr to pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes SSR request /en/ssr to pages/ssr.js" name="Default handler (i18n) Non-dynamic Routes SSR request /en/ssr to pages/ssr.js" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes SSR request /fr/ssr to pages/ssr.js" name="Default handler (i18n) Non-dynamic Routes SSR request /fr/ssr to pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Non-dynamic Routes SSR request /_next/data/test-build-id/ssr.json to pages/ssr.js" name="Default handler (i18n) Non-dynamic Routes SSR request /_next/data/test-build-id/ssr.json to pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static page /foo to file pages/en/[root].html" name="Default handler (i18n) Dynamic Routes static page /foo to file pages/en/[root].html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static page /html/bar to file pages/en/html/[page].html" name="Default handler (i18n) Dynamic Routes static page /html/bar to file pages/en/html/[page].html" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static page /fallback/new to file pages/en/fallback/new.html" name="Default handler (i18n) Dynamic Routes static page /fallback/new to file pages/en/fallback/new.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static page /en/foo to file pages/en/[root].html" name="Default handler (i18n) Dynamic Routes static page /en/foo to file pages/en/[root].html" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static page /en/html/bar to file pages/en/html/[page].html" name="Default handler (i18n) Dynamic Routes static page /en/html/bar to file pages/en/html/[page].html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static page /en/fallback/new to file pages/en/fallback/new.html" name="Default handler (i18n) Dynamic Routes static page /en/fallback/new to file pages/en/fallback/new.html" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static page /fr/foo to file pages/fr/[root].html" name="Default handler (i18n) Dynamic Routes static page /fr/foo to file pages/fr/[root].html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static page /fr/html/bar to file pages/fr/html/[page].html" name="Default handler (i18n) Dynamic Routes static page /fr/html/bar to file pages/fr/html/[page].html" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static page /fr/fallback/new to file pages/fr/fallback/new.html" name="Default handler (i18n) Dynamic Routes static page /fr/fallback/new to file pages/fr/fallback/new.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static data route /_next/data/test-build-id/fallback/new.json to file /_next/data/test-build-id/en/fallback/new.json" name="Default handler (i18n) Dynamic Routes static data route /_next/data/test-build-id/fallback/new.json to file /_next/data/test-build-id/en/fallback/new.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static data route /_next/data/test-build-id/en/fallback/new.json to file /_next/data/test-build-id/en/fallback/new.json" name="Default handler (i18n) Dynamic Routes static data route /_next/data/test-build-id/en/fallback/new.json to file /_next/data/test-build-id/en/fallback/new.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes static data route /_next/data/test-build-id/fr/fallback/new.json to file /_next/data/test-build-id/fr/fallback/new.json" name="Default handler (i18n) Dynamic Routes static data route /_next/data/test-build-id/fr/fallback/new.json to file /_next/data/test-build-id/fr/fallback/new.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes SSR request /ssr/1 to pages/ssr/[id].js" name="Default handler (i18n) Dynamic Routes SSR request /ssr/1 to pages/ssr/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes SSR request /en/ssr/1 to pages/ssr/[id].js" name="Default handler (i18n) Dynamic Routes SSR request /en/ssr/1 to pages/ssr/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes SSR request /fr/ssr/1 to pages/ssr/[id].js" name="Default handler (i18n) Dynamic Routes SSR request /fr/ssr/1 to pages/ssr/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Dynamic Routes SSR request /_next/data/test-build-id/ssr/1.json to pages/ssr/[id].js" name="Default handler (i18n) Dynamic Routes SSR request /_next/data/test-build-id/ssr/1.json to pages/ssr/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects /ssg/ to /ssg with code 308" name="Default handler (i18n) Redirect Redirects /ssg/ to /ssg with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects /favicon.ico/ to /favicon.ico with code 308" name="Default handler (i18n) Redirect Redirects /favicon.ico/ to /favicon.ico with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects /redirect-simple to /en/redirect-target with code 307" name="Default handler (i18n) Redirect Redirects /redirect-simple to /en/redirect-target with code 307" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects /redirect/test to /en/redirect-target/test with code 308" name="Default handler (i18n) Redirect Redirects /redirect/test to /en/redirect-target/test with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects /en/redirect-simple to /en/redirect-target with code 307" name="Default handler (i18n) Redirect Redirects /en/redirect-simple to /en/redirect-target with code 307" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects /en/redirect/test to /en/redirect-target/test with code 308" name="Default handler (i18n) Redirect Redirects /en/redirect/test to /en/redirect-target/test with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects /fr/redirect-simple to /fr/redirect-target with code 307" name="Default handler (i18n) Redirect Redirects /fr/redirect-simple to /fr/redirect-target with code 307" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects /fr/redirect/test to /fr/redirect-target/test with code 308" name="Default handler (i18n) Redirect Redirects /fr/redirect/test to /fr/redirect-target/test with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects accept-lang en from / to null" name="Default handler (i18n) Redirect Redirects accept-lang en from / to null" time="0.023">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects accept-lang fr from / to /fr" name="Default handler (i18n) Redirect Redirects accept-lang fr from / to /fr" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects accept-lang en from /en to null" name="Default handler (i18n) Redirect Redirects accept-lang en from /en to null" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects accept-lang fr from /en to null" name="Default handler (i18n) Redirect Redirects accept-lang fr from /en to null" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects accept-lang en from /fr to null" name="Default handler (i18n) Redirect Redirects accept-lang en from /fr to null" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects accept-lang fr from /fr to null" name="Default handler (i18n) Redirect Redirects accept-lang fr from /fr to null" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects accept-lang en from /ssg to null" name="Default handler (i18n) Redirect Redirects accept-lang en from /ssg to null" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects accept-lang fr from /ssg to null" name="Default handler (i18n) Redirect Redirects accept-lang fr from /ssg to null" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects NEXT_LOCALE en from / to null" name="Default handler (i18n) Redirect Redirects NEXT_LOCALE en from / to null" time="0.002">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects NEXT_LOCALE fr from / to /fr" name="Default handler (i18n) Redirect Redirects NEXT_LOCALE fr from / to /fr" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects NEXT_LOCALE en from /en to null" name="Default handler (i18n) Redirect Redirects NEXT_LOCALE en from /en to null" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects NEXT_LOCALE fr from /en to null" name="Default handler (i18n) Redirect Redirects NEXT_LOCALE fr from /en to null" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects NEXT_LOCALE en from /fr to null" name="Default handler (i18n) Redirect Redirects NEXT_LOCALE en from /fr to null" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects NEXT_LOCALE fr from /fr to null" name="Default handler (i18n) Redirect Redirects NEXT_LOCALE fr from /fr to null" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects NEXT_LOCALE en from /ssg to null" name="Default handler (i18n) Redirect Redirects NEXT_LOCALE en from /ssg to null" time="0">
+    </testcase>
+    <testcase classname="Default handler (i18n) Redirect Redirects NEXT_LOCALE fr from /ssg to null" name="Default handler (i18n) Redirect Redirects NEXT_LOCALE fr from /ssg to null" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="Default handler (trailing slash)" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:07" time="0.101" tests="19">
+    <testcase classname="Default handler (trailing slash) Public file Routes /favicon.ico to public file" name="Default handler (trailing slash) Public file Routes /favicon.ico to public file" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Non-dynamic Routes static page / to file pages/index.html" name="Default handler (trailing slash) Non-dynamic Routes static page / to file pages/index.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Non-dynamic Routes static page /ssg/ to file pages/ssg.html" name="Default handler (trailing slash) Non-dynamic Routes static page /ssg/ to file pages/ssg.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Non-dynamic Routes static page /not/found/ to file pages/404.html" name="Default handler (trailing slash) Non-dynamic Routes static page /not/found/ to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Non-dynamic Routes static page /rewrite-ssg/ to file pages/ssg.html" name="Default handler (trailing slash) Non-dynamic Routes static page /rewrite-ssg/ to file pages/ssg.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Non-dynamic Routes static data route /_next/data/test-build-id/ssg.json to file /_next/data/test-build-id/ssg.json" name="Default handler (trailing slash) Non-dynamic Routes static data route /_next/data/test-build-id/ssg.json to file /_next/data/test-build-id/ssg.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Non-dynamic Routes SSR request /ssr/ to page pages/ssr.js" name="Default handler (trailing slash) Non-dynamic Routes SSR request /ssr/ to page pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Non-dynamic Routes SSR request /_next/data/test-build-id/ssr.json to page pages/ssr.js" name="Default handler (trailing slash) Non-dynamic Routes SSR request /_next/data/test-build-id/ssr.json to page pages/ssr.js" time="0.004">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Non-dynamic Routes SSR request /rewrite-ssr/ to page pages/ssr.js" name="Default handler (trailing slash) Non-dynamic Routes SSR request /rewrite-ssr/ to page pages/ssr.js" time="0.002">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Non-dynamic Routes SSR request /rewrite-query/test/ to page pages/ssr.js" name="Default handler (trailing slash) Non-dynamic Routes SSR request /rewrite-query/test/ to page pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Redirects Redirects /ssg to /ssg/ with code 308" name="Default handler (trailing slash) Redirects Redirects /ssg to /ssg/ with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Redirects Redirects /favicon.ico/ to /favicon.ico with code 308" name="Default handler (trailing slash) Redirects Redirects /favicon.ico/ to /favicon.ico with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Redirects Redirects /redirect-simple/ to /redirect-target with code 307" name="Default handler (trailing slash) Redirects Redirects /redirect-simple/ to /redirect-target with code 307" time="0">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Redirects Redirects /redirect/test/ to /redirect-target/test with code 308" name="Default handler (trailing slash) Redirects Redirects /redirect/test/ to /redirect-target/test with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Redirects Redirects /redirect-query/?key=val to /redirect-target?key=val&amp;foo=bar with code 307" name="Default handler (trailing slash) Redirects Redirects /redirect-query/?key=val to /redirect-target?key=val&amp;foo=bar with code 307" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Redirects Redirects www.example.com/ to https://example.com/ with code 308" name="Default handler (trailing slash) Redirects Redirects www.example.com/ to https://example.com/ with code 308" time="0">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Redirects Redirects www.example.com/path/ to https://example.com/path/ with code 308" name="Default handler (trailing slash) Redirects Redirects www.example.com/path/ to https://example.com/path/ with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) Redirects Redirects www.example.com/path/?query to https://example.com/path/?query with code 308" name="Default handler (trailing slash) Redirects Redirects www.example.com/path/?query to https://example.com/path/?query with code 308" time="0">
+    </testcase>
+    <testcase classname="Default handler (trailing slash) External rewrite Returns external rewrite from /rewrite-external/ to https://ext.example.com" name="Default handler (trailing slash) External rewrite Returns external rewrite from /rewrite-external/ to https://ext.example.com" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Default handler" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:07" time="0.165" tests="36">
+    <testcase classname="Default handler Public file Routes /favicon.ico to public file" name="Default handler Public file Routes /favicon.ico to public file" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Public file Routes /name%20with%20spaces.txt to public file" name="Default handler Public file Routes /name%20with%20spaces.txt to public file" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes static page / to file pages/index.html" name="Default handler Non-dynamic Routes static page / to file pages/index.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes static page /ssg to file pages/ssg.html" name="Default handler Non-dynamic Routes static page /ssg to file pages/ssg.html" time="0">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes static page /not/found to file pages/404.html" name="Default handler Non-dynamic Routes static page /not/found to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes static page /rewrite-ssg to file pages/ssg.html" name="Default handler Non-dynamic Routes static page /rewrite-ssg to file pages/ssg.html" time="0.005">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes static data route /_next/data/test-build-id/ssg.json to file /_next/data/test-build-id/ssg.json" name="Default handler Non-dynamic Routes static data route /_next/data/test-build-id/ssg.json to file /_next/data/test-build-id/ssg.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes SSG request /ssg to page pages/ssg.js in preview mode" name="Default handler Non-dynamic Routes SSG request /ssg to page pages/ssg.js in preview mode" time="0.002">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes SSG request /_next/data/test-build-id/ssg.json to page pages/ssg.js in preview mode" name="Default handler Non-dynamic Routes SSG request /_next/data/test-build-id/ssg.json to page pages/ssg.js in preview mode" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes SSR request /ssr to page pages/ssr.js" name="Default handler Non-dynamic Routes SSR request /ssr to page pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes SSR request /_next/data/test-build-id/ssr.json to page pages/ssr.js" name="Default handler Non-dynamic Routes SSR request /_next/data/test-build-id/ssr.json to page pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes SSR request /rewrite-ssr to page pages/ssr.js" name="Default handler Non-dynamic Routes SSR request /rewrite-ssr to page pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Non-dynamic Routes SSR request /rewrite-query/test?key=value to page pages/ssr.js" name="Default handler Non-dynamic Routes SSR request /rewrite-query/test?key=value to page pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes static page /foo to file pages/[root].html" name="Default handler Dynamic Routes static page /foo to file pages/[root].html" time="0">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes static page /html/bar to file pages/html/[page].html" name="Default handler Dynamic Routes static page /html/bar to file pages/html/[page].html" time="0">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes static page /fallback/new to file pages/fallback/new.html" name="Default handler Dynamic Routes static page /fallback/new to file pages/fallback/new.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes static page /fallback/404 to file pages/404.html" name="Default handler Dynamic Routes static page /fallback/404 to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes static page /rewrite-path to file pages/[root].html" name="Default handler Dynamic Routes static page /rewrite-path to file pages/[root].html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes static data route /_next/data/test-build-id/fallback/new.json to file /_next/data/test-build-id/fallback/new.json" name="Default handler Dynamic Routes static data route /_next/data/test-build-id/fallback/new.json to file /_next/data/test-build-id/fallback/new.json" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes static data route /_next/data/test-build-id/fallback/404.json to file pages/404.html" name="Default handler Dynamic Routes static data route /_next/data/test-build-id/fallback/404.json to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes static data route /_next/data/test-build-id/not-found.json to file pages/404.html" name="Default handler Dynamic Routes static data route /_next/data/test-build-id/not-found.json to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes static data route /_next/data/not-build-id/fallback/new.json to file pages/404.html" name="Default handler Dynamic Routes static data route /_next/data/not-build-id/fallback/new.json to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes SSR request /ssr/1 to page pages/ssr/[id].js" name="Default handler Dynamic Routes SSR request /ssr/1 to page pages/ssr/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Dynamic Routes SSR request /_next/data/test-build-id/ssr/1.json to page pages/ssr/[id].js" name="Default handler Dynamic Routes SSR request /_next/data/test-build-id/ssr/1.json to page pages/ssr/[id].js" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Headers Sets headers for /ssr" name="Default handler Headers Sets headers for /ssr" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Redirects Redirects /ssg/ to /ssg with code 308" name="Default handler Redirects Redirects /ssg/ to /ssg with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Redirects Redirects /favicon.ico/ to /favicon.ico with code 308" name="Default handler Redirects Redirects /favicon.ico/ to /favicon.ico with code 308" time="0">
+    </testcase>
+    <testcase classname="Default handler Redirects Redirects /redirect-simple to /redirect-target with code 307" name="Default handler Redirects Redirects /redirect-simple to /redirect-target with code 307" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Redirects Redirects /redirect/test to /redirect-target/test with code 308" name="Default handler Redirects Redirects /redirect/test to /redirect-target/test with code 308" time="0">
+    </testcase>
+    <testcase classname="Default handler Redirects Redirects /redirect-query?key=val to /redirect-target?key=val&amp;foo=bar with code 307" name="Default handler Redirects Redirects /redirect-query?key=val to /redirect-target?key=val&amp;foo=bar with code 307" time="0">
+    </testcase>
+    <testcase classname="Default handler Redirects Redirects www.example.com/ to https://example.com/ with code 308" name="Default handler Redirects Redirects www.example.com/ to https://example.com/ with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler Redirects Redirects www.example.com/path to https://example.com/path with code 308" name="Default handler Redirects Redirects www.example.com/path to https://example.com/path with code 308" time="0">
+    </testcase>
+    <testcase classname="Default handler Redirects Redirects www.example.com/path?query to https://example.com/path?query with code 308" name="Default handler Redirects Redirects www.example.com/path?query to https://example.com/path?query with code 308" time="0.001">
+    </testcase>
+    <testcase classname="Default handler External rewrite Returns external rewrite from /rewrite-external to https://ext.example.com" name="Default handler External rewrite Returns external rewrite from /rewrite-external to https://ext.example.com" time="0.001">
+    </testcase>
+    <testcase classname="Default handler API Routes api request /api/preview to page $page with NodeNextRequest &amp; NodeNextResponse" name="Default handler API Routes api request /api/preview to page $page with NodeNextRequest &amp; NodeNextResponse" time="0">
+    </testcase>
+    <testcase classname="Default handler API Routes api request /api/preview to page $page" name="Default handler API Routes api request /api/preview to page $page" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="Fallback handler" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:07" time="0.113" tests="20">
+    <testcase classname="Fallback handler Non-dynamic Routes static route / to file pages/404.html" name="Fallback handler Non-dynamic Routes static route / to file pages/404.html" time="0.002">
+    </testcase>
+    <testcase classname="Fallback handler Non-dynamic Routes static route /ssg to file pages/404.html" name="Fallback handler Non-dynamic Routes static route /ssg to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="Fallback handler Non-dynamic Routes static route /not/found to file pages/404.html" name="Fallback handler Non-dynamic Routes static route /not/found to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="Fallback handler Non-dynamic Routes static route /rewrite-ssg to file pages/404.html" name="Fallback handler Non-dynamic Routes static route /rewrite-ssg to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="Fallback handler Non-dynamic Routes static route /redirect-simple to file pages/404.html" name="Fallback handler Non-dynamic Routes static route /redirect-simple to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Non-dynamic Routes static data route /_next/data/test-build-id/ssg.json to file pages/404.html" name="Fallback handler Non-dynamic Routes static data route /_next/data/test-build-id/ssg.json to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Non-dynamic Routes SSR route /ssr to page pages/ssr.js" name="Fallback handler Non-dynamic Routes SSR route /ssr to page pages/ssr.js" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes static page /foo to file pages/404.html" name="Fallback handler Dynamic Routes static page /foo to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes static page /html/bar to file pages/404.html" name="Fallback handler Dynamic Routes static page /html/bar to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes static page /rewrite-external to file pages/404.html" name="Fallback handler Dynamic Routes static page /rewrite-external to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes static page /fallback/new to file pages/fallback/[slug].html" name="Fallback handler Dynamic Routes static page /fallback/new to file pages/fallback/[slug].html" time="0.004">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes static page /rewrite-path/new to file pages/fallback/[slug].html" name="Fallback handler Dynamic Routes static page /rewrite-path/new to file pages/fallback/[slug].html" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes static data route /_next/data/test-build-id/not-found.json to file pages/404.html" name="Fallback handler Dynamic Routes static data route /_next/data/test-build-id/not-found.json to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes static data route /_next/data/test-build-id/no-fallback/new.json to file pages/404.html" name="Fallback handler Dynamic Routes static data route /_next/data/test-build-id/no-fallback/new.json to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes static data route /_next/data/not-build-id/fallback/new.json to file pages/404.html" name="Fallback handler Dynamic Routes static data route /_next/data/not-build-id/fallback/new.json to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes fallback blocking route /fallback-blocking/new to page pages/fallback-blocking/[slug].js" name="Fallback handler Dynamic Routes fallback blocking route /fallback-blocking/new to page pages/fallback-blocking/[slug].js" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes fallback data route /_next/data/test-build-id/fallback/new.json to page pages/fallback/[slug].js" name="Fallback handler Dynamic Routes fallback data route /_next/data/test-build-id/fallback/new.json to page pages/fallback/[slug].js" time="0.001">
+    </testcase>
+    <testcase classname="Fallback handler Dynamic Routes fallback data route /_next/data/test-build-id/fallback-blocking/new.json to page pages/fallback-blocking/[slug].js" name="Fallback handler Dynamic Routes fallback data route /_next/data/test-build-id/fallback-blocking/new.json to page pages/fallback-blocking/[slug].js" time="0">
+    </testcase>
+    <testcase classname="Fallback handler Returns 404 if /_next/data/test-build-id/fallback/new.json fallback returns notFound: true" name="Fallback handler Returns 404 if /_next/data/test-build-id/fallback/new.json fallback returns notFound: true" time="0.009">
+    </testcase>
+    <testcase classname="Fallback handler Returns 404 page if /fallback-blocking/404 fallback returns notFound: true" name="Fallback handler Returns 404 page if /fallback-blocking/404 fallback returns notFound: true" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Image optimizer" errors="0" failures="0" skipped="1" timestamp="2022-04-08T17:39:07" time="0.855" tests="19">
+    <testcase classname="Image optimizer Routes serves image request" name="Image optimizer Routes serves image request" time="0.03">
+    </testcase>
+    <testcase classname="Image optimizer Routes serves image request" name="Image optimizer Routes serves image request" time="0.009">
+    </testcase>
+    <testcase classname="Image optimizer Routes serves image request" name="Image optimizer Routes serves image request" time="0.009">
+    </testcase>
+    <testcase classname="Image optimizer Routes serves image request" name="Image optimizer Routes serves image request" time="0.009">
+    </testcase>
+    <testcase classname="Image optimizer Routes serves cached image on second request" name="Image optimizer Routes serves cached image on second request" time="0.01">
+    </testcase>
+    <testcase classname="Image optimizer Routes serves 304 when etag matches" name="Image optimizer Routes serves 304 when etag matches" time="0.009">
+    </testcase>
+    <testcase classname="Image optimizer Routes serves external image request" name="Image optimizer Routes serves external image request" time="0.027">
+    </testcase>
+    <testcase classname="Image optimizer Routes return 500 response when object store throws an error" name="Image optimizer Routes return 500 response when object store throws an error" time="0">
+      <skipped/>
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=100" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=100" time="0.008">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;w=64" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;w=64" time="0.006">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?w=64&amp;q=100" name="Image optimizer Routes invalid queries return 400 for path /_next/image?w=64&amp;q=100" time="0.005">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=100&amp;w=100" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=100&amp;w=100" time="0.005">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=101&amp;w=64" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=101&amp;w=64" time="0.005">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=absoluteUrl&amp;q=101&amp;w=64" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=absoluteUrl&amp;q=101&amp;w=64" time="0.005">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=ftp%3A%2F%2Fexample.com&amp;q=100&amp;w=64" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=ftp%3A%2F%2Fexample.com&amp;q=100&amp;w=64" time="0.006">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=https%3A%2F%2Fnotallowed.com%2Fimage.png&amp;q=100&amp;w=64" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=https%3A%2F%2Fnotallowed.com%2Fimage.png&amp;q=100&amp;w=64" time="0.004">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;url=%2Ftest-image2.png&amp;q=100&amp;w=128" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;url=%2Ftest-image2.png&amp;q=100&amp;w=128" time="0.004">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=100&amp;q=50&amp;w=128" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=100&amp;q=50&amp;w=128" time="0.004">
+    </testcase>
+    <testcase classname="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=100&amp;w=128&amp;w=64" name="Image optimizer Routes invalid queries return 400 for path /_next/image?url=%2Ftest-image.png&amp;q=100&amp;w=128&amp;w=64" time="0.005">
+    </testcase>
+  </testsuite>
+  <testsuite name="Matcher Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:08" time="0.066" tests="13">
+    <testcase classname="Matcher Tests matchPath() matches simple path" name="Matcher Tests matchPath() matches simple path" time="0.001">
+    </testcase>
+    <testcase classname="Matcher Tests matchPath() matches parameterized path" name="Matcher Tests matchPath() matches parameterized path" time="0">
+    </testcase>
+    <testcase classname="Matcher Tests matchPath() matches wildcards" name="Matcher Tests matchPath() matches wildcards" time="0.001">
+    </testcase>
+    <testcase classname="Matcher Tests matchPath() matches regex" name="Matcher Tests matchPath() matches regex" time="0">
+    </testcase>
+    <testcase classname="Matcher Tests matchPath() does not match regex" name="Matcher Tests matchPath() does not match regex" time="0">
+    </testcase>
+    <testcase classname="Matcher Tests compileDestination() compiles simple destination" name="Matcher Tests compileDestination() compiles simple destination" time="0">
+    </testcase>
+    <testcase classname="Matcher Tests compileDestination() compiles parameterized destination" name="Matcher Tests compileDestination() compiles parameterized destination" time="0.001">
+    </testcase>
+    <testcase classname="Matcher Tests compileDestination() compiles http URL" name="Matcher Tests compileDestination() compiles http URL" time="0">
+    </testcase>
+    <testcase classname="Matcher Tests compileDestination() compiles https URL" name="Matcher Tests compileDestination() compiles https URL" time="0">
+    </testcase>
+    <testcase classname="Matcher Tests compileDestination() compiles https URL with trailing slash" name="Matcher Tests compileDestination() compiles https URL with trailing slash" time="0.001">
+    </testcase>
+    <testcase classname="Matcher Tests compileDestination() compiles parameterized https URL" name="Matcher Tests compileDestination() compiles parameterized https URL" time="0">
+    </testcase>
+    <testcase classname="Matcher Tests compileDestination() compiles query string destination" name="Matcher Tests compileDestination() compiles query string destination" time="0">
+    </testcase>
+    <testcase classname="Matcher Tests compileDestination() invalid destination returns null" name="Matcher Tests compileDestination() invalid destination returns null" time="0.002">
+    </testcase>
+  </testsuite>
+  <testsuite name="revalidate" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:08" time="0.057" tests="5">
+    <testcase classname="revalidate getStaticRegenerationResponse() should return a cache header at the amount defined as the initialRevalidateSeconds relative to the lastModifiedHeader when no Expires header is passed" name="revalidate getStaticRegenerationResponse() should return a cache header at the amount defined as the initialRevalidateSeconds relative to the lastModifiedHeader when no Expires header is passed" time="0.001">
+    </testcase>
+    <testcase classname="revalidate getStaticRegenerationResponse() should return a cache header at for the time relative to now and the expires header" name="revalidate getStaticRegenerationResponse() should return a cache header at for the time relative to now and the expires header" time="0.003">
+    </testcase>
+    <testcase classname="revalidate getStaticRegenerationResponse() should prioritise using the Expires header if both Expires header and last modified are present" name="revalidate getStaticRegenerationResponse() should prioritise using the Expires header if both Expires header and last modified are present" time="0">
+    </testcase>
+    <testcase classname="revalidate getStaticRegenerationResponse() should return false when no headers are passed" name="revalidate getStaticRegenerationResponse() should return false when no headers are passed" time="0">
+    </testcase>
+    <testcase classname="revalidate getStaticRegenerationResponse() should return false when no Expires header is passed, and there is no initial validation seconds in manifest" name="revalidate getStaticRegenerationResponse() should return false when no Expires header is passed, and there is no initial validation seconds in manifest" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="Basic Authenticator Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:08" time="0.056" tests="2">
+    <testcase classname="Basic Authenticator Tests authenticates valid username and password" name="Basic Authenticator Tests authenticates valid username and password" time="0.001">
+    </testcase>
+    <testcase classname="Basic Authenticator Tests rejects invalid username and password" name="Basic Authenticator Tests rejects invalid username and password" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="Locale Utils Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:08" time="0.087" tests="38">
+    <testcase classname="Locale Utils Tests addDefaultLocaleToPath() changes path /a to /en/a" name="Locale Utils Tests addDefaultLocaleToPath() changes path /a to /en/a" time="0.001">
+    </testcase>
+    <testcase classname="Locale Utils Tests addDefaultLocaleToPath() changes path /en/a to /en/a" name="Locale Utils Tests addDefaultLocaleToPath() changes path /en/a to /en/a" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests addDefaultLocaleToPath() changes path /fr/a to /fr/a" name="Locale Utils Tests addDefaultLocaleToPath() changes path /fr/a to /fr/a" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests addDefaultLocaleToPath() changes path /en-GB/a to /en-GB/a" name="Locale Utils Tests addDefaultLocaleToPath() changes path /en-GB/a to /en-GB/a" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests addDefaultLocaleToPath() changes path /en-gb/a to /en-GB/a" name="Locale Utils Tests addDefaultLocaleToPath() changes path /en-gb/a to /en-GB/a" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests addDefaultLocaleToPath() changes path /nl/a to /en/a" name="Locale Utils Tests addDefaultLocaleToPath() changes path /nl/a to /en/a" time="0.001">
+    </testcase>
+    <testcase classname="Locale Utils Tests findDomainLocale() google.com is resolved to null" name="Locale Utils Tests findDomainLocale() google.com is resolved to null" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests findDomainLocale() next-serverless.fr is resolved to fr" name="Locale Utils Tests findDomainLocale() next-serverless.fr is resolved to fr" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests findDomainLocale() next-serverless.com is resolved to en" name="Locale Utils Tests findDomainLocale() next-serverless.com is resolved to en" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests findDomainLocale() google.com is resolved to null" name="Locale Utils Tests findDomainLocale() google.com is resolved to null" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests findDomainLocale() next-serverless.fr is resolved to fr" name="Locale Utils Tests findDomainLocale() next-serverless.fr is resolved to fr" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests findDomainLocale() next-serverless.com is resolved to en" name="Locale Utils Tests findDomainLocale() next-serverless.com is resolved to en" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.com with accept-language: en and cookie: undefined redirects to undefined" name="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.com with accept-language: en and cookie: undefined redirects to undefined" time="0.004">
+    </testcase>
+    <testcase classname="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.com with accept-language: fr and cookie: undefined redirects to next-serverless.fr/test" name="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.com with accept-language: fr and cookie: undefined redirects to next-serverless.fr/test" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.com with accept-language: fr;q=0.7, nl;q=0.9 and cookie: undefined redirects to next-serverless.nl/test" name="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.com with accept-language: fr;q=0.7, nl;q=0.9 and cookie: undefined redirects to next-serverless.nl/test" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.fr with accept-language: es and cookie: undefined redirects to next-serverless.com/test" name="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.fr with accept-language: es and cookie: undefined redirects to next-serverless.com/test" time="0.001">
+    </testcase>
+    <testcase classname="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.fr with accept-language: en-GB and cookie: undefined redirects to next-serverless.com/test" name="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.fr with accept-language: en-GB and cookie: undefined redirects to next-serverless.com/test" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.com with accept-language: en and cookie: NEXT_LOCALE=fr redirects to next-serverless.fr/test" name="Locale Utils Tests getLocaleDomainRedirect() host: next-serverless.com with accept-language: en and cookie: NEXT_LOCALE=fr redirects to next-serverless.fr/test" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() changes path /en to /" name="Locale Utils Tests dropLocaleFromPath() changes path /en to /" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() changes path /en/test to /test" name="Locale Utils Tests dropLocaleFromPath() changes path /en/test to /test" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() changes path /en-GB/test to /test" name="Locale Utils Tests dropLocaleFromPath() changes path /en-GB/test to /test" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() changes path /fr/api/foo to /api/foo" name="Locale Utils Tests dropLocaleFromPath() changes path /fr/api/foo to /api/foo" time="0.001">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() keeps path /base/en unchanged" name="Locale Utils Tests dropLocaleFromPath() keeps path /base/en unchanged" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() keeps path /base unchanged" name="Locale Utils Tests dropLocaleFromPath() keeps path /base unchanged" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() keeps path /base/en/test unchanged" name="Locale Utils Tests dropLocaleFromPath() keeps path /base/en/test unchanged" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() keeps path /base/test unchanged" name="Locale Utils Tests dropLocaleFromPath() keeps path /base/test unchanged" time="0.001">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() keeps path /base/en-GB/test unchanged" name="Locale Utils Tests dropLocaleFromPath() keeps path /base/en-GB/test unchanged" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() keeps path /base/test unchanged" name="Locale Utils Tests dropLocaleFromPath() keeps path /base/test unchanged" time="0.001">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() keeps path /base/fr/api/foo unchanged" name="Locale Utils Tests dropLocaleFromPath() keeps path /base/fr/api/foo unchanged" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests dropLocaleFromPath() keeps path /base/api/foo unchanged" name="Locale Utils Tests dropLocaleFromPath() keeps path /base/api/foo unchanged" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getAcceptLanguageLocale() returns /fr/ for fr" name="Locale Utils Tests getAcceptLanguageLocale() returns /fr/ for fr" time="0.001">
+    </testcase>
+    <testcase classname="Locale Utils Tests getAcceptLanguageLocale() returns /nl/ for nl" name="Locale Utils Tests getAcceptLanguageLocale() returns /nl/ for nl" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getAcceptLanguageLocale() returns /fr/ for de, fr" name="Locale Utils Tests getAcceptLanguageLocale() returns /fr/ for de, fr" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getAcceptLanguageLocale() returns /nl/ for fr;q=0.7, nl;q=0.9" name="Locale Utils Tests getAcceptLanguageLocale() returns /nl/ for fr;q=0.7, nl;q=0.9" time="0.001">
+    </testcase>
+    <testcase classname="Locale Utils Tests getAcceptLanguageLocale() returns /en-GB/ for en-GB" name="Locale Utils Tests getAcceptLanguageLocale() returns /en-GB/ for en-GB" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getAcceptLanguageLocale() returns /en-GB/ for en-gb" name="Locale Utils Tests getAcceptLanguageLocale() returns /en-GB/ for en-gb" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getAcceptLanguageLocale() returns nothing for en" name="Locale Utils Tests getAcceptLanguageLocale() returns nothing for en" time="0">
+    </testcase>
+    <testcase classname="Locale Utils Tests getAcceptLanguageLocale() returns nothing for nl;q=0.7, en;q=0.9" name="Locale Utils Tests getAcceptLanguageLocale() returns nothing for nl;q=0.7, en;q=0.9" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="notFoundPage()" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:08" time="0.071" tests="16">
+    <testcase classname="notFoundPage() Not found (html) Not found for / routes to file pages/404.html" name="notFoundPage() Not found (html) Not found for / routes to file pages/404.html" time="0.001">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (html) Not found for /foo routes to file pages/404.html" name="notFoundPage() Not found (html) Not found for /foo routes to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (ssg) Not found for / routes to file pages/404.html" name="notFoundPage() Not found (ssg) Not found for / routes to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (ssg) Not found for /foo routes to file pages/404.html" name="notFoundPage() Not found (ssg) Not found for /foo routes to file pages/404.html" time="0">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (html, basepath + locales) Not found for /base routes to file pages/en/404.html" name="notFoundPage() Not found (html, basepath + locales) Not found for /base routes to file pages/en/404.html" time="0.001">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (html, basepath + locales) Not found for /base/foo routes to file pages/en/404.html" name="notFoundPage() Not found (html, basepath + locales) Not found for /base/foo routes to file pages/en/404.html" time="0">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (html, basepath + locales) Not found for /base/en routes to file pages/en/404.html" name="notFoundPage() Not found (html, basepath + locales) Not found for /base/en routes to file pages/en/404.html" time="0.001">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (html, basepath + locales) Not found for /base/en/foo routes to file pages/en/404.html" name="notFoundPage() Not found (html, basepath + locales) Not found for /base/en/foo routes to file pages/en/404.html" time="0">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (html, basepath + locales) Not found for /base/fr routes to file pages/fr/404.html" name="notFoundPage() Not found (html, basepath + locales) Not found for /base/fr routes to file pages/fr/404.html" time="0">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (html, basepath + locales) Not found for /base/fr/foo routes to file pages/fr/404.html" name="notFoundPage() Not found (html, basepath + locales) Not found for /base/fr/foo routes to file pages/fr/404.html" time="0">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (ssg, basepath + locales) Not found for /base routes to file pages/en/404.html" name="notFoundPage() Not found (ssg, basepath + locales) Not found for /base routes to file pages/en/404.html" time="0">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/foo routes to file pages/en/404.html" name="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/foo routes to file pages/en/404.html" time="0.001">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/en routes to file pages/en/404.html" name="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/en routes to file pages/en/404.html" time="0.004">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/en/foo routes to file pages/en/404.html" name="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/en/foo routes to file pages/en/404.html" time="0.001">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/fr routes to file pages/fr/404.html" name="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/fr routes to file pages/fr/404.html" time="0.001">
+    </testcase>
+    <testcase classname="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/fr/foo routes to file pages/fr/404.html" name="notFoundPage() Not found (ssg, basepath + locales) Not found for /base/fr/foo routes to file pages/fr/404.html" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="isValidPreviewRequest" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:09" time="0.06" tests="3">
+    <testcase classname="isValidPreviewRequest with preview mode disabled is falsey for missing preview cookies" name="isValidPreviewRequest with preview mode disabled is falsey for missing preview cookies" time="0.001">
+    </testcase>
+    <testcase classname="isValidPreviewRequest with preview mode disabled is falsey for invalid preview cookies" name="isValidPreviewRequest with preview mode disabled is falsey for invalid preview cookies" time="0.001">
+    </testcase>
+    <testcase classname="isValidPreviewRequest with preview mode enabled is truthy for valid jwt token in cookies" name="isValidPreviewRequest with preview mode enabled is truthy for valid jwt token in cookies" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Redirector Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:09" time="0.068" tests="12">
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /a to /b" name="Redirector Tests getRedirectPath() redirects path /a to /b" time="0.001">
+    </testcase>
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /c to /d" name="Redirector Tests getRedirectPath() redirects path /c to /d" time="0.001">
+    </testcase>
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /old-blog/abc to /news/abc" name="Redirector Tests getRedirectPath() redirects path /old-blog/abc to /news/abc" time="0">
+    </testcase>
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /old-users/1234 to /users/1234" name="Redirector Tests getRedirectPath() redirects path /old-users/1234 to /users/1234" time="0.001">
+    </testcase>
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /old-users/abc to null" name="Redirector Tests getRedirectPath() redirects path /old-users/abc to null" time="0">
+    </testcase>
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /external to https://example.com" name="Redirector Tests getRedirectPath() redirects path /external to https://example.com" time="0">
+    </testcase>
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /external-2 to https://example.com/?a=b" name="Redirector Tests getRedirectPath() redirects path /external-2 to https://example.com/?a=b" time="0.001">
+    </testcase>
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /invalid-destination to null" name="Redirector Tests getRedirectPath() redirects path /invalid-destination to null" time="0.003">
+    </testcase>
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /en/a to /en/b" name="Redirector Tests getRedirectPath() redirects path /en/a to /en/b" time="0">
+    </testcase>
+    <testcase classname="Redirector Tests getRedirectPath() redirects path /fr/a to /fr/b" name="Redirector Tests getRedirectPath() redirects path /fr/a to /fr/b" time="0.001">
+    </testcase>
+    <testcase classname="Redirector Tests createRedirectResponse() does a permanent redirect" name="Redirector Tests createRedirectResponse() does a permanent redirect" time="0">
+    </testcase>
+    <testcase classname="Redirector Tests createRedirectResponse() does a temporary redirect with query parameters" name="Redirector Tests createRedirectResponse() does a temporary redirect with query parameters" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Rewriter Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:09" time="0.067" tests="18">
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /a to /b" name="Rewriter Tests getRewritePath() rewrites path /a to /b" time="0.001">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /c to /d" name="Rewriter Tests getRewritePath() rewrites path /c to /d" time="0.001">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /old-blog/abc to /news/abc" name="Rewriter Tests getRewritePath() rewrites path /old-blog/abc to /news/abc" time="0">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /old-users/1234 to /users/1234" name="Rewriter Tests getRewritePath() rewrites path /old-users/1234 to /users/1234" time="0.001">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /old-users/abc to undefined" name="Rewriter Tests getRewritePath() rewrites path /old-users/abc to undefined" time="0.001">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /external to https://example.com" name="Rewriter Tests getRewritePath() rewrites path /external to https://example.com" time="0">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /external-http to http://example.com" name="Rewriter Tests getRewritePath() rewrites path /external-http to http://example.com" time="0.001">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /invalid-destination to undefined" name="Rewriter Tests getRewritePath() rewrites path /invalid-destination to undefined" time="0.002">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /en/a to /en/b" name="Rewriter Tests getRewritePath() rewrites path /en/a to /en/b" time="0">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /fr/a to /fr/b" name="Rewriter Tests getRewritePath() rewrites path /fr/a to /fr/b" time="0.001">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /query/foo to /target?a=b&amp;path=foo" name="Rewriter Tests getRewritePath() rewrites path /query/foo to /target?a=b&amp;path=foo" time="0">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /manual-query/foo to /target?key=foo" name="Rewriter Tests getRewritePath() rewrites path /manual-query/foo to /target?key=foo" time="0.001">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /multi-query/foo/bar to /target?path=foo&amp;path=bar" name="Rewriter Tests getRewritePath() rewrites path /multi-query/foo/bar to /target?path=foo&amp;path=bar" time="0.001">
+    </testcase>
+    <testcase classname="Rewriter Tests getRewritePath() rewrites path /no-op-rewrite to /actual-no-op-rewrite-destination" name="Rewriter Tests getRewritePath() rewrites path /no-op-rewrite to /actual-no-op-rewrite-destination" time="0.001">
+    </testcase>
+    <testcase classname="Rewriter Tests isExternalRewrite() evaluates path http://example.com as true" name="Rewriter Tests isExternalRewrite() evaluates path http://example.com as true" time="0">
+    </testcase>
+    <testcase classname="Rewriter Tests isExternalRewrite() evaluates path https://example.com as true" name="Rewriter Tests isExternalRewrite() evaluates path https://example.com as true" time="0">
+    </testcase>
+    <testcase classname="Rewriter Tests isExternalRewrite() evaluates path ftp://example.com as false" name="Rewriter Tests isExternalRewrite() evaluates path ftp://example.com as false" time="0">
+    </testcase>
+    <testcase classname="Rewriter Tests isExternalRewrite() evaluates path //example.com as false" name="Rewriter Tests isExternalRewrite() evaluates path //example.com as false" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="API lambda handler" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:09" time="0.212" tests="4">
+    <testcase classname="API lambda handler API routes serves api request" name="API lambda handler API routes serves api request" time="0.006">
+    </testcase>
+    <testcase classname="API lambda handler API routes serves dynamic api request" name="API lambda handler API routes serves dynamic api request" time="0.007">
+    </testcase>
+    <testcase classname="API lambda handler API routes returns 404 for not-found api routes" name="API lambda handler API routes returns 404 for not-found api routes" time="0.001">
+    </testcase>
+    <testcase classname="API lambda handler Custom Rewrites serves external rewrite https://external.com for rewritten path /api/external-rewrite" name="API lambda handler Custom Rewrites serves external rewrite https://external.com for rewritten path /api/external-rewrite" time="0.028">
+    </testcase>
+  </testsuite>
+  <testsuite name="Builder Tests (dynamic)" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:09" time="0.519" tests="7">
+    <testcase classname="Builder Tests (dynamic) Cleanup .next directory is emptied except for cache/ folder" name="Builder Tests (dynamic) Cleanup .next directory is emptied except for cache/ folder" time="0.06">
+    </testcase>
+    <testcase classname="Builder Tests (dynamic) Cleanup output directory is cleanup before building" name="Builder Tests (dynamic) Cleanup output directory is cleanup before building" time="0.049">
+    </testcase>
+    <testcase classname="Builder Tests (dynamic) Default Handler Manifest adds full manifest" name="Builder Tests (dynamic) Default Handler Manifest adds full manifest" time="0.048">
+    </testcase>
+    <testcase classname="Builder Tests (dynamic) API Handler has empty API handler directory" name="Builder Tests (dynamic) API Handler has empty API handler directory" time="0.046">
+    </testcase>
+    <testcase classname="Builder Tests (dynamic) Images Handler has empty images handler directory" name="Builder Tests (dynamic) Images Handler has empty images handler directory" time="0.055">
+    </testcase>
+    <testcase classname="Builder Tests (dynamic) Default Handler copies build files" name="Builder Tests (dynamic) Default Handler copies build files" time="0.052">
+    </testcase>
+    <testcase classname="Builder Tests (dynamic) Assets copies locale-specific asset files" name="Builder Tests (dynamic) Assets copies locale-specific asset files" time="0.049">
+    </testcase>
+  </testsuite>
+  <testsuite name="Builder Tests (no API routes)" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:10" time="0.359" tests="6">
+    <testcase classname="Builder Tests (no API routes) Cleanup .next directory is emptied except for cache/ folder" name="Builder Tests (no API routes) Cleanup .next directory is emptied except for cache/ folder" time="0.04">
+    </testcase>
+    <testcase classname="Builder Tests (no API routes) Cleanup output directory is cleanup before building" name="Builder Tests (no API routes) Cleanup output directory is cleanup before building" time="0.027">
+    </testcase>
+    <testcase classname="Builder Tests (no API routes) Default Handler Manifest adds full manifest" name="Builder Tests (no API routes) Default Handler Manifest adds full manifest" time="0.034">
+    </testcase>
+    <testcase classname="Builder Tests (no API routes) API Handler has empty API handler directory" name="Builder Tests (no API routes) API Handler has empty API handler directory" time="0.024">
+    </testcase>
+    <testcase classname="Builder Tests (no API routes) Images Handler has empty images handler directory" name="Builder Tests (no API routes) Images Handler has empty images handler directory" time="0.025">
+    </testcase>
+    <testcase classname="Builder Tests (no API routes) Default Handler Artefact Files copies build files" name="Builder Tests (no API routes) Default Handler Artefact Files copies build files" time="0.026">
+    </testcase>
+  </testsuite>
+  <testsuite name="Builder Tests (with locales)" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:10" time="2.68" tests="6">
+    <testcase classname="Builder Tests (with locales) Cleanup .next directory is emptied except for cache/ folder" name="Builder Tests (with locales) Cleanup .next directory is emptied except for cache/ folder" time="0.445">
+    </testcase>
+    <testcase classname="Builder Tests (with locales) Cleanup output directory is cleanup before building" name="Builder Tests (with locales) Cleanup output directory is cleanup before building" time="0.434">
+    </testcase>
+    <testcase classname="Builder Tests (with locales) Default Handler Manifest adds full manifest" name="Builder Tests (with locales) Default Handler Manifest adds full manifest" time="0.415">
+    </testcase>
+    <testcase classname="Builder Tests (with locales) API Handler has empty API handler directory" name="Builder Tests (with locales) API Handler has empty API handler directory" time="0.391">
+    </testcase>
+    <testcase classname="Builder Tests (with locales) Default Handler copies build files" name="Builder Tests (with locales) Default Handler copies build files" time="0.409">
+    </testcase>
+    <testcase classname="Builder Tests (with locales) Assets copies locale-specific asset files" name="Builder Tests (with locales) Assets copies locale-specific asset files" time="0.394">
+    </testcase>
+  </testsuite>
+  <testsuite name="Builder Tests (with third party integrations)" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:13" time="1.015" tests="2">
+    <testcase classname="Builder Tests (with third party integrations) Regular build Default Handler Third Party Files next-i18next files are copied" name="Builder Tests (with third party integrations) Regular build Default Handler Third Party Files next-i18next files are copied" time="0.45">
+    </testcase>
+    <testcase classname="Builder Tests (with third party integrations) Regular build Regeneration Handler Third Party Files next-i18next files are copied" name="Builder Tests (with third party integrations) Regular build Regeneration Handler Third Party Files next-i18next files are copied" time="0.411">
+    </testcase>
+  </testsuite>
+  <testsuite name="Builder Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:14" time="6.9" tests="17">
+    <testcase classname="Builder Tests Regular build Cleanup .next directory is emptied except for cache/ folder" name="Builder Tests Regular build Cleanup .next directory is emptied except for cache/ folder" time="0.392">
+    </testcase>
+    <testcase classname="Builder Tests Regular build Cleanup output directory is cleanup before building" name="Builder Tests Regular build Cleanup output directory is cleanup before building" time="0.414">
+    </testcase>
+    <testcase classname="Builder Tests Regular build Default Handler Manifest adds full manifest" name="Builder Tests Regular build Default Handler Manifest adds full manifest" time="0.411">
+    </testcase>
+    <testcase classname="Builder Tests Regular build API Handler Manifest adds full api manifest" name="Builder Tests Regular build API Handler Manifest adds full api manifest" time="0.387">
+    </testcase>
+    <testcase classname="Builder Tests Regular build Default Handler Artefact Files copies build files" name="Builder Tests Regular build Default Handler Artefact Files copies build files" time="0.413">
+    </testcase>
+    <testcase classname="Builder Tests Regular build Default Handler Artefact Files default handler is not minified" name="Builder Tests Regular build Default Handler Artefact Files default handler is not minified" time="0.348">
+    </testcase>
+    <testcase classname="Builder Tests Regular build API Handler Artefact Files copies build files" name="Builder Tests Regular build API Handler Artefact Files copies build files" time="0.392">
+    </testcase>
+    <testcase classname="Builder Tests Regular build API Handler Artefact Files API handler is not minified" name="Builder Tests Regular build API Handler Artefact Files API handler is not minified" time="0.391">
+    </testcase>
+    <testcase classname="Builder Tests Regular build Image Handler Manifest adds full image manifest" name="Builder Tests Regular build Image Handler Manifest adds full image manifest" time="0.376">
+    </testcase>
+    <testcase classname="Builder Tests Regular build Image Handler Artefact Files copies build files" name="Builder Tests Regular build Image Handler Artefact Files copies build files" time="0.386">
+    </testcase>
+    <testcase classname="Builder Tests Regular build Image Handler Artefact Files image handler is not minified" name="Builder Tests Regular build Image Handler Artefact Files image handler is not minified" time="0.385">
+    </testcase>
+    <testcase classname="Builder Tests Regular build Assets Artefact Files copies all assets" name="Builder Tests Regular build Assets Artefact Files copies all assets" time="0.386">
+    </testcase>
+    <testcase classname="Builder Tests Minified handlers build default handler is minified" name="Builder Tests Minified handlers build default handler is minified" time="0.381">
+    </testcase>
+    <testcase classname="Builder Tests Minified handlers build API handler is minified" name="Builder Tests Minified handlers build API handler is minified" time="0.408">
+    </testcase>
+    <testcase classname="Builder Tests Minified handlers build Image handler is minified" name="Builder Tests Minified handlers build Image handler is minified" time="0.391">
+    </testcase>
+    <testcase classname="Builder Tests Build edge cases fails build when there is a public/static directory that conflicts with static/* behavior" name="Builder Tests Build edge cases fails build when there is a public/static directory that conflicts with static/* behavior" time="0.426">
+    </testcase>
+    <testcase classname="Builder Tests Custom handler copies build files" name="Builder Tests Custom handler copies build files" time="0.402">
+    </testcase>
+  </testsuite>
+  <testsuite name="Lambda@Edge origin response" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:21" time="0.82" tests="7">
+    <testcase classname="Lambda@Edge origin response Fallback pages serves fallback page from S3 when S3 first returns status 403" name="Lambda@Edge origin response Fallback pages serves fallback page from S3 when S3 first returns status 403" time="0.006">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response Fallback pages serves fallback page from S3 when S3 first returns status 404" name="Lambda@Edge origin response Fallback pages serves fallback page from S3 when S3 first returns status 404" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response Fallback pages serves 404 page from S3 for fallback: false" name="Lambda@Edge origin response Fallback pages serves 404 page from S3 for fallback: false" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response Fallback pages renders and uploads HTML and JSON for fallback: blocking" name="Lambda@Edge origin response Fallback pages renders and uploads HTML and JSON for fallback: blocking" time="0.008">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response Fallback pages renders and uploads HTML and JSON for fallback SSG data requests" name="Lambda@Edge origin response Fallback pages renders and uploads HTML and JSON for fallback SSG data requests" time="0.009">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response SSG page requests index page has correct status code" name="Lambda@Edge origin response SSG page requests index page has correct status code" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response SSR data requests does not upload to S3" name="Lambda@Edge origin response SSR data requests does not upload to S3" time="0.005">
+    </testcase>
+  </testsuite>
+  <testsuite name="Lambda@Edge origin response" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:21" time="0.161" tests="6">
+    <testcase classname="Lambda@Edge origin response Fallback pages serves fallback page from S3" name="Lambda@Edge origin response Fallback pages serves fallback page from S3" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response Fallback pages serves 404 page from S3 for fallback: false" name="Lambda@Edge origin response Fallback pages serves 404 page from S3 for fallback: false" time="0.003">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response Fallback pages renders and uploads HTML and JSON for fallback: blocking" name="Lambda@Edge origin response Fallback pages renders and uploads HTML and JSON for fallback: blocking" time="0.004">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response Fallback pages renders and uploads HTML and JSON for fallback SSG data requests" name="Lambda@Edge origin response Fallback pages renders and uploads HTML and JSON for fallback SSG data requests" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response SSG page requests index page has correct status code" name="Lambda@Edge origin response SSG page requests index page has correct status code" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge origin response SSR data requests does not upload to S3" name="Lambda@Edge origin response SSR data requests does not upload to S3" time="0.002">
+    </testcase>
+  </testsuite>
+  <testsuite name="Lambda@Edge" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:22" time="0.49" tests="31">
+    <testcase classname="Lambda@Edge HTML pages routing serves page /index.html from S3 for path /basepath" name="Lambda@Edge HTML pages routing serves page /index.html from S3 for path /basepath" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge HTML pages routing serves page /terms.html from S3 for path /basepath/terms" name="Lambda@Edge HTML pages routing serves page /terms.html from S3 for path /basepath/terms" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge HTML pages routing serves page /users/[...user].html from S3 for path /basepath/users/batman" name="Lambda@Edge HTML pages routing serves page /users/[...user].html from S3 for path /basepath/users/batman" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge HTML pages routing terms.html should return 200 status after successful S3 Origin response" name="Lambda@Edge HTML pages routing terms.html should return 200 status after successful S3 Origin response" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge Public files routing serves public file from S3 /public folder" name="Lambda@Edge Public files routing serves public file from S3 /public folder" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge Public files routing public file should return 200 status after successful S3 Origin response" name="Lambda@Edge Public files routing public file should return 200 status after successful S3 Origin response" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/[root].js for path /basepath/abc" name="Lambda@Edge SSR pages routing renders page pages/[root].js for path /basepath/abc" time="0.006">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/blog/[id].js for path /basepath/blog/foo" name="Lambda@Edge SSR pages routing renders page pages/blog/[id].js for path /basepath/blog/foo" time="0.005">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers.js for path /basepath/customers" name="Lambda@Edge SSR pages routing renders page pages/customers.js for path /basepath/customers" time="0.006">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers/[customer].js for path /basepath/customers/superman" name="Lambda@Edge SSR pages routing renders page pages/customers/[customer].js for path /basepath/customers/superman" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers/[customer]/[post].js for path /basepath/customers/superman/howtofly" name="Lambda@Edge SSR pages routing renders page pages/customers/[customer]/[post].js for path /basepath/customers/superman/howtofly" time="0.006">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers/[customer]/profile.js for path /basepath/customers/superman/profile" name="Lambda@Edge SSR pages routing renders page pages/customers/[customer]/profile.js for path /basepath/customers/superman/profile" time="0.009">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers/[...catchAll].js for path /basepath/customers/test/catch/all" name="Lambda@Edge SSR pages routing renders page pages/customers/[...catchAll].js for path /basepath/customers/test/catch/all" time="0.007">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via SSR for SSR path /basepath/_next/data/build-id/customers.json" name="Lambda@Edge Data Requests serves json data via SSR for SSR path /basepath/_next/data/build-id/customers.json" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via SSR for SSR path /basepath/_next/data/build-id/customers/superman.json" name="Lambda@Edge Data Requests serves json data via SSR for SSR path /basepath/_next/data/build-id/customers/superman.json" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via S3 for SSG path /basepath/_next/data/build-id" name="Lambda@Edge Data Requests serves json data via S3 for SSG path /basepath/_next/data/build-id" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via S3 for SSG path /basepath/_next/data/build-id/index.json" name="Lambda@Edge Data Requests serves json data via S3 for SSG path /basepath/_next/data/build-id/index.json" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via S3 for SSG path /basepath/_next/data/build-id/fallback/not-yet-built.json" name="Lambda@Edge Data Requests serves json data via S3 for SSG path /basepath/_next/data/build-id/fallback/not-yet-built.json" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge uses default s3 endpoint when bucket region is us-east-1" name="Lambda@Edge uses default s3 endpoint when bucket region is us-east-1" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge uses regional endpoint for static page when bucket region is not us-east-1" name="Lambda@Edge uses regional endpoint for static page when bucket region is not us-east-1" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge uses regional endpoint for public asset when bucket region is not us-east-1" name="Lambda@Edge uses regional endpoint for public asset when bucket region is not us-east-1" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page renders 404 page if request path can&apos;t be matched to any page / api routes" name="Lambda@Edge 404 page renders 404 page if request path can&apos;t be matched to any page / api routes" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /terms" name="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /terms" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /not/found" name="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /not/found" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /manifest.json" name="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /manifest.json" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /terms/" name="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /terms/" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /not/found/" name="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /not/found/" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /manifest.json/" name="Lambda@Edge 404 page serves 404 page from S3 for path without basepath prefix: /manifest.json/" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page returns 404 page if data request can&apos;t be matched for path: /basepath/_next/data/unmatched" name="Lambda@Edge 404 page returns 404 page if data request can&apos;t be matched for path: /basepath/_next/data/unmatched" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page 404.html should return 404 status after successful S3 Origin response" name="Lambda@Edge 404 page 404.html should return 404 status after successful S3 Origin response" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge 500 page renders 500 page if page render has an error" name="Lambda@Edge 500 page renders 500 page if page render has an error" time="0.011">
+    </testcase>
+  </testsuite>
+  <testsuite name="Lambda@Edge" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:22" time="0.318" tests="37">
+    <testcase classname="Lambda@Edge HTML pages routing serves page /index.html from S3 for path /" name="Lambda@Edge HTML pages routing serves page /index.html from S3 for path /" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge HTML pages routing serves page /terms.html from S3 for path /terms" name="Lambda@Edge HTML pages routing serves page /terms.html from S3 for path /terms" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge HTML pages routing serves page /users/[...user].html from S3 for path /users/batman" name="Lambda@Edge HTML pages routing serves page /users/[...user].html from S3 for path /users/batman" time="0.006">
+    </testcase>
+    <testcase classname="Lambda@Edge HTML pages routing terms.html should return 200 status after successful S3 Origin response" name="Lambda@Edge HTML pages routing terms.html should return 200 status after successful S3 Origin response" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Public files routing serves public file at path /manifest.json from S3 /public folder" name="Lambda@Edge Public files routing serves public file at path /manifest.json from S3 /public folder" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Public files routing serves public file at path /file%20with%20spaces.json from S3 /public folder" name="Lambda@Edge Public files routing serves public file at path /file%20with%20spaces.json from S3 /public folder" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge Public files routing public file should return 200 status after successful S3 Origin response" name="Lambda@Edge Public files routing public file should return 200 status after successful S3 Origin response" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/[root].js for path /abc" name="Lambda@Edge SSR pages routing renders page pages/[root].js for path /abc" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/blog/[id].js for path /blog/foo" name="Lambda@Edge SSR pages routing renders page pages/blog/[id].js for path /blog/foo" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers.js for path /customers" name="Lambda@Edge SSR pages routing renders page pages/customers.js for path /customers" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers/[customer].js for path /customers/superman" name="Lambda@Edge SSR pages routing renders page pages/customers/[customer].js for path /customers/superman" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers/[customer]/[post].js for path /customers/superman/howtofly" name="Lambda@Edge SSR pages routing renders page pages/customers/[customer]/[post].js for path /customers/superman/howtofly" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers/[customer]/profile.js for path /customers/superman/profile" name="Lambda@Edge SSR pages routing renders page pages/customers/[customer]/profile.js for path /customers/superman/profile" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge SSR pages routing renders page pages/customers/[...catchAll].js for path /customers/test/catch/all" name="Lambda@Edge SSR pages routing renders page pages/customers/[...catchAll].js for path /customers/test/catch/all" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via SSR for SSR path /_next/data/build-id/customers.json" name="Lambda@Edge Data Requests serves json data via SSR for SSR path /_next/data/build-id/customers.json" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via SSR for SSR path /_next/data/build-id/customers/superman.json" name="Lambda@Edge Data Requests serves json data via SSR for SSR path /_next/data/build-id/customers/superman.json" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via SSR for SSR path /_next/data/build-id/customers/superman/profile.json" name="Lambda@Edge Data Requests serves json data via SSR for SSR path /_next/data/build-id/customers/superman/profile.json" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via SSR for SSR path /_next/data/build-id/customers/test/catch/all.json" name="Lambda@Edge Data Requests serves json data via SSR for SSR path /_next/data/build-id/customers/test/catch/all.json" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via S3 for SSG path /_next/data/build-id" name="Lambda@Edge Data Requests serves json data via S3 for SSG path /_next/data/build-id" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via S3 for SSG path /_next/data/build-id/index.json" name="Lambda@Edge Data Requests serves json data via S3 for SSG path /_next/data/build-id/index.json" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests serves json data via S3 for SSG path /_next/data/build-id/fallback/not-yet-built.json" name="Lambda@Edge Data Requests serves json data via S3 for SSG path /_next/data/build-id/fallback/not-yet-built.json" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests correctly removes the expires header if set in the response for an ssg page" name="Lambda@Edge Data Requests correctly removes the expires header if set in the response for an ssg page" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests returns a correct cache control header when an expiry header in the future is sent" name="Lambda@Edge Data Requests returns a correct cache control header when an expiry header in the future is sent" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests returns a correct cache control header when an expiry header in the past is sent" name="Lambda@Edge Data Requests returns a correct cache control header when an expiry header in the past is sent" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests returns a correct cache control header when a last-modified header is sent" name="Lambda@Edge Data Requests returns a correct cache control header when a last-modified header is sent" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Data Requests returns a correct throttled cache header when &apos;throttle&apos; value is returned true" name="Lambda@Edge Data Requests returns a correct throttled cache header when &apos;throttle&apos; value is returned true" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge uses default s3 endpoint when bucket region is us-east-1" name="Lambda@Edge uses default s3 endpoint when bucket region is us-east-1" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge uses regional endpoint for static page when bucket region is not us-east-1" name="Lambda@Edge uses regional endpoint for static page when bucket region is not us-east-1" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge uses regional endpoint for public asset when bucket region is not us-east-1" name="Lambda@Edge uses regional endpoint for public asset when bucket region is not us-east-1" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page returns 404 page if request path can&apos;t be matched to any page / api routes" name="Lambda@Edge 404 page returns 404 page if request path can&apos;t be matched to any page / api routes" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page returns 404 page if data request can&apos;t be matched for path: /_next/data/unmatched" name="Lambda@Edge 404 page returns 404 page if data request can&apos;t be matched for path: /_next/data/unmatched" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page 404.html should return 404 status after successful S3 Origin response" name="Lambda@Edge 404 page 404.html should return 404 status after successful S3 Origin response" time="0">
+    </testcase>
+    <testcase classname="Lambda@Edge 404 page path ending 404 should return 200 status after successful S3 Origin response" name="Lambda@Edge 404 page path ending 404 should return 200 status after successful S3 Origin response" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge 500 page renders 500 page if page render has an error" name="Lambda@Edge 500 page renders 500 page if page render has an error" time="0.002">
+    </testcase>
+    <testcase classname="Lambda@Edge 500 page path ending 500 should return 200 status after successful S3 Origin response" name="Lambda@Edge 500 page path ending 500 should return 200 status after successful S3 Origin response" time="0.001">
+    </testcase>
+    <testcase classname="Lambda@Edge Custom Rewrites serves external rewrite https://external.com for rewritten path /external-rewrite and method GET" name="Lambda@Edge Custom Rewrites serves external rewrite https://external.com for rewritten path /external-rewrite and method GET" time="0.006">
+    </testcase>
+    <testcase classname="Lambda@Edge Custom Rewrites serves external rewrite https://external.com for rewritten path /external-rewrite and method POST" name="Lambda@Edge Custom Rewrites serves external rewrite https://external.com for rewritten path /external-rewrite and method POST" time="0.004">
+    </testcase>
+  </testsuite>
+  <testsuite name="Dynamic Routes Precedence" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:23" time="0.175" tests="2">
+    <testcase classname="Dynamic Routes Precedence adds dynamic page routes to the manifest in correct order of precedence" name="Dynamic Routes Precedence adds dynamic page routes to the manifest in correct order of precedence" time="0.03">
+    </testcase>
+    <testcase classname="Dynamic Routes Precedence adds dynamic api routes to the manifest in correct order of precedence" name="Dynamic Routes Precedence adds dynamic api routes to the manifest in correct order of precedence" time="0.018">
+    </testcase>
+  </testsuite>
+  <testsuite name="Image lambda handler" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:23" time="0.283" tests="3">
+    <testcase classname="Image lambda handler Routes returns 404 for non-image routes" name="Image lambda handler Routes returns 404 for non-image routes" time="0.001">
+    </testcase>
+    <testcase classname="Image lambda handler Domain Redirects redirects path /basepath/_next/image to https://www.example.com/basepath/_next/image, expectedRedirectStatusCode: 308" name="Image lambda handler Domain Redirects redirects path /basepath/_next/image to https://www.example.com/basepath/_next/image, expectedRedirectStatusCode: 308" time="0.001">
+    </testcase>
+    <testcase classname="Image lambda handler Domain Redirects redirects path /basepath/_next/image to https://www.example.com/basepath/_next/image?a=1234, expectedRedirectStatusCode: 308" name="Image lambda handler Domain Redirects redirects path /basepath/_next/image to https://www.example.com/basepath/_next/image?a=1234, expectedRedirectStatusCode: 308" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="Image lambda handler" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:23" time="0.449" tests="2">
+    <testcase classname="Image lambda handler Basic Authentication for test:123, authenticated successfully: true" name="Image lambda handler Basic Authentication for test:123, authenticated successfully: true" time="0.279">
+    </testcase>
+    <testcase classname="Image lambda handler Basic Authentication for test:wrong, authenticated successfully: false" name="Image lambda handler Basic Authentication for test:wrong, authenticated successfully: false" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Image lambda handler" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:24" time="0.167" tests="3">
+    <testcase classname="Image lambda handler Routes returns 404 for non-image routes" name="Image lambda handler Routes returns 404 for non-image routes" time="0.001">
+    </testcase>
+    <testcase classname="Image lambda handler Domain Redirects redirects path /_next/image to https://www.example.com/_next/image, expectedRedirectStatusCode: 308" name="Image lambda handler Domain Redirects redirects path /_next/image to https://www.example.com/_next/image, expectedRedirectStatusCode: 308" time="0">
+    </testcase>
+    <testcase classname="Image lambda handler Domain Redirects redirects path /_next/image to https://www.example.com/_next/image?a=1234, expectedRedirectStatusCode: 308" name="Image lambda handler Domain Redirects redirects path /_next/image to https://www.example.com/_next/image?a=1234, expectedRedirectStatusCode: 308" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="When public and static directories do not exist" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:24" time="0.159" tests="1">
+    <testcase classname="When public and static directories do not exist does not put any public files in the build manifest" name="When public and static directories do not exist does not put any public files in the build manifest" time="0.032">
+    </testcase>
+  </testsuite>
+  <testsuite name="Regeneration Handler" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:24" time="0.218" tests="4">
+    <testcase classname="Regeneration Handler should generate correct page when path is /preview" name="Regeneration Handler should generate correct page when path is /preview" time="0.147">
+    </testcase>
+    <testcase classname="Regeneration Handler should generate correct page when path is /en/preview" name="Regeneration Handler should generate correct page when path is /en/preview" time="0.001">
+    </testcase>
+    <testcase classname="Regeneration Handler should generate correct page when path is /fr/preview" name="Regeneration Handler should generate correct page when path is /fr/preview" time="0.001">
+    </testcase>
+    <testcase classname="Regeneration Handler should generate correct page when path is /nl/preview" name="Regeneration Handler should generate correct page when path is /nl/preview" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Regeneration Handler" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:24" time="0.165" tests="2">
+    <testcase classname="Regeneration Handler should generate correct page when basePath = /custom" name="Regeneration Handler should generate correct page when basePath = /custom" time="0.105">
+    </testcase>
+    <testcase classname="Regeneration Handler should generate correct page when basePath = " name="Regeneration Handler should generate correct page when basePath = " time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="S3StorePage Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:24" time="0.063" tests="4">
+    <testcase classname="S3StorePage Tests should store the page with basePath undefined at path /custom with expectedKeyName custom" name="S3StorePage Tests should store the page with basePath undefined at path /custom with expectedKeyName custom" time="0.001">
+    </testcase>
+    <testcase classname="S3StorePage Tests should store the page with basePath undefined at path / with expectedKeyName index" name="S3StorePage Tests should store the page with basePath undefined at path / with expectedKeyName index" time="0.001">
+    </testcase>
+    <testcase classname="S3StorePage Tests should store the page with basePath /basepath at path /custom with expectedKeyName custom" name="S3StorePage Tests should store the page with basePath /basepath at path /custom with expectedKeyName custom" time="0">
+    </testcase>
+    <testcase classname="S3StorePage Tests should store the page with basePath /basepath at path / with expectedKeyName index" name="S3StorePage Tests should store the page with basePath /basepath at path / with expectedKeyName index" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="triggerStaticRegeneration()" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:24" time="0.072" tests="7">
+    <testcase classname="triggerStaticRegeneration() should not throttle if no rate limit is thrown" name="triggerStaticRegeneration() should not throttle if no rate limit is thrown" time="0.001">
+    </testcase>
+    <testcase classname="triggerStaticRegeneration() should throttle if a RequestThrottledException is thrown" name="triggerStaticRegeneration() should throttle if a RequestThrottledException is thrown" time="0.001">
+    </testcase>
+    <testcase classname="triggerStaticRegeneration() should rethrow an unknown error" name="triggerStaticRegeneration() should rethrow an unknown error" time="0.001">
+    </testcase>
+    <testcase classname="triggerStaticRegeneration() should reject when corrupt s3 name is passed" name="triggerStaticRegeneration() should reject when corrupt s3 name is passed" time="0">
+    </testcase>
+    <testcase classname="triggerStaticRegeneration() should reject when no region is passed" name="triggerStaticRegeneration() should reject when no region is passed" time="0.001">
+    </testcase>
+    <testcase classname="triggerStaticRegeneration() should throttle send correct parameters to the queue" name="triggerStaticRegeneration() should throttle send correct parameters to the queue" time="0">
+    </testcase>
+    <testcase classname="triggerStaticRegeneration() should throttle send correct parameters to the queue" name="triggerStaticRegeneration() should throttle send correct parameters to the queue" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Builder Tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:24" time="0.463" tests="1">
+    <testcase classname="Builder Tests builds successfully from .next with default options" name="Builder Tests builds successfully from .next with default options" time="0.316">
+    </testcase>
+  </testsuite>
+  <testsuite name="Delete old static assets tests for basePath: []" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:25" time="0.256" tests="6">
+    <testcase classname="Delete old static assets tests for basePath: [] does not delete static assets when no BUILD_ID exists" name="Delete old static assets tests for basePath: [] does not delete static assets when no BUILD_ID exists" time="0.004">
+    </testcase>
+    <testcase classname="Delete old static assets tests for basePath: [] does not delete static assets when BUILD_ID exists but listed objects are empty" name="Delete old static assets tests for basePath: [] does not delete static assets when BUILD_ID exists but listed objects are empty" time="0.001">
+    </testcase>
+    <testcase classname="Delete old static assets tests for basePath: [] deletes static assets when BUILD_ID exists" name="Delete old static assets tests for basePath: [] deletes static assets when BUILD_ID exists" time="0.002">
+    </testcase>
+    <testcase classname="Delete old static assets tests for basePath: [/basepath] does not delete static assets when no BUILD_ID exists" name="Delete old static assets tests for basePath: [/basepath] does not delete static assets when no BUILD_ID exists" time="0.001">
+    </testcase>
+    <testcase classname="Delete old static assets tests for basePath: [/basepath] does not delete static assets when BUILD_ID exists but listed objects are empty" name="Delete old static assets tests for basePath: [/basepath] does not delete static assets when BUILD_ID exists but listed objects are empty" time="0">
+    </testcase>
+    <testcase classname="Delete old static assets tests for basePath: [/basepath] deletes static assets when BUILD_ID exists" name="Delete old static assets tests for basePath: [/basepath] deletes static assets when BUILD_ID exists" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Upload tests from build" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:25" time="0.137" tests="9">
+    <testcase classname="Upload tests from build passes credentials to S3 client" name="Upload tests from build passes credentials to S3 client" time="0.009">
+    </testcase>
+    <testcase classname="Upload tests from build uses accelerated bucket option if available" name="Upload tests from build uses accelerated bucket option if available" time="0.006">
+    </testcase>
+    <testcase classname="Upload tests from build falls back to non accelerated client if checking for bucket acceleration throws an error" name="Upload tests from build falls back to non accelerated client if checking for bucket acceleration throws an error" time="0.007">
+    </testcase>
+    <testcase classname="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads static files in _next/static" name="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads static files in _next/static" time="0.006">
+    </testcase>
+    <testcase classname="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads HTML pages in static-pages" name="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads HTML pages in static-pages" time="0.005">
+    </testcase>
+    <testcase classname="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads staticProps JSON files in _next/data" name="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads staticProps JSON files in _next/data" time="0.005">
+    </testcase>
+    <testcase classname="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads files in the public folder" name="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads files in the public folder" time="0.008">
+    </testcase>
+    <testcase classname="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads files in the static folder" name="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build, nextStaticDir=undefined uploads files in the static folder" time="0.004">
+    </testcase>
+    <testcase classname="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build-basepath, nextStaticDir=undefined supports basePath" name="Content Upload Tests - nextConfigDir=./fixtures/app-basic-upload-from-build-basepath, nextStaticDir=undefined supports basePath" time="0.007">
+    </testcase>
+  </testsuite>
+  <testsuite name="readDirectoryFiles" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:25" time="0.066" tests="2">
+    <testcase classname="readDirectoryFiles returns an empty array when the file is not found" name="readDirectoryFiles returns an empty array when the file is not found" time="0.001">
+    </testcase>
+    <testcase classname="readDirectoryFiles returns all files from fixture without directories" name="readDirectoryFiles returns all files from fixture without directories" time="0.003">
+    </testcase>
+  </testsuite>
+  <testsuite name="Input origin as a custom url" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:25" time="1.194" tests="2">
+    <testcase classname="Input origin as a custom url creates distribution with custom default behavior options" name="Input origin as a custom url creates distribution with custom default behavior options" time="0.009">
+    </testcase>
+    <testcase classname="Input origin as a custom url creates distribution with custom behavior options" name="Input origin as a custom url creates distribution with custom behavior options" time="0.003">
+    </testcase>
+  </testsuite>
+  <testsuite name="Configures custom error responses" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:27" time="0.184" tests="3">
+    <testcase classname="Configures custom error responses creates distribution with custom error responses" name="Configures custom error responses creates distribution with custom error responses" time="0.003">
+    </testcase>
+    <testcase classname="Configures custom error responses clears custom error responses when not configured" name="Configures custom error responses clears custom error responses when not configured" time="0.002">
+    </testcase>
+    <testcase classname="Configures custom error responses only allows certain error codes" name="Configures custom error responses only allows certain error codes" time="0.021">
+    </testcase>
+  </testsuite>
+  <testsuite name="Input origin as a custom url" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:27" time="0.166" tests="2">
+    <testcase classname="Input origin as a custom url creates distribution with custom url origin and sets defaults" name="Input origin as a custom url creates distribution with custom url origin and sets defaults" time="0.003">
+    </testcase>
+    <testcase classname="Input origin as a custom url updates distribution" name="Input origin as a custom url updates distribution" time="0.005">
+    </testcase>
+  </testsuite>
+  <testsuite name="Working with an existing distribution" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:27" time="0.178" tests="5">
+    <testcase classname="Working with an existing distribution should not create a new distribution" name="Working with an existing distribution should not create a new distribution" time="0.002">
+    </testcase>
+    <testcase classname="Working with an existing distribution should update the existing distribution by ID" name="Working with an existing distribution should update the existing distribution by ID" time="0.002">
+    </testcase>
+    <testcase classname="Working with an existing distribution should add the new origin to the distribution" name="Working with an existing distribution should add the new origin to the distribution" time="0.002">
+    </testcase>
+    <testcase classname="Working with an existing distribution should modify the existing origin by adding a new cache behavior" name="Working with an existing distribution should modify the existing origin by adding a new cache behavior" time="0.002">
+    </testcase>
+    <testcase classname="Working with an existing distribution should preserve the existing origin cache behaviors" name="Working with an existing distribution should preserve the existing origin cache behaviors" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="General options propagation" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:27" time="0.214" tests="14">
+    <testcase classname="General options propagation create distribution with comment and update it" name="General options propagation create distribution with comment and update it" time="0.007">
+    </testcase>
+    <testcase classname="General options propagation create disabled distribution and update it" name="General options propagation create disabled distribution and update it" time="0.003">
+    </testcase>
+    <testcase classname="General options propagation create distribution with aliases and update it" name="General options propagation create distribution with aliases and update it" time="0.002">
+    </testcase>
+    <testcase classname="General options propagation update distribution with undefined aliases does not override existing aliases" name="General options propagation update distribution with undefined aliases does not override existing aliases" time="0.002">
+    </testcase>
+    <testcase classname="General options propagation create distribution with priceClass and update it" name="General options propagation create distribution with priceClass and update it" time="0.002">
+    </testcase>
+    <testcase classname="General options propagation create distribution with web ACL id and update it" name="General options propagation create distribution with web ACL id and update it" time="0.002">
+    </testcase>
+    <testcase classname="General options propagation create distribution with web ACL id and delete it" name="General options propagation create distribution with web ACL id and delete it" time="0.001">
+    </testcase>
+    <testcase classname="General options propagation create distribution with restrictions and updates it" name="General options propagation create distribution with restrictions and updates it" time="0.002">
+    </testcase>
+    <testcase classname="General options propagation create distribution with restrictions and deletes it" name="General options propagation create distribution with restrictions and deletes it" time="0.002">
+    </testcase>
+    <testcase classname="General options propagation create distribution with certificate arn and updates it" name="General options propagation create distribution with certificate arn and updates it" time="0.002">
+    </testcase>
+    <testcase classname="General options propagation create distribution with default certificate" name="General options propagation create distribution with default certificate" time="0.002">
+    </testcase>
+    <testcase classname="General options propagation create distribution with IAM certificate" name="General options propagation create distribution with IAM certificate" time="0.001">
+    </testcase>
+    <testcase classname="General options propagation creates distribution with tags" name="General options propagation creates distribution with tags" time="0.001">
+    </testcase>
+    <testcase classname="General options propagation updates distribution with tags" name="General options propagation updates distribution with tags" time="0.002">
+    </testcase>
+  </testsuite>
+  <testsuite name="Input origin as a custom url" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:27" time="0.178" tests="2">
+    <testcase classname="Input origin as a custom url creates distribution with lambda associations for each event type" name="Input origin as a custom url creates distribution with lambda associations for each event type" time="0.004">
+    </testcase>
+    <testcase classname="Input origin as a custom url throws error when event type provided is not valid" name="Input origin as a custom url throws error when event type provided is not valid" time="0.002">
+    </testcase>
+  </testsuite>
+  <testsuite name="Input origin with custom header" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:28" time="0.169" tests="1">
+    <testcase classname="Input origin with custom header creates distribution with custom url origin" name="Input origin with custom header creates distribution with custom url origin" time="0.005">
+    </testcase>
+  </testsuite>
+  <testsuite name="Input origin with custom origin config" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:28" time="0.181" tests="2">
+    <testcase classname="Input origin with custom origin config creates distribution with custom origin config" name="Input origin with custom origin config creates distribution with custom origin config" time="0.004">
+    </testcase>
+    <testcase classname="Input origin with custom origin config updates distribution" name="Input origin with custom origin config updates distribution" time="0.003">
+    </testcase>
+  </testsuite>
+  <testsuite name="Input origin with path pattern" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:28" time="0.179" tests="2">
+    <testcase classname="Input origin with path pattern creates distribution with custom url origin" name="Input origin with path pattern creates distribution with custom url origin" time="0.004">
+    </testcase>
+    <testcase classname="Input origin with path pattern updates distribution" name="Input origin with path pattern updates distribution" time="0.008">
+    </testcase>
+  </testsuite>
+  <testsuite name="S3 origins" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:28" time="0.212" tests="11">
+    <testcase classname="S3 origins When origin is an S3 bucket URL creates distribution" name="S3 origins When origin is an S3 bucket URL creates distribution" time="0.003">
+    </testcase>
+    <testcase classname="S3 origins When origin is an S3 bucket URL updates distribution" name="S3 origins When origin is an S3 bucket URL updates distribution" time="0.003">
+    </testcase>
+    <testcase classname="S3 origins When origin is an S3 URL only accessible via CloudFront creates distribution" name="S3 origins When origin is an S3 URL only accessible via CloudFront creates distribution" time="0.004">
+    </testcase>
+    <testcase classname="S3 origins When origin is an S3 URL only accessible via CloudFront updates distribution" name="S3 origins When origin is an S3 URL only accessible via CloudFront updates distribution" time="0.003">
+    </testcase>
+    <testcase classname="S3 origins When origin is an S3 URL only accessible via CloudFront updates distribution persisting existing identity" name="S3 origins When origin is an S3 URL only accessible via CloudFront updates distribution persisting existing identity" time="0.006">
+    </testcase>
+    <testcase classname="S3 origins when origin is outside of us-east-1 should use the origin&apos;s host at the DomainName" name="S3 origins when origin is outside of us-east-1 should use the origin&apos;s host at the DomainName" time="0.003">
+    </testcase>
+    <testcase classname="S3 origins when origin is outside of us-east-1 updates distribution" name="S3 origins when origin is outside of us-east-1 updates distribution" time="0.002">
+    </testcase>
+    <testcase classname="S3 origins when origin is outside of us-east-1 and contains dots should use the origin&apos;s host at the DomainName" name="S3 origins when origin is outside of us-east-1 and contains dots should use the origin&apos;s host at the DomainName" time="0.002">
+    </testcase>
+    <testcase classname="S3 origins when origin is outside of us-east-1 and contains dots updates distribution" name="S3 origins when origin is outside of us-east-1 and contains dots updates distribution" time="0.003">
+    </testcase>
+    <testcase classname="S3 origins when origin is outside of us-east-1 and contains s3 and dots should use the origin&apos;s host at the DomainName" name="S3 origins when origin is outside of us-east-1 and contains s3 and dots should use the origin&apos;s host at the DomainName" time="0.002">
+    </testcase>
+    <testcase classname="S3 origins when origin is outside of us-east-1 and contains s3 and dots updates distribution" name="S3 origins when origin is outside of us-east-1 and contains s3 and dots updates distribution" time="0.003">
+    </testcase>
+  </testsuite>
+  <testsuite name="publishVersion" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:28" time="0.613" tests="2">
+    <testcase classname="publishVersion publishes new version of lambda that was created" name="publishVersion publishes new version of lambda that was created" time="0.018">
+    </testcase>
+    <testcase classname="publishVersion publishes new version of lambda that was updated" name="publishVersion publishes new version of lambda that was updated" time="0.008">
+    </testcase>
+  </testsuite>
+  <testsuite name="publishVersion" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:29" time="0.078" tests="1">
+    <testcase classname="publishVersion removes all old lambda versions" name="publishVersion removes all old lambda versions" time="0.006">
+    </testcase>
+  </testsuite>
+  <testsuite name="waitLambdaReady" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:29" time="0.051" tests="1">
+    <testcase classname="waitLambdaReady waits until lambda is ready" name="waitLambdaReady waits until lambda is ready" time="0.002">
+    </testcase>
+  </testsuite>
+  <testsuite name="sqs component" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:29" time="0.313" tests="8">
+    <testcase classname="sqs component creates a new queue" name="sqs component creates a new queue" time="0.004">
+    </testcase>
+    <testcase classname="sqs component deletes and recreates a queue" name="sqs component deletes and recreates a queue" time="0.002">
+    </testcase>
+    <testcase classname="sqs component creates a queue but does not try to delete an existing queue if none exist already" name="sqs component creates a queue but does not try to delete an existing queue if none exist already" time="0.002">
+    </testcase>
+    <testcase classname="sqs component does not create a lambda mapping when a mapping is found" name="sqs component does not create a lambda mapping when a mapping is found" time="0.001">
+    </testcase>
+    <testcase classname="sqs component creates lambda mapping when no mapping is found" name="sqs component creates lambda mapping when no mapping is found" time="0.001">
+    </testcase>
+    <testcase classname="sqs component calls the delete handler when component is deleted" name="sqs component calls the delete handler when component is deleted" time="0.001">
+    </testcase>
+    <testcase classname="sqs component configures queue tags when tags are different" name="sqs component configures queue tags when tags are different" time="0.002">
+    </testcase>
+    <testcase classname="sqs component does not configure queue tags when tags are the same" name="sqs component does not configure queue tags when tags are the same" time="0.002">
+    </testcase>
+  </testsuite>
+  <testsuite name="CDK Construct" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:29" time="5.592" tests="14">
+    <testcase classname="CDK Construct passes correct lambda options to underlying lambdas when single value passed" name="CDK Construct passes correct lambda options to underlying lambdas when single value passed" time="0.243">
+    </testcase>
+    <testcase classname="CDK Construct passes correct lambda options to underlying lambdas when object passed" name="CDK Construct passes correct lambda options to underlying lambdas when object passed" time="0.131">
+    </testcase>
+    <testcase classname="CDK Construct lambda cache policy passes correct headers to origin when specified" name="CDK Construct lambda cache policy passes correct headers to origin when specified" time="0.118">
+    </testcase>
+    <testcase classname="CDK Construct lambda cache policy passes correct cookies to origin when specified" name="CDK Construct lambda cache policy passes correct cookies to origin when specified" time="0.125">
+    </testcase>
+    <testcase classname="CDK Construct lambda cache policy passes all cookies to origin when not specified" name="CDK Construct lambda cache policy passes all cookies to origin when not specified" time="0.124">
+    </testcase>
+    <testcase classname="CDK Construct statics cache policy uses passed in policy if provided" name="CDK Construct statics cache policy uses passed in policy if provided" time="0.123">
+    </testcase>
+    <testcase classname="CDK Construct image cache policy uses passed in policy if provided" name="CDK Construct image cache policy uses passed in policy if provided" time="0.127">
+    </testcase>
+    <testcase classname="CDK Construct lambda cache policy uses passed in policy if provided" name="CDK Construct lambda cache policy uses passed in policy if provided" time="0.122">
+    </testcase>
+    <testcase classname="CDK Construct creates resources required for a custom domain when specified" name="CDK Construct creates resources required for a custom domain when specified" time="0.116">
+    </testcase>
+    <testcase classname="CDK Construct does not create Route53 records when no domain specified" name="CDK Construct does not create Route53 records when no domain specified" time="0.116">
+    </testcase>
+    <testcase classname="CDK Construct does not create an SQS queue if the app has no ISR pages" name="CDK Construct does not create an SQS queue if the app has no ISR pages" time="0.114">
+    </testcase>
+    <testcase classname="CDK Construct does create an SQS queue if the app has ISR pages" name="CDK Construct does create an SQS queue if the app has ISR pages" time="0.12">
+    </testcase>
+    <testcase classname="CDK Construct configure distribution, but not Route53 records, with custom domain outside AWS" name="CDK Construct configure distribution, but not Route53 records, with custom domain outside AWS" time="0.105">
+    </testcase>
+    <testcase classname="CDK Construct concatenates edgeLambdas passed to defaultBehavior" name="CDK Construct concatenates edgeLambdas passed to defaultBehavior" time="0.115">
+    </testcase>
+  </testsuite>
+  <testsuite name="CDK Construct Snapshots" errors="0" failures="2" skipped="0" timestamp="2022-04-08T17:39:35" time="0.897" tests="2">
+    <testcase classname="CDK Construct Snapshots creates next app with no ISR page" name="CDK Construct Snapshots creates next app with no ISR page" time="0.186">
+      <failure>Error: expect(received).toMatchSnapshot()
+
+Snapshot name: `CDK Construct Snapshots creates next app with no ISR page 1`
+
+- Snapshot  - 285
++ Received  +   5
+
+@@ -851,11 +851,11 @@
+                ],
+                &quot;OriginRequestPolicyId&quot;: Object {
+                  &quot;Ref&quot;: &quot;StackImageOriginRequest30DFB17C&quot;,
+                },
+                &quot;PathPattern&quot;: &quot;_next/image*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin227291135&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+              Object {
+                &quot;AllowedMethods&quot;: Array [
+                  &quot;GET&quot;,
+@@ -885,11 +885,11 @@
+                      &quot;Ref&quot;: &quot;StackNextLambdaCurrentVersion21F01F87b5875487743b0e6b4f7058e417862406&quot;,
+                    },
+                  },
+                ],
+                &quot;PathPattern&quot;: &quot;_next/data/*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin33202980A&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+              Object {
+                &quot;AllowedMethods&quot;: Array [
+                  &quot;GET&quot;,
+@@ -904,11 +904,11 @@
+                  &quot;HEAD&quot;,
+                  &quot;OPTIONS&quot;,
+                ],
+                &quot;Compress&quot;: true,
+                &quot;PathPattern&quot;: &quot;_next/*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin4BE563FB7&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+              Object {
+                &quot;AllowedMethods&quot;: Array [
+                  &quot;GET&quot;,
+@@ -923,11 +923,11 @@
+                  &quot;HEAD&quot;,
+                  &quot;OPTIONS&quot;,
+                ],
+                &quot;Compress&quot;: true,
+                &quot;PathPattern&quot;: &quot;static/*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin5E99C79BE&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+              Object {
+                &quot;AllowedMethods&quot;: Array [
+                  &quot;GET&quot;,
+@@ -955,11 +955,11 @@
+                      &quot;Ref&quot;: &quot;StackNextApiLambdaCurrentVersion09578A6Acd8902824567fc1209c5eab71955b64a&quot;,
+                    },
+                  },
+                ],
+                &quot;PathPattern&quot;: &quot;api/*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin6F399DA4B&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+            ],
+            &quot;DefaultCacheBehavior&quot;: Object {
+              &quot;AllowedMethods&quot;: Array [
+@@ -1017,175 +1017,25 @@
+                      &quot;&quot;,
+                      Array [
+                        &quot;origin-access-identity/cloudfront/&quot;,
+                        Object {
+                          &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin1S3OriginE5C3C6BA&quot;,
+-                       },
+-                     ],
+-                   ],
+-                 },
+-               },
+-             },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin227291135&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin2S3OriginBE3A92C1&quot;,
+-                       },
+-                     ],
+-                   ],
+-                 },
+-               },
+                        },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin33202980A&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin3S3Origin815895A3&quot;,
+-                       },
+                      ],
+                    ],
+                  },
+                },
+              },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin4BE563FB7&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin4S3Origin25CF633C&quot;,
+-                       },
+-                     ],
+            ],
+          },
+        },
+-             },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin5E99C79BE&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin5S3OriginF7CEDF65&quot;,
+-                       },
+-                     ],
+-                   ],
+-                 },
+-               },
+-             },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin6F399DA4B&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin6S3Origin922D99DB&quot;,
+-                       },
+-                     ],
+-                   ],
+-                 },
+-               },
+-             },
+-           ],
+-         },
+-       },
+        &quot;Type&quot;: &quot;AWS::CloudFront::Distribution&quot;,
+      },
+      &quot;StackNextJSDistributionOrigin1S3OriginE5C3C6BA&quot;: Object {
+        &quot;Properties&quot;: Object {
+          &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+            &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin164EFF789&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin2S3OriginBE3A92C1&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin227291135&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin3S3Origin815895A3&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin33202980A&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin4S3Origin25CF633C&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin4BE563FB7&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin5S3OriginF7CEDF65&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin5E99C79BE&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin6S3Origin922D99DB&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin6F399DA4B&quot;,
+          },
+        },
+        &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+      },
+      &quot;StackNextLambdaCacheF214CEF2&quot;: Object {
+@@ -1432,140 +1282,10 @@
+                &quot;Effect&quot;: &quot;Allow&quot;,
+                &quot;Principal&quot;: Object {
+                  &quot;CanonicalUser&quot;: Object {
+                    &quot;Fn::GetAtt&quot;: Array [
+                      &quot;StackNextJSDistributionOrigin1S3OriginE5C3C6BA&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin2S3OriginBE3A92C1&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin3S3Origin815895A3&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin4S3Origin25CF633C&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin5S3OriginF7CEDF65&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin6S3Origin922D99DB&quot;,
+                      &quot;S3CanonicalUserId&quot;,
+                    ],
+                  },
+                },
+                &quot;Resource&quot;: Object {
+    at Object.&lt;anonymous&gt; (/Users/bj.clark/sites/serverless-next.js/packages/serverless-components/nextjs-cdk-construct/__tests__/snapshots.test.ts:14:30)
+    at Promise.then.completed (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/utils.js:391:28)
+    at new Promise (&lt;anonymous&gt;)
+    at callAsyncCircusFn (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/utils.js:316:10)
+    at _callCircusTest (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:218:40)
+    at _runTest (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:155:3)
+    at _runTestsForDescribeBlock (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:66:9)
+    at _runTestsForDescribeBlock (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:60:9)
+    at run (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:25:3)
+    at runAndTransformResultsToJestFormat (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:170:21)</failure>
+    </testcase>
+    <testcase classname="CDK Construct Snapshots creates next app with ISR pages" name="CDK Construct Snapshots creates next app with ISR pages" time="0.162">
+      <failure>Error: expect(received).toMatchSnapshot()
+
+Snapshot name: `CDK Construct Snapshots creates next app with ISR pages 1`
+
+- Snapshot  - 285
++ Received  +   5
+
+@@ -875,11 +875,11 @@
+                ],
+                &quot;OriginRequestPolicyId&quot;: Object {
+                  &quot;Ref&quot;: &quot;StackImageOriginRequest30DFB17C&quot;,
+                },
+                &quot;PathPattern&quot;: &quot;_next/image*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin227291135&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+              Object {
+                &quot;AllowedMethods&quot;: Array [
+                  &quot;GET&quot;,
+@@ -909,11 +909,11 @@
+                      &quot;Ref&quot;: &quot;StackNextLambdaCurrentVersion21F01F879970bafa5c9141f6152d4057c3ab8184&quot;,
+                    },
+                  },
+                ],
+                &quot;PathPattern&quot;: &quot;_next/data/*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin33202980A&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+              Object {
+                &quot;AllowedMethods&quot;: Array [
+                  &quot;GET&quot;,
+@@ -928,11 +928,11 @@
+                  &quot;HEAD&quot;,
+                  &quot;OPTIONS&quot;,
+                ],
+                &quot;Compress&quot;: true,
+                &quot;PathPattern&quot;: &quot;_next/*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin4BE563FB7&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+              Object {
+                &quot;AllowedMethods&quot;: Array [
+                  &quot;GET&quot;,
+@@ -947,11 +947,11 @@
+                  &quot;HEAD&quot;,
+                  &quot;OPTIONS&quot;,
+                ],
+                &quot;Compress&quot;: true,
+                &quot;PathPattern&quot;: &quot;static/*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin5E99C79BE&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+              Object {
+                &quot;AllowedMethods&quot;: Array [
+                  &quot;GET&quot;,
+@@ -979,11 +979,11 @@
+                      &quot;Ref&quot;: &quot;StackNextApiLambdaCurrentVersion09578A6Acd8902824567fc1209c5eab71955b64a&quot;,
+                    },
+                  },
+                ],
+                &quot;PathPattern&quot;: &quot;api/*&quot;,
+-               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin6F399DA4B&quot;,
++               &quot;TargetOriginId&quot;: &quot;StackNextJSDistributionOrigin164EFF789&quot;,
+                &quot;ViewerProtocolPolicy&quot;: &quot;redirect-to-https&quot;,
+              },
+            ],
+            &quot;DefaultCacheBehavior&quot;: Object {
+              &quot;AllowedMethods&quot;: Array [
+@@ -1041,175 +1041,25 @@
+                      &quot;&quot;,
+                      Array [
+                        &quot;origin-access-identity/cloudfront/&quot;,
+                        Object {
+                          &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin1S3OriginE5C3C6BA&quot;,
+-                       },
+-                     ],
+-                   ],
+-                 },
+-               },
+-             },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin227291135&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin2S3OriginBE3A92C1&quot;,
+-                       },
+-                     ],
+-                   ],
+-                 },
+-               },
+                        },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin33202980A&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin3S3Origin815895A3&quot;,
+-                       },
+                      ],
+                    ],
+                  },
+                },
+              },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin4BE563FB7&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin4S3Origin25CF633C&quot;,
+-                       },
+-                     ],
+            ],
+          },
+        },
+-             },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin5E99C79BE&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin5S3OriginF7CEDF65&quot;,
+-                       },
+-                     ],
+-                   ],
+-                 },
+-               },
+-             },
+-             Object {
+-               &quot;DomainName&quot;: Object {
+-                 &quot;Fn::GetAtt&quot;: Array [
+-                   &quot;StackPublicAssets8F0F4FE8&quot;,
+-                   &quot;RegionalDomainName&quot;,
+-                 ],
+-               },
+-               &quot;Id&quot;: &quot;StackNextJSDistributionOrigin6F399DA4B&quot;,
+-               &quot;S3OriginConfig&quot;: Object {
+-                 &quot;OriginAccessIdentity&quot;: Object {
+-                   &quot;Fn::Join&quot;: Array [
+-                     &quot;&quot;,
+-                     Array [
+-                       &quot;origin-access-identity/cloudfront/&quot;,
+-                       Object {
+-                         &quot;Ref&quot;: &quot;StackNextJSDistributionOrigin6S3Origin922D99DB&quot;,
+-                       },
+-                     ],
+-                   ],
+-                 },
+-               },
+-             },
+-           ],
+-         },
+-       },
+        &quot;Type&quot;: &quot;AWS::CloudFront::Distribution&quot;,
+      },
+      &quot;StackNextJSDistributionOrigin1S3OriginE5C3C6BA&quot;: Object {
+        &quot;Properties&quot;: Object {
+          &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+            &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin164EFF789&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin2S3OriginBE3A92C1&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin227291135&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin3S3Origin815895A3&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin33202980A&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin4S3Origin25CF633C&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin4BE563FB7&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin5S3OriginF7CEDF65&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin5E99C79BE&quot;,
+-         },
+-       },
+-       &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+-     },
+-     &quot;StackNextJSDistributionOrigin6S3Origin922D99DB&quot;: Object {
+-       &quot;Properties&quot;: Object {
+-         &quot;CloudFrontOriginAccessIdentityConfig&quot;: Object {
+-           &quot;Comment&quot;: &quot;Identity for StackNextJSDistributionOrigin6F399DA4B&quot;,
+          },
+        },
+        &quot;Type&quot;: &quot;AWS::CloudFront::CloudFrontOriginAccessIdentity&quot;,
+      },
+      &quot;StackNextLambdaCacheF214CEF2&quot;: Object {
+@@ -1456,140 +1306,10 @@
+                &quot;Effect&quot;: &quot;Allow&quot;,
+                &quot;Principal&quot;: Object {
+                  &quot;CanonicalUser&quot;: Object {
+                    &quot;Fn::GetAtt&quot;: Array [
+                      &quot;StackNextJSDistributionOrigin1S3OriginE5C3C6BA&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin2S3OriginBE3A92C1&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin3S3Origin815895A3&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin4S3Origin25CF633C&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin5S3OriginF7CEDF65&quot;,
+-                     &quot;S3CanonicalUserId&quot;,
+-                   ],
+-                 },
+-               },
+-               &quot;Resource&quot;: Object {
+-                 &quot;Fn::Join&quot;: Array [
+-                   &quot;&quot;,
+-                   Array [
+-                     Object {
+-                       &quot;Fn::GetAtt&quot;: Array [
+-                         &quot;StackPublicAssets8F0F4FE8&quot;,
+-                         &quot;Arn&quot;,
+-                       ],
+-                     },
+-                     &quot;/*&quot;,
+-                   ],
+-                 ],
+-               },
+-             },
+-             Object {
+-               &quot;Action&quot;: &quot;s3:GetObject&quot;,
+-               &quot;Effect&quot;: &quot;Allow&quot;,
+-               &quot;Principal&quot;: Object {
+-                 &quot;CanonicalUser&quot;: Object {
+-                   &quot;Fn::GetAtt&quot;: Array [
+-                     &quot;StackNextJSDistributionOrigin6S3Origin922D99DB&quot;,
+                      &quot;S3CanonicalUserId&quot;,
+                    ],
+                  },
+                },
+                &quot;Resource&quot;: Object {
+    at Object.&lt;anonymous&gt; (/Users/bj.clark/sites/serverless-next.js/packages/serverless-components/nextjs-cdk-construct/__tests__/snapshots.test.ts:24:30)
+    at Promise.then.completed (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/utils.js:391:28)
+    at new Promise (&lt;anonymous&gt;)
+    at callAsyncCircusFn (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/utils.js:316:10)
+    at _callCircusTest (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:218:40)
+    at _runTest (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:155:3)
+    at _runTestsForDescribeBlock (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:66:9)
+    at _runTestsForDescribeBlock (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:60:9)
+    at run (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/run.js:25:3)
+    at runAndTransformResultsToJestFormat (/Users/bj.clark/sites/serverless-next.js/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:170:21)</failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="CDK Utils" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:36" time="0.057" tests="12">
+    <testcase classname="CDK Utils toLambdaOption" name="CDK Utils toLambdaOption" time="0">
+    </testcase>
+    <testcase classname="CDK Utils toLambdaOption" name="CDK Utils toLambdaOption" time="0.001">
+    </testcase>
+    <testcase classname="CDK Utils toLambdaOption" name="CDK Utils toLambdaOption" time="0">
+    </testcase>
+    <testcase classname="CDK Utils toLambdaOption" name="CDK Utils toLambdaOption" time="0">
+    </testcase>
+    <testcase classname="CDK Utils toLambdaOption" name="CDK Utils toLambdaOption" time="0.001">
+    </testcase>
+    <testcase classname="CDK Utils readInvalidationPathsFromManifest" name="CDK Utils readInvalidationPathsFromManifest" time="0">
+    </testcase>
+    <testcase classname="CDK Utils reduceInvalidationPaths" name="CDK Utils reduceInvalidationPaths" time="0.001">
+    </testcase>
+    <testcase classname="CDK Utils reduceInvalidationPaths" name="CDK Utils reduceInvalidationPaths" time="0">
+    </testcase>
+    <testcase classname="CDK Utils reduceInvalidationPaths" name="CDK Utils reduceInvalidationPaths" time="0">
+    </testcase>
+    <testcase classname="CDK Utils reduceInvalidationPaths" name="CDK Utils reduceInvalidationPaths" time="0.001">
+    </testcase>
+    <testcase classname="CDK Utils reduceInvalidationPaths" name="CDK Utils reduceInvalidationPaths" time="0">
+    </testcase>
+    <testcase classname="CDK Utils reduceInvalidationPaths" name="CDK Utils reduceInvalidationPaths" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="basepath tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:36" time="1.005" tests="1">
+    <testcase classname="basepath tests cloudfront adds basepath to paths" name="basepath tests cloudfront adds basepath to paths" time="0.357">
+    </testcase>
+  </testsuite>
+  <testsuite name="Custom inputs" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:39:37" time="29.932" tests="75">
+    <testcase classname="Custom inputs When input region is undefined passes the us-east-1 region to the s3 and cloudFront components" name="Custom inputs When input region is undefined passes the us-east-1 region to the s3 and cloudFront components" time="0.373">
+    </testcase>
+    <testcase classname="Custom inputs When input region is eu-west-2 passes the eu-west-2 region to the s3 and cloudFront components" name="Custom inputs When input region is eu-west-2 passes the eu-west-2 region to the s3 and cloudFront components" time="0.363">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" name="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" time="0.391">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses custom policy document provided" name="Custom inputs Custom domain uses custom policy document provided" time="0.401">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain outputs custom domain url" name="Custom inputs Custom domain outputs custom domain url" time="0.519">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" name="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" time="0.451">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses custom policy document provided" name="Custom inputs Custom domain uses custom policy document provided" time="0.47">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain outputs custom domain url" name="Custom inputs Custom domain outputs custom domain url" time="0.444">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" name="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" time="0.433">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses custom policy document provided" name="Custom inputs Custom domain uses custom policy document provided" time="0.464">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain outputs custom domain url" name="Custom inputs Custom domain outputs custom domain url" time="0.389">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" name="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" time="0.412">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses custom policy document provided" name="Custom inputs Custom domain uses custom policy document provided" time="0.434">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain outputs custom domain url" name="Custom inputs Custom domain outputs custom domain url" time="0.395">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" name="Custom inputs Custom domain uses @sls-next/domain to provision custom domain" time="0.397">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain uses custom policy document provided" name="Custom inputs Custom domain uses custom policy document provided" time="0.375">
+    </testcase>
+    <testcase classname="Custom inputs Custom domain outputs custom domain url" name="Custom inputs Custom domain outputs custom domain url" time="0.366">
+    </testcase>
+    <testcase classname="Custom inputs Custom role arn uses custom role arn provided" name="Custom inputs Custom role arn uses custom role arn provided" time="0.367">
+    </testcase>
+    <testcase classname="Custom inputs nextConfigDir=nextConfigDir, nextStaticDir=nextStaticDir uploads static assets to S3 correctly" name="Custom inputs nextConfigDir=nextConfigDir, nextStaticDir=nextStaticDir uploads static assets to S3 correctly" time="0.301">
+    </testcase>
+    <testcase classname="Custom inputs input=inputPublicDirectoryCache, expected={&quot;expected&quot;: &quot;public, max-age=31536000, must-revalidate&quot;, &quot;publicDirectoryCache&quot;: undefined} sets the public, max-age=31536000, must-revalidate Cache - Control header on undefined " name="Custom inputs input=inputPublicDirectoryCache, expected={&quot;expected&quot;: &quot;public, max-age=31536000, must-revalidate&quot;, &quot;publicDirectoryCache&quot;: undefined} sets the public, max-age=31536000, must-revalidate Cache - Control header on undefined " time="0.341">
+    </testcase>
+    <testcase classname="Custom inputs input=inputPublicDirectoryCache, expected={&quot;expected&quot;: undefined, &quot;publicDirectoryCache&quot;: false} sets the undefined Cache - Control header on false " name="Custom inputs input=inputPublicDirectoryCache, expected={&quot;expected&quot;: undefined, &quot;publicDirectoryCache&quot;: false} sets the undefined Cache - Control header on false " time="0.379">
+    </testcase>
+    <testcase classname="Custom inputs input=inputPublicDirectoryCache, expected={&quot;expected&quot;: &quot;public, max-age=306000&quot;, &quot;publicDirectoryCache&quot;: [Object]} sets the public, max-age=306000 Cache - Control header on [object Object] " name="Custom inputs input=inputPublicDirectoryCache, expected={&quot;expected&quot;: &quot;public, max-age=306000&quot;, &quot;publicDirectoryCache&quot;: [Object]} sets the public, max-age=306000 Cache - Control header on [object Object] " time="0.422">
+    </testcase>
+    <testcase classname="Custom inputs Lambda memory input sets default lambda memory to 512 and api lambda memory to 512 " name="Custom inputs Lambda memory input sets default lambda memory to 512 and api lambda memory to 512 " time="0.422">
+    </testcase>
+    <testcase classname="Custom inputs Lambda memory input sets default lambda memory to 512 and api lambda memory to 512 " name="Custom inputs Lambda memory input sets default lambda memory to 512 and api lambda memory to 512 " time="0.408">
+    </testcase>
+    <testcase classname="Custom inputs Lambda memory input sets default lambda memory to 1024 and api lambda memory to 1024 " name="Custom inputs Lambda memory input sets default lambda memory to 1024 and api lambda memory to 1024 " time="0.378">
+    </testcase>
+    <testcase classname="Custom inputs Lambda memory input sets default lambda memory to 1024 and api lambda memory to 512 " name="Custom inputs Lambda memory input sets default lambda memory to 1024 and api lambda memory to 512 " time="0.424">
+    </testcase>
+    <testcase classname="Custom inputs Lambda memory input sets default lambda memory to 512 and api lambda memory to 2048 " name="Custom inputs Lambda memory input sets default lambda memory to 512 and api lambda memory to 2048 " time="0.464">
+    </testcase>
+    <testcase classname="Custom inputs Lambda memory input sets default lambda memory to 128 and api lambda memory to 2048 " name="Custom inputs Lambda memory input sets default lambda memory to 128 and api lambda memory to 2048 " time="0.421">
+    </testcase>
+    <testcase classname="Custom inputs Lambda tags input sets lambda tags to {&quot;defaultLambda&quot;:{&quot;tag1&quot;:&quot;val1&quot;},&quot;apiLambda&quot;:{&quot;tag2&quot;:&quot;val2&quot;},&quot;imageLambda&quot;:{&quot;tag3&quot;:&quot;val3&quot;}}" name="Custom inputs Lambda tags input sets lambda tags to {&quot;defaultLambda&quot;:{&quot;tag1&quot;:&quot;val1&quot;},&quot;apiLambda&quot;:{&quot;tag2&quot;:&quot;val2&quot;},&quot;imageLambda&quot;:{&quot;tag3&quot;:&quot;val3&quot;}}" time="0.409">
+    </testcase>
+    <testcase classname="Custom inputs Old lambda function version removal removes old versions of lambda functions" name="Custom inputs Old lambda function version removal removes old versions of lambda functions" time="0.433">
+    </testcase>
+    <testcase classname="Custom inputs Input timeout options sets default lambda timeout to 10 and api lambda timeout to 10 " name="Custom inputs Input timeout options sets default lambda timeout to 10 and api lambda timeout to 10 " time="0.407">
+    </testcase>
+    <testcase classname="Custom inputs Input timeout options sets default lambda timeout to 10 and api lambda timeout to 10 " name="Custom inputs Input timeout options sets default lambda timeout to 10 and api lambda timeout to 10 " time="0.378">
+    </testcase>
+    <testcase classname="Custom inputs Input timeout options sets default lambda timeout to 40 and api lambda timeout to 40 " name="Custom inputs Input timeout options sets default lambda timeout to 40 and api lambda timeout to 40 " time="0.381">
+    </testcase>
+    <testcase classname="Custom inputs Input timeout options sets default lambda timeout to 20 and api lambda timeout to 10 " name="Custom inputs Input timeout options sets default lambda timeout to 20 and api lambda timeout to 10 " time="0.467">
+    </testcase>
+    <testcase classname="Custom inputs Input timeout options sets default lambda timeout to 10 and api lambda timeout to 20 " name="Custom inputs Input timeout options sets default lambda timeout to 10 and api lambda timeout to 20 " time="0.421">
+    </testcase>
+    <testcase classname="Custom inputs Input timeout options sets default lambda timeout to 15 and api lambda timeout to 20 " name="Custom inputs Input timeout options sets default lambda timeout to 15 and api lambda timeout to 20 " time="0.337">
+    </testcase>
+    <testcase classname="Custom inputs Input runtime options sets default lambda runtime to nodejs14.x and api lambda runtime to nodejs14.x " name="Custom inputs Input runtime options sets default lambda runtime to nodejs14.x and api lambda runtime to nodejs14.x " time="0.393">
+    </testcase>
+    <testcase classname="Custom inputs Input runtime options sets default lambda runtime to nodejs14.x and api lambda runtime to nodejs14.x " name="Custom inputs Input runtime options sets default lambda runtime to nodejs14.x and api lambda runtime to nodejs14.x " time="0.386">
+    </testcase>
+    <testcase classname="Custom inputs Input runtime options sets default lambda runtime to nodejs12.x and api lambda runtime to nodejs12.x " name="Custom inputs Input runtime options sets default lambda runtime to nodejs12.x and api lambda runtime to nodejs12.x " time="0.391">
+    </testcase>
+    <testcase classname="Custom inputs Input runtime options sets default lambda runtime to nodejs12.x and api lambda runtime to nodejs14.x " name="Custom inputs Input runtime options sets default lambda runtime to nodejs12.x and api lambda runtime to nodejs14.x " time="0.38">
+    </testcase>
+    <testcase classname="Custom inputs Input runtime options sets default lambda runtime to nodejs14.x and api lambda runtime to nodejs12.x " name="Custom inputs Input runtime options sets default lambda runtime to nodejs14.x and api lambda runtime to nodejs12.x " time="0.37">
+    </testcase>
+    <testcase classname="Custom inputs Input runtime options sets default lambda runtime to nodejs12.x and api lambda runtime to nodejs12.x " name="Custom inputs Input runtime options sets default lambda runtime to nodejs12.x and api lambda runtime to nodejs12.x " time="0.389">
+    </testcase>
+    <testcase classname="Custom inputs Lambda name input sets default lambda name to undefined and api lambda name to undefined " name="Custom inputs Lambda name input sets default lambda name to undefined and api lambda name to undefined " time="0.39">
+    </testcase>
+    <testcase classname="Custom inputs Lambda name input sets default lambda name to undefined and api lambda name to undefined " name="Custom inputs Lambda name input sets default lambda name to undefined and api lambda name to undefined " time="0.368">
+    </testcase>
+    <testcase classname="Custom inputs Lambda name input sets default lambda name to fooFunction and api lambda name to undefined " name="Custom inputs Lambda name input sets default lambda name to fooFunction and api lambda name to undefined " time="0.427">
+    </testcase>
+    <testcase classname="Custom inputs Lambda name input sets default lambda name to undefined and api lambda name to fooFunction " name="Custom inputs Lambda name input sets default lambda name to undefined and api lambda name to fooFunction " time="0.37">
+    </testcase>
+    <testcase classname="Custom inputs Lambda name input sets default lambda name to fooFunction and api lambda name to barFunction " name="Custom inputs Lambda name input sets default lambda name to fooFunction and api lambda name to barFunction " time="0.394">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.376">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.385">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.417">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.341">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.372">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.367">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.409">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.414">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.383">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.378">
+    </testcase>
+    <testcase classname="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" name="Custom inputs Custom cloudfront inputs Sets cloudfront options if present" time="0.361">
+    </testcase>
+    <testcase classname="Custom inputs API cloudfront inputs allows setting custom cache behavior: {&quot;api&quot;:{&quot;minTTL&quot;:100,&quot;maxTTL&quot;:100,&quot;defaultTTL&quot;:100}}" name="Custom inputs API cloudfront inputs allows setting custom cache behavior: {&quot;api&quot;:{&quot;minTTL&quot;:100,&quot;maxTTL&quot;:100,&quot;defaultTTL&quot;:100}}" time="0.393">
+    </testcase>
+    <testcase classname="Custom inputs API cloudfront inputs allows setting custom cache behavior: {&quot;api/test&quot;:{&quot;minTTL&quot;:100,&quot;maxTTL&quot;:100,&quot;defaultTTL&quot;:100}}" name="Custom inputs API cloudfront inputs allows setting custom cache behavior: {&quot;api/test&quot;:{&quot;minTTL&quot;:100,&quot;maxTTL&quot;:100,&quot;defaultTTL&quot;:100}}" time="0.393">
+    </testcase>
+    <testcase classname="Custom inputs API cloudfront inputs allows setting custom cache behavior: {&quot;api/*&quot;:{&quot;minTTL&quot;:100,&quot;maxTTL&quot;:100,&quot;defaultTTL&quot;:100}}" name="Custom inputs API cloudfront inputs allows setting custom cache behavior: {&quot;api/*&quot;:{&quot;minTTL&quot;:100,&quot;maxTTL&quot;:100,&quot;defaultTTL&quot;:100}}" time="0.381">
+    </testcase>
+    <testcase classname="Custom inputs Build using serverless trace target builds correctly" name="Custom inputs Build using serverless trace target builds correctly" time="0.397">
+    </testcase>
+    <testcase classname="Custom inputs Skip deployment after build builds but skips deployment" name="Custom inputs Skip deployment after build builds but skips deployment" time="0.373">
+    </testcase>
+    <testcase classname="Custom inputs Skip deployment after build builds but skips deployment" name="Custom inputs Skip deployment after build builds but skips deployment" time="0.375">
+    </testcase>
+    <testcase classname="Custom inputs Lambda handler input sets handler to index.handler and api lambda handler to index.handler" name="Custom inputs Lambda handler input sets handler to index.handler and api lambda handler to index.handler" time="0.385">
+    </testcase>
+    <testcase classname="Custom inputs Lambda handler input sets handler to customHandler.handler and api lambda handler to customHandler.handler" name="Custom inputs Lambda handler input sets handler to customHandler.handler and api lambda handler to customHandler.handler" time="0.378">
+    </testcase>
+    <testcase classname="Custom inputs Miscellaneous CloudFront inputs sets custom comment" name="Custom inputs Miscellaneous CloudFront inputs sets custom comment" time="0.367">
+    </testcase>
+    <testcase classname="Custom inputs Miscellaneous CloudFront inputs sets web ACL id for AWS WAF" name="Custom inputs Miscellaneous CloudFront inputs sets web ACL id for AWS WAF" time="0.376">
+    </testcase>
+    <testcase classname="Custom inputs Miscellaneous CloudFront inputs sets restrictions" name="Custom inputs Miscellaneous CloudFront inputs sets restrictions" time="0.387">
+    </testcase>
+    <testcase classname="Custom inputs Miscellaneous CloudFront inputs sets certificate with an ACM ARN" name="Custom inputs Miscellaneous CloudFront inputs sets certificate with an ACM ARN" time="0.394">
+    </testcase>
+    <testcase classname="Custom inputs Miscellaneous CloudFront inputs sets certificate with an IAM certificate" name="Custom inputs Miscellaneous CloudFront inputs sets certificate with an IAM certificate" time="0.402">
+    </testcase>
+    <testcase classname="Custom inputs Miscellaneous CloudFront inputs sets certificate to default" name="Custom inputs Miscellaneous CloudFront inputs sets certificate to default" time="0.391">
+    </testcase>
+    <testcase classname="Custom inputs Miscellaneous CloudFront inputs sets invalidation paths" name="Custom inputs Miscellaneous CloudFront inputs sets invalidation paths" time="0.39">
+    </testcase>
+    <testcase classname="Custom inputs Miscellaneous CloudFront inputs skips invalidation" name="Custom inputs Miscellaneous CloudFront inputs skips invalidation" time="0.37">
+    </testcase>
+    <testcase classname="Custom inputs SQS inputs sets sqs inputs including name and tags" name="Custom inputs SQS inputs sets sqs inputs including name and tags" time="0.286">
+    </testcase>
+  </testsuite>
+  <testsuite name="deploy tests (without ISR)" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:40:07" time="8.089" tests="19">
+    <testcase classname="deploy tests (without ISR) outputs next application url from cloudfront" name="deploy tests (without ISR) outputs next application url from cloudfront" time="0.402">
+    </testcase>
+    <testcase classname="deploy tests (without ISR) outputs S3 bucket name" name="deploy tests (without ISR) outputs S3 bucket name" time="0.407">
+    </testcase>
+    <testcase classname="deploy tests (without ISR) cloudfront provisions default lambda" name="deploy tests (without ISR) cloudfront provisions default lambda" time="0.399">
+    </testcase>
+    <testcase classname="deploy tests (without ISR) cloudfront provisions api lambda" name="deploy tests (without ISR) cloudfront provisions api lambda" time="0.415">
+    </testcase>
+    <testcase classname="deploy tests (without ISR) cloudfront provisions image lambda" name="deploy tests (without ISR) cloudfront provisions image lambda" time="0.412">
+    </testcase>
+    <testcase classname="deploy tests (without ISR) cloudfront creates distribution" name="deploy tests (without ISR) cloudfront creates distribution" time="0.394">
+    </testcase>
+    <testcase classname="deploy tests (without ISR) cloudfront invalidates distribution cache" name="deploy tests (without ISR) cloudfront invalidates distribution cache" time="0.395">
+    </testcase>
+    <testcase classname="deploy tests (without ISR) cloudfront does not remove old versions of lambda functions by default" name="deploy tests (without ISR) cloudfront does not remove old versions of lambda functions by default" time="0.455">
+    </testcase>
+    <testcase classname="deploy tests (without ISR) uploads static assets to S3 correctly" name="deploy tests (without ISR) uploads static assets to S3 correctly" time="0.374">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) outputs next application url from cloudfront" name="deploy tests (with ISR) outputs next application url from cloudfront" time="0.388">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) outputs S3 bucket name" name="deploy tests (with ISR) outputs S3 bucket name" time="0.401">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) cloudfront provisions regeneration lambda" name="deploy tests (with ISR) cloudfront provisions regeneration lambda" time="0.406">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) cloudfront provisions default lambda" name="deploy tests (with ISR) cloudfront provisions default lambda" time="0.405">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) cloudfront provisions api lambda" name="deploy tests (with ISR) cloudfront provisions api lambda" time="0.394">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) cloudfront provisions image lambda" name="deploy tests (with ISR) cloudfront provisions image lambda" time="0.404">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) cloudfront creates distribution" name="deploy tests (with ISR) cloudfront creates distribution" time="0.431">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) cloudfront invalidates distribution cache" name="deploy tests (with ISR) cloudfront invalidates distribution cache" time="0.51">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) cloudfront does not remove old versions of lambda functions by default" name="deploy tests (with ISR) cloudfront does not remove old versions of lambda functions by default" time="0.404">
+    </testcase>
+    <testcase classname="deploy tests (with ISR) uploads static assets to S3 correctly" name="deploy tests (with ISR) uploads static assets to S3 correctly" time="0.386">
+    </testcase>
+  </testsuite>
+  <testsuite name="Initialize tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:40:15" time="2.779" tests="2">
+    <testcase classname="Initialize tests sets stack trace limit" name="Initialize tests sets stack trace limit" time="0">
+    </testcase>
+    <testcase classname="Initialize tests sets AWS config correctly" name="Initialize tests sets AWS config correctly" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="Post-build tests" errors="0" failures="0" skipped="0" timestamp="2022-04-08T17:40:18" time="0.296" tests="2">
+    <testcase classname="Post-build tests executes post-build command successfully" name="Post-build tests executes post-build command successfully" time="0.054">
+    </testcase>
+    <testcase classname="Post-build tests fails to execute post-build command" name="Post-build tests fails to execute post-build command" time="0.047">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "clean": "lerna run clean",
     "docs": "cd documentation && yarn && yarn build",
     "handlers:upload-handler-sizes": "ts-node scripts/upload-handler-sizes.ts",
-    "handlers:comment-handler-sizes": "ts-node scripts/comment-handler-sizes.ts"
+    "handlers:comment-handler-sizes": "ts-node scripts/comment-handler-sizes.ts",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The CDK construct creates a new instance of `S3Origin` for each behavior. Since all behaviors point to the same bucket, this can be consolidated to one instance of `S3Origin`, which makes things cleaner and easier to see in the AWS Console after the CloudFront distribution has been deployed.

Also, some code was reformatted based on ESLint rules.