### PR TITLE
Do not forward cookies to S3 for public files

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -253,6 +253,7 @@ const handleOriginRequest = async ({
 
   if (route.isPublicFile) {
     const { file } = route as PublicFileRoute;
+    request.headers["cookies"] = [];
     return await staticRequest(
       event,
       file,

--- a/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
+++ b/packages/libs/lambda-at-edge/tests/default-handler/default-handler-with-basepath.test.ts
@@ -146,6 +146,26 @@ describe("Lambda@Edge", () => {
 
       expect(response.status).toEqual("200");
     });
+
+    it("public file should not forward cookies to S3", async () => {
+      const event = createCloudFrontEvent({
+        uri: "/basepath/manifest.json",
+        host: "mydistribution.cloudfront.net",
+        requestHeaders: {
+          cookies: [
+            {
+              key: "Cookie",
+              value: "cookie1=value"
+            }
+          ]
+        }
+      });
+
+      const result = await handler(event);
+      const request = result as CloudFrontRequest;
+
+      expect(request.headers["cookies"]).toHaveLength(0);
+    });
   });
 
   describe("SSR pages routing", () => {


### PR DESCRIPTION
# Why?
I am facing an issue with a Next.js site build with SST when requesting public files while accessing to the site with a lot of long cookies:
![image](https://user-images.githubusercontent.com/8282971/202738247-7349e397-a0a7-4428-8054-d8922494b42a.png)

Here, getting a 400 error when requesting `/fonts/sofia-pro-bold.woff2` which is present in the `/public` directory in my site.

The issue seems to be that S3 has a hard limit of 8192 characters for the headers, and all the cookies are forwarded to S3 when requesting public files, which then makes the request explode in S3.

I have started a [discussion on the Discord #help channel](https://discord.com/channels/983865673656705025/983866416832864350/threads/1043132972162895892) to look for help on this.

# What?
Edit the Lambda@Edge handler to not forward cookies to S3 for public files.

# How to reproduce?
While accessing a Next.js website, in your browser create 3 or more cookies with 3000 characters (total should be more than 8192) and request a public resource. The request doesn't complete.

This is the simplest and safest solution I could come up with to not break anything else, happy to get other suggestions or proposals to solve this issue.