### PR TITLE
Handle V2, fix logging error when S3 permissions are not granted 

### DIFF
--- a/packages/libs/aws-common/src/awsPlatformClient.ts
+++ b/packages/libs/aws-common/src/awsPlatformClient.ts
@@ -62,7 +62,7 @@ export class AwsPlatformClient implements PlatformClient {
 
       console.info(
         "Got error response from S3. Will default to returning empty response. Error: " +
-          JSON.stringify(e)
+          e
       );
       return {
         body: undefined,


### PR DESCRIPTION
To reproduce:
 - set `useV2Handle: true` in `serverless.yml`
 - make sure the permission of the default lambda miss the `s3:GetObject` permission 
 - run the default lambda using `getStaticProps`
 Error is
 ```js
 {
    "errorType": "TypeError",
    "errorMessage": "Converting circular structure to JSON\n    --> starting at object with constructor 'IncomingMessage'\n    |     property 'req' -> object with constructor 'ClientRequest'\n    --- property 'res' closes the circle",
    "stack": [
        "TypeError: Converting circular structure to JSON",
        "    --> starting at object with constructor 'IncomingMessage'",
        "    |     property 'req' -> object with constructor 'ClientRequest'",
        "    --- property 'res' closes the circle",
        "    at JSON.stringify (<anonymous>)",
        "    at AwsPlatformClient.getObject (/var/task/default-handler-v2-fe969e74.js:102744:22)",
        "    at processTicksAndRejections (internal/process/task_queues.js:95:5)",
        "    at async staticRequest (/var/task/default-handler-v2-fe969e74.js:83675:26)",
        "    at async defaultHandler (/var/task/default-handler-v2-fe969e74.js:83851:16)",
        "    at async Runtime.handler (/var/task/default-handler-v2-fe969e74.js:102901:5)"
    ]
}
```

This PR prevent the API from returning `503` response. 