### PR TITLE
fix: locale in homepage with query params

### DIFF
--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
@@ -75,6 +75,12 @@ describe("Pages Tests", () => {
         }
       );
     });
+
+    it("serves SSR homepage with query params with right locale", () => {
+      cy.visit("/fr?foo=bar");
+
+      cy.get("[data-cy=locale]").contains("fr");
+    });
   });
 
   describe("SSG pages", () => {

--- a/packages/e2e-tests/next-app-with-locales/pages/index.tsx
+++ b/packages/e2e-tests/next-app-with-locales/pages/index.tsx
@@ -24,7 +24,7 @@ export default function IndexPage(props: IndexPageProps): JSX.Element {
   );
 }
 
-export function getStaticProps(): { props: IndexPageProps } {
+export function getServerSideProps(): { props: IndexPageProps } {
   return {
     props: { name: "serverless-next.js" }
   };

--- a/packages/libs/core/src/route/locale.ts
+++ b/packages/libs/core/src/route/locale.ts
@@ -49,6 +49,10 @@ export const findDomainLocale = (
   return null;
 };
 
+function getPathName(lowerCase: string): string {
+  return lowerCase.split("?", 2)[0];
+}
+
 export function addDefaultLocaleToPath(
   path: string,
   routesManifest: RoutesManifest,
@@ -63,11 +67,11 @@ export function addDefaultLocaleToPath(
       : "";
 
     // If prefixed with a locale, return that path with normalized locale
-    const pathLowerCase = path.toLowerCase();
+    const pathNameLowerCased = getPathName(path.toLowerCase());
     for (const locale of locales) {
       if (
-        pathLowerCase === `${basePath}/${locale}`.toLowerCase() ||
-        pathLowerCase.startsWith(`${basePath}/${locale}/`.toLowerCase())
+        pathNameLowerCased === `${basePath}/${locale}`.toLowerCase() ||
+        pathNameLowerCased.startsWith(`${basePath}/${locale}/`.toLowerCase())
       ) {
         return path.replace(
           new RegExp(`${basePath}/${locale}`, "i"),

--- a/packages/libs/core/tests/route/locale.test.ts
+++ b/packages/libs/core/tests/route/locale.test.ts
@@ -26,13 +26,14 @@ describe("Locale Utils Tests", () => {
     });
 
     it.each`
-      path          | forceLocale | expectedPath
-      ${"/a"}       | ${null}     | ${"/en/a"}
-      ${"/en/a"}    | ${null}     | ${"/en/a"}
-      ${"/fr/a"}    | ${null}     | ${"/fr/a"}
-      ${"/en-GB/a"} | ${null}     | ${"/en-GB/a"}
-      ${"/en-gb/a"} | ${null}     | ${"/en-GB/a"}
-      ${"/nl/a"}    | ${"en"}     | ${"/en/a"}
+      path             | forceLocale | expectedPath
+      ${"/a"}          | ${null}     | ${"/en/a"}
+      ${"/en/a"}       | ${null}     | ${"/en/a"}
+      ${"/fr/a"}       | ${null}     | ${"/fr/a"}
+      ${"/fr?foo=bar"} | ${null}     | ${"/fr?foo=bar"}
+      ${"/en-GB/a"}    | ${null}     | ${"/en-GB/a"}
+      ${"/en-gb/a"}    | ${null}     | ${"/en-GB/a"}
+      ${"/nl/a"}       | ${"en"}     | ${"/en/a"}
     `(
       "changes path $path to $expectedPath",
       ({ path, forceLocale, expectedPath }) => {


### PR DESCRIPTION
This is a PR to fix a weird bug on **localized** SSR root path, where adding query params to the root path redirected to the default locale.

Happy to have your thoughts & comments!