### PR TITLE
feat(nextjs-cdk-construct): add optional prop to override API Lambda role

### DIFF
--- a/documentation/docs/cdkconstruct.md
+++ b/documentation/docs/cdkconstruct.md
@@ -104,3 +104,4 @@ new NextJSLambdaEdge(this, "NextJsApp", {
 - `nextStaticsCachePolicy?: CachePolicy;`: configure the CloudFront cache policy used for static resources
 - `nextImageCachePolicy?: CachePolicy;`: configure the CloudFront cache policy used for image caching
 - `nextLambdaCachePolicy?: CachePolicy;`: configure the CloudFront cache policy used for Lambda functions
+- `nextApiLambdaRole?: iam.Role;`: provide an override IAM role to attach to the API edge lambda. The default role will be replaced so you need to ensure the lambda obtains the same level of minimum permissions [granted by the default role](https://github.com/serverless-nextjs/serverless-next.js#aws-permissions) to execute correctly.

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.0-alpha.0",
+  "version": "3.8.0-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/serverless-components/nextjs-cdk-construct/package.json
+++ b/packages/serverless-components/nextjs-cdk-construct/package.json
@@ -4,7 +4,7 @@
     "access": "public"
   },
   "description": "Serverless Next.js powered by AWS CDK",
-  "version": "3.8.0-alpha.0",
+  "version": "3.8.0-alpha.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Henry Kirkness <henry@planes.studio>",

--- a/packages/serverless-components/nextjs-cdk-construct/src/index.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/index.ts
@@ -137,9 +137,11 @@ export class NextJSLambdaEdge extends Construct {
           runtime:
             toLambdaOption("regenerationLambda", props.runtime) ??
             lambda.Runtime.NODEJS_14_X,
-          memorySize: toLambdaOption("regenerationLambda", props.memory) ?? undefined,
+          memorySize:
+            toLambdaOption("regenerationLambda", props.memory) ?? undefined,
           timeout:
-            toLambdaOption("regenerationLambda", props.timeout) ?? Duration.seconds(30)
+            toLambdaOption("regenerationLambda", props.timeout) ??
+            Duration.seconds(30)
         }
       );
 
@@ -197,7 +199,9 @@ export class NextJSLambdaEdge extends Construct {
         code: lambda.Code.fromAsset(
           path.join(this.props.serverlessBuildOutDir, "api-lambda")
         ),
-        role: this.edgeLambdaRole,
+        role:
+          toLambdaOption("apiLambda", props.nextApiLambdaRole) ??
+          this.edgeLambdaRole,
         runtime:
           toLambdaOption("apiLambda", props.runtime) ??
           lambda.Runtime.NODEJS_12_X,
@@ -245,8 +249,7 @@ export class NextJSLambdaEdge extends Construct {
         minTtl: Duration.days(30),
         enableAcceptEncodingBrotli: true,
         enableAcceptEncodingGzip: true
-      }
-    );
+      });
 
     this.nextImageCachePolicy =
       props.nextImageCachePolicy ||
@@ -260,8 +263,7 @@ export class NextJSLambdaEdge extends Construct {
         minTtl: Duration.days(0),
         enableAcceptEncodingBrotli: true,
         enableAcceptEncodingGzip: true
-      }
-    );
+      });
 
     this.nextLambdaCachePolicy =
       props.nextLambdaCachePolicy ||
@@ -282,8 +284,7 @@ export class NextJSLambdaEdge extends Construct {
         minTtl: Duration.seconds(0),
         enableAcceptEncodingBrotli: true,
         enableAcceptEncodingGzip: true
-      }
-    );
+      });
 
     const edgeLambdas: cloudfront.EdgeLambda[] = [
       {
@@ -408,8 +409,11 @@ export class NextJSLambdaEdge extends Construct {
 
     const assetsDirectory = path.join(props.serverlessBuildOutDir, "assets");
     const { basePath } = this.routesManifest || {};
-    const normalizedBasePath = basePath && basePath.length > 0 ? basePath.slice(1) : "";
-    const assets = readAssetsDirectory({ assetsDirectory: path.join(assetsDirectory, normalizedBasePath) });
+    const normalizedBasePath =
+      basePath && basePath.length > 0 ? basePath.slice(1) : "";
+    const assets = readAssetsDirectory({
+      assetsDirectory: path.join(assetsDirectory, normalizedBasePath)
+    });
 
     // This `BucketDeployment` deploys just the BUILD_ID file. We don't actually
     // use the BUILD_ID file at runtime, however in this case we use it as a

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -1,9 +1,14 @@
 import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
-import { BehaviorOptions, DistributionProps, CachePolicy } from "aws-cdk-lib/aws-cloudfront";
+import {
+  BehaviorOptions,
+  DistributionProps,
+  CachePolicy
+} from "aws-cdk-lib/aws-cloudfront";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { IHostedZone } from "aws-cdk-lib/aws-route53";
 import { BucketProps } from "aws-cdk-lib/aws-s3";
 import { Duration, StackProps } from "aws-cdk-lib";
+import { Role } from "aws-cdk-lib/aws-iam";
 
 export type LambdaOption<T> =
   | T
@@ -129,4 +134,9 @@ export interface Props extends StackProps {
    * Override cache policy used for Lambda
    */
   nextLambdaCachePolicy?: CachePolicy;
+
+  /**
+   * Override IAM role attached to API Lambda
+   */
+  nextApiLambdaRole?: Role;
 }


### PR DESCRIPTION
Add an optional prop to the `NextJsLambdaEdge` CDK construct to override the IAM role that is attached to it. This can be useful as sometimes it's desirable to give the Nextjs API backend the ability to interact with other AWS resources such as DynamoDB.