### PR TITLE
fix: [Issue-2437] Rewrites should support special symbols in dynamic routes

### DIFF
--- a/packages/libs/core/src/match.ts
+++ b/packages/libs/core/src/match.ts
@@ -32,7 +32,7 @@ export function compileDestination(
     ) {
       // Handle external URL redirects
       const { origin, pathname, search } = new URL(destination);
-      const toPath = compile(pathname);
+      const toPath = compile(pathname, { encode: encodeURI });
       const compiledDestination = `${origin}${toPath(params)}${search}`;
 
       // Remove trailing slash if original destination didn't have it
@@ -44,7 +44,9 @@ export function compileDestination(
     } else {
       // Handle all other paths. Escape all ? in case of query parameters
       const escapedDestination = destination.replace(/\?/g, "\\?");
-      const toPath = compile(escapedDestination);
+      const toPath = compile(escapedDestination, {
+        encode: encodeURI
+      });
       return toPath(params);
     }
   } catch (error) {

--- a/packages/libs/core/src/match.ts
+++ b/packages/libs/core/src/match.ts
@@ -32,7 +32,7 @@ export function compileDestination(
     ) {
       // Handle external URL redirects
       const { origin, pathname, search } = new URL(destination);
-      const toPath = compile(pathname, { encode: encodeURIComponent });
+      const toPath = compile(pathname);
       const compiledDestination = `${origin}${toPath(params)}${search}`;
 
       // Remove trailing slash if original destination didn't have it
@@ -44,9 +44,7 @@ export function compileDestination(
     } else {
       // Handle all other paths. Escape all ? in case of query parameters
       const escapedDestination = destination.replace(/\?/g, "\\?");
-      const toPath = compile(escapedDestination, {
-        encode: encodeURIComponent
-      });
+      const toPath = compile(escapedDestination);
       return toPath(params);
     }
   } catch (error) {

--- a/packages/libs/core/src/route/rewrite.ts
+++ b/packages/libs/core/src/route/rewrite.ts
@@ -35,7 +35,7 @@ export function getRewritePath(
     }
 
     // No-op rewrite support for pages: skip to next rewrite if path does not map to existing non-dynamic and dynamic routes
-    if (pageManifest && path === destination) {
+    if (pageManifest && path === decodeURI(destination)) {
       const url = handlePageReq(
         req,
         destination,

--- a/packages/libs/core/tests/match.test.ts
+++ b/packages/libs/core/tests/match.test.ts
@@ -52,6 +52,14 @@ describe("Matcher Tests", () => {
       expect(match).toEqual("/about/123/456");
     });
 
+    it("compiles destination with special symbols", () => {
+      const match = compileDestination("/about/:a/:b", {
+        a: "@aaa@",
+        b: "=bbb="
+      });
+      expect(match).toEqual("/about/@aaa@/=bbb=");
+    });
+
     it("compiles http URL", () => {
       const match = compileDestination("http://example.com", {});
       expect(match).toEqual("http://example.com");

--- a/packages/libs/core/tests/match.test.ts
+++ b/packages/libs/core/tests/match.test.ts
@@ -52,14 +52,6 @@ describe("Matcher Tests", () => {
       expect(match).toEqual("/about/123/456");
     });
 
-    it("compiles destination with special symbols", () => {
-      const match = compileDestination("/about/:a/:b", {
-        a: "@aaa@",
-        b: "=bbb="
-      });
-      expect(match).toEqual("/about/@aaa@/=bbb=");
-    });
-
     it("compiles http URL", () => {
       const match = compileDestination("http://example.com", {});
       expect(match).toEqual("http://example.com");
@@ -90,6 +82,41 @@ describe("Matcher Tests", () => {
     it("invalid destination returns null", () => {
       const match = compileDestination("abc://123", {});
       expect(match).toBeNull();
+    });
+
+    it("compiles not ASCII url for external rewrite", () => {
+      const externalMatch = compileDestination("https://пример.ру/:ru/:en", {
+        ru: "ру-ру",
+        en: "en-en"
+      });
+      expect(externalMatch).toEqual(
+        "https://xn--e1afmkfd.xn--p1ag/%D1%80%D1%83-%D1%80%D1%83/en-en"
+      );
+    });
+
+    it("compiles not ASCII url for internal rewrite", () => {
+      const internalMatch = compileDestination("/example/:ru/:en", {
+        ru: "ру-ру",
+        en: "en-en"
+      });
+      expect(internalMatch).toEqual("/example/%D1%80%D1%83-%D1%80%D1%83/en-en");
+    });
+
+    it("compiles url with allowed symbols for external rewrite", () => {
+      const externalMatch = compileDestination(
+        "https://example.com/users/:userid",
+        {
+          userid: "@testuser="
+        }
+      );
+      expect(externalMatch).toEqual("https://example.com/users/@testuser=");
+    });
+
+    it("compiles url with allowed symbols for internal rewrite", () => {
+      const externalMatch = compileDestination("/users/:userid", {
+        userid: "@testuser="
+      });
+      expect(externalMatch).toEqual("/users/@testuser=");
     });
   });
 });

--- a/packages/libs/core/tests/route/rewrite.test.ts
+++ b/packages/libs/core/tests/route/rewrite.test.ts
@@ -1,123 +1,241 @@
 import { getRewritePath, isExternalRewrite } from "../../src/route/rewrite";
 import { PageManifest, RoutesManifest } from "../../src/types";
 
+const buildPageManifest = ({
+  dynamic = [],
+  html = {
+    dynamic: {},
+    nonDynamic: {}
+  },
+  ssg = {
+    dynamic: {},
+    nonDynamic: {},
+    notFound: {}
+  },
+  ssr = {
+    dynamic: {},
+    nonDynamic: {}
+  }
+}: Partial<PageManifest["pages"]> = {}): PageManifest => {
+  return {
+    publicFiles: {},
+    trailingSlash: false,
+    buildId: "test-build-id",
+    pages: {
+      dynamic,
+      html,
+      ssg,
+      ssr
+    },
+    domainRedirects: {},
+    hasApiPages: false
+  };
+};
+
+const buildRoutesManifest = ({
+  rewrites = []
+}: { rewrites?: RoutesManifest["rewrites"] } = {}): RoutesManifest => {
+  return {
+    rewrites,
+    basePath: "",
+    headers: [],
+    redirects: []
+  };
+};
+
 describe("Rewriter Tests", () => {
   describe("getRewritePath()", () => {
-    let routesManifest: RoutesManifest;
-    let pageManifest: PageManifest;
+    describe("basic rewrites", () => {
+      let routesManifest: RoutesManifest;
+      let pageManifest: PageManifest;
 
-    beforeAll(() => {
-      routesManifest = {
-        basePath: "",
-        headers: [],
-        rewrites: [
-          {
-            source: "/old-blog/:slug",
-            destination: "/news/:slug"
-          },
-          { source: "/a", destination: "/b" },
-          {
-            source: "/:nextInternalLocale(en|nl|fr)/a",
-            destination: "/:nextInternalLocale/b"
-          },
-          { source: "/c", destination: "/d" },
-          {
-            source: "/old-users/:id(\\d{1,})",
-            destination: "/users/:id"
-          },
-          {
-            source: "/external",
-            destination: "https://example.com"
-          },
-          {
-            source: "/external-http",
-            destination: "http://example.com"
-          },
-          {
-            source: "/invalid-destination",
-            destination: "ftp://example.com"
-          },
-          {
-            source: "/query/:path",
-            destination: "/target?a=b"
-          },
-          {
-            source: "/manual-query/:path",
-            destination: "/target?key=:path"
-          },
-          {
-            source: "/multi-query/:path*",
-            destination: "/target"
-          },
-          {
-            source: "/no-op-rewrite",
-            destination: "/no-op-rewrite"
-          },
-          {
-            source: "/no-op-rewrite",
-            destination: "/actual-no-op-rewrite-destination"
-          }
-        ],
-        redirects: []
-      };
+      beforeAll(() => {
+        routesManifest = buildRoutesManifest({
+          rewrites: [
+            {
+              source: "/old-blog/:slug",
+              destination: "/news/:slug"
+            },
+            { source: "/a", destination: "/b" },
+            {
+              source: "/:nextInternalLocale(en|nl|fr)/a",
+              destination: "/:nextInternalLocale/b"
+            },
+            { source: "/c", destination: "/d" },
+            {
+              source: "/old-users/:id(\\d{1,})",
+              destination: "/users/:id"
+            },
+            {
+              source: "/external",
+              destination: "https://example.com"
+            },
+            {
+              source: "/external-http",
+              destination: "http://example.com"
+            },
+            {
+              source: "/invalid-destination",
+              destination: "ftp://example.com"
+            },
+            {
+              source: "/query/:path",
+              destination: "/target?a=b"
+            },
+            {
+              source: "/manual-query/:path",
+              destination: "/target?key=:path"
+            },
+            {
+              source: "/multi-query/:path*",
+              destination: "/target"
+            },
+            {
+              source: "/no-op-rewrite",
+              destination: "/no-op-rewrite"
+            },
+            {
+              source: "/no-op-rewrite",
+              destination: "/actual-no-op-rewrite-destination"
+            }
+          ]
+        });
 
-      pageManifest = {
-        publicFiles: {},
-        trailingSlash: false,
-        buildId: "test-build-id",
-        pages: {
-          dynamic: [],
-          html: {
-            dynamic: {},
-            nonDynamic: {}
-          },
-          ssg: {
-            dynamic: {},
-            nonDynamic: {},
-            notFound: {}
-          },
-          ssr: {
-            dynamic: {},
-            nonDynamic: {}
+        pageManifest = buildPageManifest();
+      });
+
+      it.each`
+        path                      | expectedRewrite
+        ${"/a"}                   | ${"/b"}
+        ${"/c"}                   | ${"/d"}
+        ${"/old-blog/abc"}        | ${"/news/abc"}
+        ${"/old-users/1234"}      | ${"/users/1234"}
+        ${"/old-users/abc"}       | ${undefined}
+        ${"/external"}            | ${"https://example.com"}
+        ${"/external-http"}       | ${"http://example.com"}
+        ${"/invalid-destination"} | ${undefined}
+        ${"/en/a"}                | ${"/en/b"}
+        ${"/fr/a"}                | ${"/fr/b"}
+        ${"/query/foo"}           | ${"/target?a=b&path=foo"}
+        ${"/manual-query/foo"}    | ${"/target?key=foo"}
+        ${"/multi-query/foo/bar"} | ${"/target?path=foo&path=bar"}
+        ${"/no-op-rewrite"}       | ${"/actual-no-op-rewrite-destination"}
+      `(
+        "rewrites path $path to $expectedRewrite",
+        ({ path, expectedRewrite }) => {
+          const req = {
+            headers: {
+              host: [{ key: "Host", value: "next-serverless.com" }]
+            },
+            uri: path
+          };
+          const rewrite = getRewritePath(
+            req,
+            path,
+            routesManifest,
+            pageManifest
+          );
+
+          if (expectedRewrite) {
+            expect(rewrite).toEqual(expectedRewrite);
+          } else {
+            expect(rewrite).toBeUndefined();
           }
         }
-      };
+      );
     });
 
-    it.each`
-      path                      | expectedRewrite
-      ${"/a"}                   | ${"/b"}
-      ${"/c"}                   | ${"/d"}
-      ${"/old-blog/abc"}        | ${"/news/abc"}
-      ${"/old-users/1234"}      | ${"/users/1234"}
-      ${"/old-users/abc"}       | ${undefined}
-      ${"/external"}            | ${"https://example.com"}
-      ${"/external-http"}       | ${"http://example.com"}
-      ${"/invalid-destination"} | ${undefined}
-      ${"/en/a"}                | ${"/en/b"}
-      ${"/fr/a"}                | ${"/fr/b"}
-      ${"/query/foo"}           | ${"/target?a=b&path=foo"}
-      ${"/manual-query/foo"}    | ${"/target?key=foo"}
-      ${"/multi-query/foo/bar"} | ${"/target?path=foo&path=bar"}
-      ${"/no-op-rewrite"}       | ${"/actual-no-op-rewrite-destination"}
-    `(
-      "rewrites path $path to $expectedRewrite",
-      ({ path, expectedRewrite }) => {
-        const req = {
-          headers: {
-            host: [{ key: "Host", value: "next-serverless.com" }]
+    describe("fallback rewrites simulation", () => {
+      const externalApp = "https://example.com";
+      const routesManifest = buildRoutesManifest({
+        rewrites: [
+          {
+            source: "/:path*",
+            destination: "/:path*"
           },
-          uri: path
-        };
-        const rewrite = getRewritePath(req, path, routesManifest, pageManifest);
+          {
+            source: "/:path*",
+            destination: `${externalApp}/:path*`
+          }
+        ]
+      });
 
-        if (expectedRewrite) {
-          expect(rewrite).toEqual(expectedRewrite);
-        } else {
-          expect(rewrite).toBeUndefined();
+      // path, expectedRewrite, typeOfPage:
+      const cases: [string, string, "ssg" | "ssr" | "html"][] = [
+        // request for existing dynamic-route
+        [
+          "/dynamic-route/@slug-id=",
+          "/dynamic-route/@slug-id=?path=dynamic-route&path=@slug-id=",
+          "ssg"
+        ],
+        [
+          "/dynamic-route/@slug-id=",
+          "/dynamic-route/@slug-id=?path=dynamic-route&path=@slug-id=",
+          "ssr"
+        ],
+        [
+          "/dynamic-route/@slug-id=",
+          "/dynamic-route/@slug-id=?path=dynamic-route&path=@slug-id=",
+          "html"
+        ],
+        // request for not existing dynamic-route
+        [
+          "/not-existing/@slug-id=",
+          `${externalApp}/not-existing/@slug-id=?path=not-existing&path=@slug-id=`,
+          "ssg"
+        ],
+        [
+          "/not-existing/@slug-id=",
+          `${externalApp}/not-existing/@slug-id=?path=not-existing&path=@slug-id=`,
+          "ssr"
+        ],
+        [
+          "/not-existing/@slug-id=",
+          `${externalApp}/not-existing/@slug-id=?path=not-existing&path=@slug-id=`,
+          "html"
+        ]
+      ];
+
+      it.each(cases)(
+        "rewrites path: %p to %p when %p dynamic-route exists",
+        (path, expectedRewrite, typeOfPage) => {
+          const req = {
+            headers: {
+              host: [{ key: "Host", value: "next-serverless.com" }]
+            },
+            uri: path
+          };
+
+          const pageManifest = buildPageManifest({
+            dynamic: [
+              {
+                route: "/dynamic-route/[slug]",
+                regex: "^\\/dynamic\\-route(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$"
+              }
+            ],
+            [typeOfPage]: {
+              dynamic: {
+                "/dynamic-route/[slug]": "pages/dynamic-route/[slug].html"
+              },
+              nonDynamic: {}
+            }
+          });
+
+          const rewrite = getRewritePath(
+            req,
+            path,
+            routesManifest,
+            pageManifest
+          );
+
+          if (expectedRewrite) {
+            expect(rewrite).toEqual(expectedRewrite);
+          } else {
+            expect(rewrite).toBeUndefined();
+          }
         }
-      }
-    );
+      );
+    });
   });
 
   describe("isExternalRewrite()", () => {

--- a/packages/libs/core/tests/route/rewrite.test.ts
+++ b/packages/libs/core/tests/route/rewrite.test.ts
@@ -193,6 +193,39 @@ describe("Rewriter Tests", () => {
           "/not-existing/@slug-id=",
           `${externalApp}/not-existing/@slug-id=?path=not-existing&path=@slug-id=`,
           "html"
+        ],
+
+        // request for existing dynamic-route with non-ASCII chars
+        [
+          "/dynamic-route/пример",
+          "/dynamic-route/%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80?path=dynamic-route&path=пример",
+          "ssg"
+        ],
+        [
+          "/dynamic-route/пример",
+          "/dynamic-route/%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80?path=dynamic-route&path=пример",
+          "ssr"
+        ],
+        [
+          "/dynamic-route/пример",
+          "/dynamic-route/%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80?path=dynamic-route&path=пример",
+          "html"
+        ],
+        // request for not existing dynamic-route with non-ASCII chars
+        [
+          "/not-existing/пример",
+          `${externalApp}/not-existing/%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80?path=not-existing&path=пример`,
+          "ssg"
+        ],
+        [
+          "/not-existing/пример",
+          `${externalApp}/not-existing/%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80?path=not-existing&path=пример`,
+          "ssr"
+        ],
+        [
+          "/not-existing/пример",
+          `${externalApp}/not-existing/%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80?path=not-existing&path=пример`,
+          "html"
         ]
       ];
 


### PR DESCRIPTION
A proposal for fixing «Rewrites don't work with special symbols in a URL»
[Issue reference.](https://github.com/serverless-nextjs/serverless-next.js/issues/2437)

Summary of the issue: 
1. no-op rewrites don't work with paths that include symbols like `@` and `=`
2. external rewrites will build incorrect destination routes for paths that include symbols like `@` and `=`
all of the above works in the Next.js server

I followed the code and found no reason for using encoders in the rewrite mechanism.
the [next code](https://github.com/serverless-nextjs/serverless-next.js/blob/master/packages/libs/core/src/route/rewrite.ts#L26):
```
const match = matchPath(path, rewrite.source);
if (!match) {
  continue;
}
```
should prevent wrong path matching from the beginning.


Also, the [`compile` function](https://github.com/serverless-nextjs/serverless-next.js/compare/master...sleukhin:rewrites-with-special-symbols-in-dynamic-routes?expand=1#diff-b7d18047cd9bd1f67c726c2ff914a4e2ce5f543533d8b7a9653e124c067cb7f9R35) should not produce an invalid path since `validation` is enabled by default

@dphang  Am I missing something?