### PR TITLE
Fix passing etag arg as last modified header, prefer last modified if present as message deduplication id

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -386,7 +386,7 @@ const handleOriginResponse = async ({
           request,
           pageS3Path: s3Uri,
           eTag: response.headers["etag"]?.[0].value,
-          lastModified: response.headers["etag"]?.[0].value,
+          lastModified: response.headers["last-modified"]?.[0].value,
           pagePath: staticRoute.page,
           queueName: regenerationQueueName
         });

--- a/packages/libs/lambda-at-edge/src/lib/triggerStaticRegeneration.ts
+++ b/packages/libs/lambda-at-edge/src/lib/triggerStaticRegeneration.ts
@@ -57,11 +57,9 @@ export const triggerStaticRegeneration = async (
         // We only want to trigger the regeneration once for every previous
         // update. This will prevent the case where this page is being
         // requested again whilst its already started to regenerate.
-        MessageDeduplicationId:
-          options.eTag ??
-          (options.lastModified
-            ? new Date(options.lastModified).getTime().toString()
-            : new Date().getTime().toString()),
+        MessageDeduplicationId: options.lastModified
+          ? new Date(options.lastModified).getTime().toString()
+          : options.eTag ?? new Date().getTime().toString(),
         // Only deduplicate based on the object, i.e. we can generate
         // different pages in parallel, just not the same one
         MessageGroupId: hashedUri

--- a/packages/libs/lambda-at-edge/tests/utils/triggerStaticRegeneration.test.ts
+++ b/packages/libs/lambda-at-edge/tests/utils/triggerStaticRegeneration.test.ts
@@ -90,9 +90,9 @@ describe("triggerStaticRegeneration()", () => {
   });
 
   it.each`
-    lastModified                  | etag         | expected
-    ${"2021-05-05T17:15:04.472Z"} | ${"tag"}     | ${"tag"}
-    ${"2021-05-05T17:15:04.472Z"} | ${undefined} | ${"1620234904472"}
+    lastModified                  | etag     | expected
+    ${"2021-05-05T17:15:04.472Z"} | ${"tag"} | ${"1620234904472"}
+    ${undefined}                  | ${"tag"} | ${"tag"}
   `(
     "should throttle send correct parameters to the queue",
     async ({ lastModified, etag, expected }) => {


### PR DESCRIPTION
ISR enabled pages does not always get fresh content because of SQS message deduplication id set to ETag of the object (previously generated static page HTML file) stored in S3. Here is the scenario where `revalidate` option is set to `1`:

1. Open the page, see regeneration happened and page content updated in S3 (assuming previously generated content was different or 5-min elapsed)
2. Update page content (i.e. modify the DB records that are used to build the page)
3. Wait for `revalidate` seconds
4. Open the same page again, see regeneration is being triggered by the default Lambda, but is not picked by regeneration Lambda as SQS message deduplication id (ETag of page HTML file in S3) is exactly same as previous message. 

So in this case we have to wait for 5 minutes which is [SQS message deduplication interval](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html). This PR will attempt to use last modified header instead, so that even if the page content is same, it's last modified date will be different (i.e. newer) therefore regeneration will happen.