### PR TITLE
feat(nextjs-cdk-construct): add optional prop to extend lambda perms

### DIFF
--- a/documentation/docs/cdkconstruct.md
+++ b/documentation/docs/cdkconstruct.md
@@ -104,3 +104,4 @@ new NextJSLambdaEdge(this, "NextJsApp", {
 - `nextStaticsCachePolicy?: CachePolicy;`: configure the CloudFront cache policy used for static resources
 - `nextImageCachePolicy?: CachePolicy;`: configure the CloudFront cache policy used for image caching
 - `nextLambdaCachePolicy?: CachePolicy;`: configure the CloudFront cache policy used for Lambda functions
+- `nextLambdaExtraManagedPolicies?: ManagedPolicy[];`: provide an additional list of IAM Managed Policies to attach to the IAM role used by the SSR, ISR and API Next Lambdas.

--- a/packages/serverless-components/nextjs-cdk-construct/src/props.ts
+++ b/packages/serverless-components/nextjs-cdk-construct/src/props.ts
@@ -1,9 +1,14 @@
 import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
-import { BehaviorOptions, DistributionProps, CachePolicy } from "aws-cdk-lib/aws-cloudfront";
+import {
+  BehaviorOptions,
+  DistributionProps,
+  CachePolicy
+} from "aws-cdk-lib/aws-cloudfront";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { IHostedZone } from "aws-cdk-lib/aws-route53";
 import { BucketProps } from "aws-cdk-lib/aws-s3";
 import { Duration, StackProps } from "aws-cdk-lib";
+import { ManagedPolicy, Role } from "aws-cdk-lib/aws-iam";
 
 export type LambdaOption<T> =
   | T
@@ -129,4 +134,9 @@ export interface Props extends StackProps {
    * Override cache policy used for Lambda
    */
   nextLambdaCachePolicy?: CachePolicy;
+
+  /**
+   * List of additional IAM Managed Policies to append to the default Next Lambda roles
+   */
+  nextLambdaExtraManagedPolicies?: ManagedPolicy[];
 }


### PR DESCRIPTION
Add an optional prop to `NextJsLambdaEdge` Construct to attach a list of
IAM Managed Policies to the default lambda policy list. This allows
extending the privileges of the default, API and ISR Next lambdas so
they can interact with or fetch data from other AWS services, such as
DynamoDB.