### PR TITLE
fix: wrong locale when dynamic fallback blocking page is not found

### DIFF
--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
@@ -267,20 +267,17 @@ describe("Pages Tests", () => {
 
   describe("404 pages", () => {
     [
-      { path: "/unmatched" },
-      { path: "/unmatched/nested" },
-      { path: "/en/unmatched" },
-      { path: "/en/unmatched/nested" },
-      { path: "/fr/unmatched" },
-      { path: "/fr/unmatched/nested" }
-    ].forEach(({ path }) => {
+      { path: "/unmatched", locale: "en" },
+      { path: "/unmatched/nested", locale: "en" },
+      { path: "/en/unmatched", locale: "en" },
+      { path: "/en/unmatched/nested", locale: "en" },
+      { path: "/fr/unmatched", locale: "fr" },
+      { path: "/fr/unmatched/nested", locale: "fr" }
+    ].forEach(({ path, locale }) => {
       it(`serves 404 page ${path}`, () => {
         cy.ensureRouteHasStatusCode(path, 404);
         cy.visit(path, { failOnStatusCode: false });
-
-        // Custom static error page with getStaticProps
-        // TODO: test localization
-        cy.contains("Custom 404");
+        cy.get("[data-cy=locale]").contains(locale);
       });
     });
   });

--- a/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
+++ b/packages/e2e-tests/next-app-with-locales/cypress/integration/pages.test.ts
@@ -272,7 +272,8 @@ describe("Pages Tests", () => {
       { path: "/en/unmatched", locale: "en" },
       { path: "/en/unmatched/nested", locale: "en" },
       { path: "/fr/unmatched", locale: "fr" },
-      { path: "/fr/unmatched/nested", locale: "fr" }
+      { path: "/fr/unmatched/nested", locale: "fr" },
+      { path: "/fr/fallback-blocking/unmatched", locale: "fr" }
     ].forEach(({ path, locale }) => {
       it(`serves 404 page ${path}`, () => {
         cy.ensureRouteHasStatusCode(path, 404);

--- a/packages/e2e-tests/next-app-with-locales/pages/404.tsx
+++ b/packages/e2e-tests/next-app-with-locales/pages/404.tsx
@@ -1,5 +1,15 @@
+import { useRouter } from "next/router";
+import React from "react";
+
 export default function Custom404() {
-  return <h1>Custom 404</h1>;
+  const { locale } = useRouter();
+
+  return (
+    <>
+      <h1>Custom 404</h1>
+      <p data-cy="locale">{locale}</p>
+    </>
+  );
 }
 
 export async function getStaticProps() {

--- a/packages/e2e-tests/next-app-with-locales/pages/404.tsx
+++ b/packages/e2e-tests/next-app-with-locales/pages/404.tsx
@@ -12,7 +12,7 @@ export default function Custom404() {
   );
 }
 
-export async function getStaticProps() {
+export function getStaticProps() {
   return {
     props: {}
   };

--- a/packages/e2e-tests/next-app-with-locales/pages/fallback-blocking/[slug].tsx
+++ b/packages/e2e-tests/next-app-with-locales/pages/fallback-blocking/[slug].tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GetStaticProps } from "next";
+import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 
 type DynamicIndexPageProps = {
@@ -20,17 +20,23 @@ export default function DynamicIndexPage(
   );
 }
 
-export const getStaticProps: GetStaticProps = async (ctx) => {
-  return {
-    props: {
-      slug: ctx.params?.slug as string
-    }
-  };
+const PRE_EXISTING_SLUGS = ["a", "b"];
+const SLUGS = [...PRE_EXISTING_SLUGS, "c"];
+
+export const getStaticProps: GetStaticProps = (ctx) => {
+  const slug = ctx.params?.slug;
+  if (typeof slug === "string" && SLUGS.includes(slug)) {
+    return {
+      props: {
+        slug: slug as string
+      }
+    };
+  } else {
+    return { notFound: true };
+  }
 };
 
-export async function getStaticPaths() {
-  return {
-    paths: [{ params: { slug: "a" } }, { params: { slug: "b" } }],
-    fallback: "blocking"
-  };
-}
+export const getStaticPaths: GetStaticPaths = () => ({
+  paths: PRE_EXISTING_SLUGS.map((slug) => ({ params: { slug } })),
+  fallback: "blocking"
+});

--- a/packages/libs/core/src/utils/renderUtils.ts
+++ b/packages/libs/core/src/utils/renderUtils.ts
@@ -1,6 +1,10 @@
 import { resultsToString } from "next/dist/server/utils";
 import { IncomingMessage, ServerResponse } from "http";
 
+function clone(req: IncomingMessage) {
+  return Object.assign(Object.create(Object.getPrototypeOf(req)), req);
+}
+
 /**
  * Render to HTML helper. Starting in Next.js 11.1 a change was introduced so renderReqToHTML no longer returns a string.
  * See: https://github.com/vercel/next.js/pull/27319
@@ -25,7 +29,7 @@ export const renderPageToHtml = async (
   renderMode?: "export" | "passthrough" | true
 ): Promise<{ html: string; renderOpts: Record<string, any> }> => {
   const { renderOpts, html: htmlResult } = await page.renderReqToHTML(
-    req,
+    clone(req),
     res,
     renderMode
   );


### PR DESCRIPTION
This fixes a bug when trying to access a **dynamic fallback blocking** page in a locale different than the default one: the 404 was served in the **default** locale, rather than the requested one.