### PR TITLE
Since custom handlers are not copied to the regeneration lambda, use the default handler and ignore the customer handler when building the regeneration lambda

### DIFF
--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -554,7 +554,7 @@ class NextjsComponent extends Component {
         description: inputs.description
           ? `${inputs.description} (Regeneration)`
           : "Next.js Regeneration Lambda",
-        handler: inputs.handler || "index.handler",
+        handler: "index.handler",
         code: join(nextConfigPath, REGENERATION_LAMBDA_CODE_DIR),
         role: readLambdaInputValue("roleArn", "regenerationLambda", undefined)
           ? {


### PR DESCRIPTION
When you use a custom `handler` option (mine is handler.js, so my config is `handler.handler`), the custom handler file gets copied to the default lambda and the image lambda, but not the regeneration lambda. However, the regeneration lambda still attempts to load the customer handler named in the options, and since that custom handler is not copied over, the regeneration lambda fails. This is the error I see:

```
{
    "errorType": "Runtime.ImportModuleError",
    "errorMessage": "Error: Cannot find module 'handler'\nRequire stack:\n- /var/runtime/UserFunction.js\n- /var/runtime/Runtime.js\n- /var/runtime/index.js",
    "stack": [
        "Runtime.ImportModuleError: Error: Cannot find module 'handler'",
        "Require stack:",
        "- /var/runtime/UserFunction.js",
        "- /var/runtime/Runtime.js",
        "- /var/runtime/index.js",
        "    at _loadUserApp (/var/runtime/UserFunction.js:221:13)",
        "    at Object.module.exports.load (/var/runtime/UserFunction.js:279:17)",
        "    at Object.<anonymous> (/var/runtime/index.js:43:34)",
        "    at Module._compile (internal/modules/cjs/loader.js:1085:14)",
        "    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)",
        "    at Module.load (internal/modules/cjs/loader.js:950:32)",
        "    at Function.Module._load (internal/modules/cjs/loader.js:790:12)",
        "    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:75:12)",
        "    at internal/main/run_main_module.js:17:47"
    ]
}
```

Here's another person experiencing the same issue:
https://github.com/serverless-nextjs/serverless-next.js/issues/1098#issuecomment-873509152

This PR  use the default handler name and ignores the custom handler when building the regeneration lambda.