### PR TITLE
Removed bucket deletion if name changes

### DIFF
--- a/packages/serverless-components/aws-s3/src/component.ts
+++ b/packages/serverless-components/aws-s3/src/component.ts
@@ -65,12 +65,6 @@ class AwsS3 extends Component {
       await configureBucketTags(clients.regular, config.name, config.tags);
     }
 
-    // todo we probably don't need this logic now that we auto generate names
-    const nameChanged = this.state.name && this.state.name !== config.name;
-    if (nameChanged) {
-      await this.remove();
-    }
-
     this.state.name = config.name;
     this.state.region = config.region;
     this.state.accelerated = config.accelerated;


### PR DESCRIPTION
This is to solve the issue raised [here](https://github.com/serverless-nextjs/serverless-next.js/issues/2513).

I have opted for simply deleting this logic since there is already a comment to suggest doing this. I also believe that deleting the bucket because the name has changed is also not necessary and removing it should not affect the rest of the deployment functionality.