### PR TITLE
fix: don't fallback on rendering the html when the page is not found

### DIFF
--- a/packages/libs/core/src/utils/renderUtils.ts
+++ b/packages/libs/core/src/utils/renderUtils.ts
@@ -47,7 +47,7 @@ export const renderPageToHtml = async (
     }
   }
 
-  if (!html) {
+  if (!html && !renderOpts.isNotFound) {
     console.log(
       "html is empty, falling back to using page's rendering function for html"
     );


### PR DESCRIPTION
Fixes #2427

When a dynamic page `getStaticProps` returns `{ "notFound": true }` the returned `html` from the pages `renderReqToHTML` will be null:

https://github.com/vercel/next.js/blob/b188fab3360855c28fd9407bd07c4ee9f5de16a6/packages/next/server/render.tsx#L969-L977

Internally Next.js Server deals with this in `renderReqToHTML` by explicitly setting the res.respond to `{ notFound: true }`

https://github.com/vercel/next.js/blob/b188fab3360855c28fd9407bd07c4ee9f5de16a6/packages/next/build/webpack/loaders/next-serverless-loader/page-handler.ts#L296-L320

To correctly mimic this behaviour in Next.JS v12 we should allow for a case where `html` is `null` by checking if the page `isNotFound`.  Later on in the fallback code the `res` is correctly set
https://github.com/serverless-nextjs/serverless-next.js/blob/master/packages/libs/core/src/handle/fallback.ts#L60-L66

Returning `undefined` here will cause the following branch to return from the default-handler causing the correct respons of `{ "notFound": true }`

https://github.com/serverless-nextjs/serverless-next.js/blob/master/packages/libs/lambda-at-edge/src/default-handler.ts#L427-L438

## Current Implementation
Because of the forced render of the HTML, Next.JS will write the 404 HTML to the `res` object and finalise it:

https://github.com/serverless-nextjs/serverless-next.js/blob/e6367b585fb98608cd2e9327e2c8d4058ba73b00/packages/libs/core/src/utils/renderUtils.ts#L50-L57

This causes the following code to have zero effect as the `res` is finalised and nothing can be written to it

https://github.com/serverless-nextjs/serverless-next.js/blob/master/packages/libs/core/src/handle/fallback.ts#L60-L66