### PR TITLE
Return res object to allow method chaining on res.setHeader

### DIFF
--- a/packages/compat-layers/lambda-at-edge-compat/__tests__/next-aws-cloudfront.response.test.js
+++ b/packages/compat-layers/lambda-at-edge-compat/__tests__/next-aws-cloudfront.response.test.js
@@ -191,8 +191,7 @@ describe("Response Tests", () => {
       }
     });
 
-    res.setHeader("set-cookie", ["1", "2"]);
-    res.end();
+    res.setHeader("set-cookie", ["1", "2"]).end();
 
     return responsePromise.then((response) => {
       expect(response.headers).toEqual({

--- a/packages/compat-layers/lambda-at-edge-compat/next-aws-cloudfront.js
+++ b/packages/compat-layers/lambda-at-edge-compat/next-aws-cloudfront.js
@@ -277,6 +277,7 @@ const handler = (
   res.setHeader = (name, value) => {
     res.headers[name.toLowerCase()] = value;
     headerNames[name.toLowerCase()] = name;
+    return res;
   };
   res.removeHeader = (name) => {
     delete res.headers[name.toLowerCase()];


### PR DESCRIPTION
Addresses issue #2332 

Next.js allows method chaining on `setHeader`