### PR TITLE
Remove target config (#2477)

### DIFF
--- a/packages/libs/core/src/build/builder.ts
+++ b/packages/libs/core/src/build/builder.ts
@@ -105,8 +105,7 @@ export default abstract class CoreBuilder {
 
     const { restoreUserConfig } = await createServerlessConfig(
       cwd,
-      path.join(this.nextConfigDir),
-      false
+      path.join(this.nextConfigDir)
     );
 
     try {


### PR DESCRIPTION
`target` is no longer a supported configuration option in nextjs.

If you try to use a recent version of Nextjs with middleware this becomes a build error: https://github.com/serverless-nextjs/serverless-next.js/issues/2477

Perhaps we should remove the `useServerlessTraceTarget` option or just [assume it is true](https://nextjs.org/docs/advanced-features/output-file-tracing)?